### PR TITLE
Remove stable feature info

### DIFF
--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2021 MASSA LABS <info@massa.net>
 
 #![feature(ip)]
-#![feature(destructuring_assignment)]
 #![doc = include_str!("../../README.md")]
 
 extern crate massa_logging;


### PR DESCRIPTION
```bash
   Compiling massa_execution v0.1.0 (/home/adrien/Documents/repos/massa/massa-execution)
   Compiling massa_consensus v0.1.0 (/home/adrien/Documents/repos/massa/massa-consensus)
   Compiling massa_api v0.1.0 (/home/adrien/Documents/repos/massa/massa-api)
   Compiling massa_bootstrap v0.1.0 (/home/adrien/Documents/repos/massa/massa-bootstrap)
   Compiling massa-node v0.1.0 (/home/adrien/Documents/repos/massa/massa-node)
warning: the feature `destructuring_assignment` has been stable since 1.59.0 and no longer requires an attribute to enable
 --> massa-node/src/main.rs:4:12
  |
4 | #![feature(destructuring_assignment)]
  |            ^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(stable_features)]` on by default

warning: `massa-node` (bin "massa-node") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 11.42s
```

run `rustup upgrade`