### PR TITLE
Rename `darwin` to `macos` in release artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,24 +1,22 @@
-name: Release
+name: CD
+
 on:
-    push:
-      tags:
+  push:
+    tags:
       - TEST.*
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: full
 
 jobs:
-  build_linux:
+  linux:
     runs-on: ubuntu-latest
     container:
       image: massalabs/linux-ci
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 20
-    - name: Cargo build
-      run: |
+    - run: |
         export HOME=/root
         rustup default nightly
         rustup target add x86_64-unknown-linux-musl
@@ -33,25 +31,19 @@ jobs:
         cp -rv ../massa-node/base_config ./massa-node/base_config
         cp -rv ../massa-node/storage ./massa-node/storage
         cp -v ../target/x86_64-unknown-linux-musl/release/massa-client ./massa-client/massa-client
-        # cp -rv ../massa-client/config ./massa-client/config
         cp -rv ../massa-client/base_config ./massa-client/base_config
-    - name: Archive compilation results
-      uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2
       with:
         name: release_linux
         path: massa/
 
-  build_windows:
+  windows:
     runs-on: ubuntu-latest
     container:
       image: massalabs/linux-ci
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 20
-    - name: Cargo build
-      run: |
+    - run: |
         export HOME=/root
         rustup update
         rustup default nightly
@@ -67,26 +59,19 @@ jobs:
         cp -rv ../massa-node/base_config ./massa-node/base_config
         cp -rv ../massa-node/storage ./massa-node/storage
         cp -v ../target/x86_64-pc-windows-gnu/release/massa-client.exe ./massa-client/massa-client.exe
-        # cp -rv ../massa-client/config ./massa-client/config
         cp -rv ../massa-client/base_config ./massa-client/base_config
-
-    - name: Archive compilation results
-      uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2
       with:
         name: release_windows
         path: massa/
 
-  build_darwin:
+  macos:
     runs-on: ubuntu-latest
     container:
       image: massalabs/linux-ci
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        fetch-depth: 20
-    - name: Cargo build
-      run: |
+    - run: |
         export HOME=/root
         rustup update
         rustup default nightly
@@ -102,43 +87,34 @@ jobs:
         cp -rv ../massa-node/base_config ./massa-node/base_config
         cp -rv ../massa-node/storage ./massa-node/storage
         cp -v ../target/x86_64-apple-darwin/release/massa-client ./massa-client/massa-client
-        # cp -rv ../massa-client/config ./massa-client/config
         cp -rv ../massa-client/base_config ./massa-client/base_config
-    - name: Archive compilation results
-      uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v2
       with:
-        name: release_darwin
+        name: release_macos
         path: massa/
 
   release:
     runs-on: ubuntu-latest
-    needs: [build_linux, build_windows, build_darwin]
+    needs: [linux, windows, macos]
     steps:
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v2.0.10
+    - uses: actions/download-artifact@v2.0.10
       with:
-        # Artifact name
-        name: release_darwin
-        path: release_darwin
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v2.0.10
+        name: release_macos
+        path: release_macos
+    - uses: actions/download-artifact@v2.0.10
       with:
-        # Artifact name
         name: release_windows
         path: release_windows
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v2.0.10
+    - uses: actions/download-artifact@v2.0.10
       with:
-        # Artifact name
         name: release_linux
         path: release_linux
-    - name: Compress and zip releases
-      run: |
-        tar -czvf release_linux.tar.gz release_linux
-        tar -czvf release_windows.tar.gz release_windows
-        tar -czvf release_darwin.tar.gz release_darwin
-    - name: Release
-      uses: softprops/action-gh-release@v1
+    - run: |
+        echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        tar -czvf massa_${RELEASE_VERSION}_linux.tar.gz release_linux
+        tar -czvf massa_${RELEASE_VERSION}_windows.tar.gz release_windows
+        tar -czvf massa_${RELEASE_VERSION}_macos.tar.gz release_macos
+    - uses: softprops/action-gh-release@v1
       with:
         files: |
           release_linux.tar.gz


### PR DESCRIPTION
Fix #1891