### PR TITLE
Execution: re-add test for start/stop without commmands

### DIFF
--- a/execution/src/tests/scenarios_mandatories.rs
+++ b/execution/src/tests/scenarios_mandatories.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn test_start_sendcommand_stop() {
+async fn test_start_send_command_stop() {
     let (mut command_sender, _event_receiver, manager) = start_controller(ExecutionConfig {}, 2)
         .await
         .expect("Failed to start execution.");
@@ -13,5 +13,15 @@ async fn test_start_sendcommand_stop() {
         .update_blockclique(Default::default(), Default::default())
         .await
         .expect("Failed to send command");
+    manager.stop().await.expect("Failed to stop execution.");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_start_stop() {
+    // Not sending any commands here, to make sure stopping does not require it.
+    let (mut _command_sender, _event_receiver, manager) = start_controller(ExecutionConfig {}, 2)
+        .await
+        .expect("Failed to start execution.");
     manager.stop().await.expect("Failed to stop execution.");
 }


### PR DESCRIPTION
Re-adding tests, since the initial problem only became apparent with a test where no commands where sent.