### PR TITLE
[FIX] Unit tests used to failed with timeout on macOS (#1826)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # FIXME: - macOS-latest
+          - macOS-latest
           - windows-latest
     steps:
       - uses: actions/checkout@v2

--- a/massa-consensus/src/tests/scenarios_reward_split.rs
+++ b/massa-consensus/src/tests/scenarios_reward_split.rs
@@ -116,7 +116,7 @@ async fn test_reward_split() {
             let (b1_id, b1, _) =
                 tools::create_block(&cfg, Slot::new(1, 0), parents, slot_one_priv_key);
 
-            tools::propagate_block(&mut protocol_controller, b1, true, 500).await;
+            tools::propagate_block(&mut protocol_controller, b1, true, 1000).await;
 
             let slot_two_block_addr = draws.get(&Slot::new(2, 0)).unwrap().0;
 


### PR DESCRIPTION
`cargo test` fail on macOS in CI with a timeout error