### PR TITLE
Make `massa-node` & `massa-client` config loading behave the same way

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,6 +1104,7 @@ dependencies = [
  "config",
  "console",
  "dialoguer",
+ "directories",
  "erased-serde",
  "futures 0.3.18",
  "jsonrpc-core-client",

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -11,6 +11,7 @@ atty = "0.2"
 config = "0.11"
 console = "0.15"
 dialoguer = { version = "0.9", git = "https://github.com/yvan-sraka/dialoguer.git", branch="completion-feature", features = ["history", "completion"] }
+directories = "4.0"
 erased-serde = "0.3"
 futures = "0.3"
 jsonrpc-core-client = { version = "18.0.0", features = ["http", "tls"] }

--- a/massa-client/src/settings.rs
+++ b/massa-client/src/settings.rs
@@ -1,25 +1,23 @@
 // Copyright (c) 2021 MASSA LABS <info@massa.net>
 
+use directories::ProjectDirs;
 use serde::Deserialize;
 use std::net::IpAddr;
 
-const BASE_CONFIG_PATH: &str = "base_config/config.toml";
-const OVERRIDE_CONFIG_PATH: &str = "config/config.toml";
-
 lazy_static::lazy_static! {
+    // TODO: this code is duplicated from /massa-node/settings.rs and should be part of a custom crate
     pub static ref SETTINGS: Settings = {
         let mut settings = config::Config::default();
-        settings
-            .merge(config::File::with_name(BASE_CONFIG_PATH))
-            .unwrap();
-        if std::path::Path::new(OVERRIDE_CONFIG_PATH).is_file() {
-            settings
-                .merge(config::File::with_name(OVERRIDE_CONFIG_PATH))
-                .unwrap();
+        let config_path = std::env::var("MASSA_CONFIG_PATH").unwrap_or_else(|_| "base_config/config.toml".to_string());
+        settings.merge(config::File::with_name(&config_path)).unwrap_or_else(|_| panic!("failed to read {} config {}", config_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+        if let Some(proj_dirs) = ProjectDirs::from("com", "MassaLabs", "massa-client") { // Portable user config loading
+            let user_config_path = proj_dirs.config_dir();
+            if user_config_path.exists() {
+                let path_str = user_config_path.to_str().unwrap();
+                settings.merge(config::File::with_name(path_str)).unwrap_or_else(|_| panic!("failed to read {} user config", path_str));
+            }
         }
-        settings
-            .merge(config::Environment::with_prefix("MASSA_CLIENT"))
-            .unwrap();
+        settings.merge(config::Environment::with_prefix("MASSA_CLIENT")).unwrap();
         settings.try_into().unwrap()
     };
 }

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 config = "0.11"
-directories = "4.0.1"
+directories = "4.0"
 futures = "0.3"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2021 MASSA LABS <info@massa.net>
 
-extern crate directories;
 use bootstrap::BootstrapSettings;
 use consensus::ConsensusSettings;
 use directories::ProjectDirs;
@@ -13,12 +12,12 @@ use serde::Deserialize;
 
 lazy_static::lazy_static! {
     pub static ref VERSION: Version = "TEST.5.0".parse().unwrap();
-
+    // TODO: this code is duplicated from /massa-client/settings.rs and should be part of a custom crate
     pub static ref SETTINGS: Settings = {
         let mut settings = config::Config::default();
         let config_path = std::env::var("MASSA_CONFIG_PATH").unwrap_or_else(|_| "base_config/config.toml".to_string());
-        settings.merge(config::File::with_name(&config_path)).unwrap_or_else(|_| panic!("failed to read {} config.... {}", config_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
-        if let Some(proj_dirs) = ProjectDirs::from("com", "MassaLabs", "Massa") { // Portable user config loading
+        settings.merge(config::File::with_name(&config_path)).unwrap_or_else(|_| panic!("failed to read {} config {}", config_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+        if let Some(proj_dirs) = ProjectDirs::from("com", "MassaLabs", "massa-node") { // Portable user config loading
             let user_config_path = proj_dirs.config_dir();
             if user_config_path.exists() {
                 let path_str = user_config_path.to_str().unwrap();


### PR DESCRIPTION
So `massa-node` user custom config is now localized in:
- Linux: `/home/alice/.config/massa-node/config.toml`
- Windows: `C:\Users\Alice\AppData\RoamingMassaLabs\massa-node\config.toml`
- macOS: ` /Users/Alice/Library/Application Support/com.Massa-Labs.massa-node/config.toml`

 ... and `massa-client` one in:
- Linux: `/home/alice/.config/massa-client/config.toml`
- Windows: `C:\Users\Alice\AppData\RoamingMassaLabs\massa-client\config.toml`
- macOS: ` /Users/Alice/Library/Application Support/com.Massa-Labs.massa-client/config.toml`