### PR TITLE
Improve vm execution handling

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -315,7 +315,7 @@ impl Endpoints for API<Public> {
                     is_stale: false,
                     is_in_blockclique: blockclique.block_ids.contains(&id),
                     slot: exported_block.header.content.slot,
-                    creator: Address::from_public_key(&exported_block.header.content.creator)?,
+                    creator: Address::from_public_key(&exported_block.header.content.creator),
                     parents: exported_block.header.content.parents,
                 });
             }
@@ -327,7 +327,7 @@ impl Endpoints for API<Public> {
                         is_stale: true,
                         is_in_blockclique: false,
                         slot: header.content.slot,
-                        creator: Address::from_public_key(&header.content.creator)?,
+                        creator: Address::from_public_key(&header.content.creator),
                         parents: header.content.parents,
                     });
                 }

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -42,7 +42,7 @@ pub fn get_random_public_key() -> PublicKey {
 pub fn get_random_address() -> Address {
     let priv_key = generate_random_private_key();
     let pub_key = derive_public_key(&priv_key);
-    Address::from_public_key(&pub_key).unwrap()
+    Address::from_public_key(&pub_key)
 }
 
 pub fn get_dummy_signature(s: &str) -> Signature {
@@ -384,7 +384,7 @@ pub fn assert_eq_exec(v1: &BootstrapExecutionState, v2: &BootstrapExecutionState
 pub fn get_boot_state() -> (ExportProofOfStake, BootstrapableGraph) {
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
 
     let mut ledger_subset = LedgerSubset::default();
     ledger_subset.0.insert(

--- a/massa-consensus/src/consensus_controller.rs
+++ b/massa-consensus/src/consensus_controller.rs
@@ -142,7 +142,7 @@ async fn load_initial_staking_keys(
         .map(|private_key| {
             let public_key = derive_public_key(private_key);
             Ok((
-                Address::from_public_key(&public_key)?,
+                Address::from_public_key(&public_key),
                 (public_key, *private_key),
             ))
         })

--- a/massa-consensus/src/consensus_worker.rs
+++ b/massa-consensus/src/consensus_worker.rs
@@ -225,7 +225,7 @@ impl ConsensusWorker {
 
         // add genesis blocks to stats
         let genesis_public_key = derive_public_key(&cfg.genesis_key);
-        let genesis_addr = Address::from_public_key(&genesis_public_key)?;
+        let genesis_addr = Address::from_public_key(&genesis_public_key);
         let mut final_block_stats = VecDeque::new();
         for thread in 0..cfg.thread_count {
             final_block_stats.push_back((
@@ -844,10 +844,10 @@ impl ConsensusWorker {
                     res.push((
                         cur_slot,
                         if cur_slot.period == 0 {
-                            match Address::from_public_key(&self.genesis_public_key) {
-                                Ok(addr) => (addr, Vec::new()),
-                                Err(err) => break Err(err.into()),
-                            }
+                            (
+                                Address::from_public_key(&self.genesis_public_key),
+                                Vec::new(),
+                            )
                         } else {
                             (
                                 match self.pos.draw_block_producer(cur_slot) {
@@ -956,7 +956,7 @@ impl ConsensusWorker {
             ConsensusCommand::RegisterStakingPrivateKeys(keys) => {
                 for key in keys.into_iter() {
                     let public = derive_public_key(&key);
-                    let address = Address::from_public_key(&public)?;
+                    let address = Address::from_public_key(&public);
                     info!("Staking with address {}", address);
                     self.staking_keys.insert(address, (public, key));
                 }
@@ -1343,7 +1343,7 @@ impl ConsensusWorker {
                 self.final_block_stats.push_back((
                     timestamp,
                     a_block.operation_set.len() as u64,
-                    Address::from_public_key(&a_block.block.header.content.creator)?,
+                    Address::from_public_key(&a_block.block.header.content.creator),
                 ));
             }
         }
@@ -1457,7 +1457,7 @@ impl ConsensusWorker {
         for (b_id, (b_creator, b_slot)) in new_stale_block_ids_creators_slots.into_iter() {
             self.stale_block_stats.push_back(timestamp);
 
-            let creator_addr = Address::from_public_key(&b_creator)?;
+            let creator_addr = Address::from_public_key(&b_creator);
             if self.staking_keys.contains_key(&creator_addr) {
                 warn!("block {} that was produced by our address {} at slot {} became stale. This is probably due to a temporary desynchronization.", b_id, b_slot, creator_addr);
             }

--- a/massa-consensus/src/ledger.rs
+++ b/massa-consensus/src/ledger.rs
@@ -178,7 +178,7 @@ impl OperationLedgerInterface for Operation {
         let mut res = LedgerChanges::default();
 
         // sender fee
-        let sender_address = Address::from_public_key(&self.content.sender_public_key)?;
+        let sender_address = Address::from_public_key(&self.content.sender_public_key);
         res.apply(
             &sender_address,
             &LedgerChange {

--- a/massa-consensus/src/pos.rs
+++ b/massa-consensus/src/pos.rs
@@ -281,7 +281,7 @@ impl OperationRollInterface for Operation {
             OperationType::Transaction { .. } => {}
             OperationType::RollBuy { roll_count } => {
                 res.apply(
-                    &Address::from_public_key(&self.content.sender_public_key)?,
+                    &Address::from_public_key(&self.content.sender_public_key),
                     &RollUpdate {
                         roll_purchases: roll_count,
                         roll_sales: 0,
@@ -290,7 +290,7 @@ impl OperationRollInterface for Operation {
             }
             OperationType::RollSell { roll_count } => {
                 res.apply(
-                    &Address::from_public_key(&self.content.sender_public_key)?,
+                    &Address::from_public_key(&self.content.sender_public_key),
                     &RollUpdate {
                         roll_purchases: 0,
                         roll_sales: roll_count,
@@ -803,7 +803,7 @@ impl ProofOfStake {
         let cycle_last_period = (cycle + 1) * self.cfg.periods_per_cycle - 1;
         if cycle_first_period == 0 {
             // genesis slots: force block creator and endorsement creator address draw
-            let genesis_addr = Address::from_public_key(&derive_public_key(&self.cfg.genesis_key))?;
+            let genesis_addr = Address::from_public_key(&derive_public_key(&self.cfg.genesis_key));
             for draw_thread in 0..self.cfg.thread_count {
                 draws.insert(
                     Slot::new(0, draw_thread),

--- a/massa-consensus/src/tests/scenario_block_creation.rs
+++ b/massa-consensus/src/tests/scenario_block_creation.rs
@@ -29,21 +29,21 @@ async fn test_genesis_block_creation() {
     // addr 2 is in consensus and has 0 roll and 1000 coins
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 
@@ -106,21 +106,21 @@ async fn test_block_creation_with_draw() {
     // addr 2 is in consensus and has 0 roll and 1000 coins
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 
@@ -249,7 +249,7 @@ async fn test_block_creation_with_draw() {
                     .expect("block did not propagate in time");
                 assert_eq!(
                     draws[&cur_slot],
-                    Address::from_public_key(&block_creator).unwrap(),
+                    Address::from_public_key(&block_creator),
                     "wrong block creator"
                 );
                 cur_slot = cur_slot.get_next_slot(cfg.thread_count).unwrap();
@@ -273,21 +273,21 @@ async fn test_interleaving_block_creation_with_reception() {
     // addresses a and b both in thread 0
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 
@@ -375,7 +375,7 @@ async fn test_interleaving_block_creation_with_reception() {
                         .expect("block did not propagate in time");
                     assert_eq!(
                         *creator,
-                        Address::from_public_key(&header.content.creator).unwrap(),
+                        Address::from_public_key(&header.content.creator),
                         "wrong block creator"
                     );
                     id
@@ -426,21 +426,21 @@ async fn test_order_of_inclusion() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 
@@ -590,19 +590,19 @@ async fn test_block_filling() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 1 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     let mut ledger = HashMap::new();
     ledger.insert(

--- a/massa-consensus/src/tests/scenario_roll.rs
+++ b/massa-consensus/src/tests/scenario_roll.rs
@@ -43,21 +43,21 @@ async fn test_roll() {
     // addresses 1 and 2 both in thread 0
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 
@@ -490,21 +490,21 @@ async fn test_roll_block_creation() {
     // addresses 1 and 2 both in thread 0
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 
@@ -795,7 +795,7 @@ async fn test_roll_deactivation() {
     loop {
         privkey_a0 = generate_random_private_key();
         pubkey_a0 = derive_public_key(&privkey_a0);
-        address_a0 = Address::from_public_key(&pubkey_a0).unwrap();
+        address_a0 = Address::from_public_key(&pubkey_a0);
         if address_a0.get_thread(thread_count) == 0 {
             break;
         }
@@ -806,7 +806,7 @@ async fn test_roll_deactivation() {
     loop {
         privkey_b0 = generate_random_private_key();
         pubkey_b0 = derive_public_key(&privkey_b0);
-        address_b0 = Address::from_public_key(&pubkey_b0).unwrap();
+        address_b0 = Address::from_public_key(&pubkey_b0);
         if address_b0.get_thread(thread_count) == 0 {
             break;
         }
@@ -818,7 +818,7 @@ async fn test_roll_deactivation() {
     loop {
         privkey_a1 = generate_random_private_key();
         pubkey_a1 = derive_public_key(&privkey_a1);
-        address_a1 = Address::from_public_key(&pubkey_a1).unwrap();
+        address_a1 = Address::from_public_key(&pubkey_a1);
         if address_a1.get_thread(thread_count) == 1 {
             break;
         }
@@ -829,7 +829,7 @@ async fn test_roll_deactivation() {
     loop {
         privkey_b1 = generate_random_private_key();
         pubkey_b1 = derive_public_key(&privkey_b1);
-        address_b1 = Address::from_public_key(&pubkey_b1).unwrap();
+        address_b1 = Address::from_public_key(&pubkey_b1);
         if address_b1.get_thread(thread_count) == 1 {
             break;
         }

--- a/massa-consensus/src/tests/scenarios_endorsements.rs
+++ b/massa-consensus/src/tests/scenarios_endorsements.rs
@@ -28,21 +28,21 @@ async fn test_endorsement_check() {
     // addresses 1 and 2 both in thread 0
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 

--- a/massa-consensus/src/tests/scenarios_get_operations.rs
+++ b/massa-consensus/src/tests/scenarios_get_operations.rs
@@ -29,21 +29,21 @@ async fn test_get_operation() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 

--- a/massa-consensus/src/tests/scenarios_get_selection_draws.rs
+++ b/massa-consensus/src/tests/scenarios_get_selection_draws.rs
@@ -25,21 +25,21 @@ async fn test_get_selection_draws_high_end_slot() {
     // addresses 1 and 2 both in thread 0
     let mut priv_1 = generate_random_private_key();
     let mut pubkey_1 = derive_public_key(&priv_1);
-    let mut address_1 = Address::from_public_key(&pubkey_1).unwrap();
+    let mut address_1 = Address::from_public_key(&pubkey_1);
     while 0 != address_1.get_thread(thread_count) {
         priv_1 = generate_random_private_key();
         pubkey_1 = derive_public_key(&priv_1);
-        address_1 = Address::from_public_key(&pubkey_1).unwrap();
+        address_1 = Address::from_public_key(&pubkey_1);
     }
     assert_eq!(0, address_1.get_thread(thread_count));
 
     let mut priv_2 = generate_random_private_key();
     let mut pubkey_2 = derive_public_key(&priv_2);
-    let mut address_2 = Address::from_public_key(&pubkey_2).unwrap();
+    let mut address_2 = Address::from_public_key(&pubkey_2);
     while 0 != address_2.get_thread(thread_count) {
         priv_2 = generate_random_private_key();
         pubkey_2 = derive_public_key(&priv_2);
-        address_2 = Address::from_public_key(&pubkey_2).unwrap();
+        address_2 = Address::from_public_key(&pubkey_2);
     }
     assert_eq!(0, address_2.get_thread(thread_count));
 

--- a/massa-consensus/src/tests/scenarios_ledger.rs
+++ b/massa-consensus/src/tests/scenarios_ledger.rs
@@ -74,7 +74,7 @@ async fn test_ledger_final_balance_increment_new_address() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     let changes = LedgerChanges(
@@ -121,7 +121,7 @@ async fn test_ledger_final_balance_increment_address_above_max() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     let changes = LedgerChanges(
@@ -181,7 +181,7 @@ async fn test_ledger_final_balance_decrement_address_balance_to_zero() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     // Increment.
@@ -254,7 +254,7 @@ async fn test_ledger_final_balance_decrement_address_below_zero() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     // Increment.
@@ -341,7 +341,7 @@ async fn test_ledger_final_balance_decrement_non_existing_address() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     // Decrement.
@@ -375,7 +375,7 @@ async fn test_ledger_final_balance_non_existing_address() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
 
     let final_datas = ledger
         .get_final_data(vec![address].into_iter().collect())
@@ -403,7 +403,7 @@ async fn test_ledger_final_balance_duplicate_address() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
 
     // Same address twice.
     let final_datas = ledger
@@ -437,7 +437,7 @@ async fn test_ledger_final_balance_multiple_addresses() {
     for _ in 0..5 {
         let private_key = generate_random_private_key();
         let public_key = derive_public_key(&private_key);
-        let address = Address::from_public_key(&public_key).unwrap();
+        let address = Address::from_public_key(&public_key);
         addresses.push(address);
     }
 
@@ -472,7 +472,7 @@ async fn test_ledger_clear() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     let changes = LedgerChanges(
@@ -530,7 +530,7 @@ async fn test_ledger_read_whole() {
 
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
-    let address = Address::from_public_key(&public_key).unwrap();
+    let address = Address::from_public_key(&public_key);
     let thread = address.get_thread(cfg.thread_count);
 
     let changes = LedgerChanges(
@@ -593,7 +593,7 @@ async fn test_ledger_update_when_a_batch_of_blocks_becomes_final() {
         // A
         private_key_1 = generate_random_private_key();
         public_key_1 = derive_public_key(&private_key_1);
-        address_1 = Address::from_public_key(&public_key_1).unwrap();
+        address_1 = Address::from_public_key(&public_key_1);
         if address_1.get_thread(thread_count) == 0 {
             break;
         }
@@ -602,7 +602,7 @@ async fn test_ledger_update_when_a_batch_of_blocks_becomes_final() {
         // B
         private_key_2 = generate_random_private_key();
         public_key_2 = derive_public_key(&private_key_2);
-        address_2 = Address::from_public_key(&public_key_2).unwrap();
+        address_2 = Address::from_public_key(&public_key_2);
         if address_2.get_thread(thread_count) == 1 {
             break;
         }
@@ -611,7 +611,7 @@ async fn test_ledger_update_when_a_batch_of_blocks_becomes_final() {
         // C
         private_key_3 = generate_random_private_key();
         public_key_3 = derive_public_key(&private_key_3);
-        address_3 = Address::from_public_key(&public_key_3).unwrap();
+        address_3 = Address::from_public_key(&public_key_3);
         if address_3.get_thread(thread_count) == 0 {
             break;
         }

--- a/massa-consensus/src/tests/scenarios_operations_check.rs
+++ b/massa-consensus/src/tests/scenarios_operations_check.rs
@@ -44,7 +44,7 @@ async fn test_operations_check() {
     loop {
         private_key_1 = generate_random_private_key();
         public_key_1 = derive_public_key(&private_key_1);
-        address_1 = Address::from_public_key(&public_key_1).unwrap();
+        address_1 = Address::from_public_key(&public_key_1);
         if address_1.get_thread(thread_count) == 0 {
             break;
         }
@@ -52,7 +52,7 @@ async fn test_operations_check() {
     loop {
         private_key_2 = generate_random_private_key();
         public_key_2 = derive_public_key(&private_key_2);
-        address_2 = Address::from_public_key(&public_key_2).unwrap();
+        address_2 = Address::from_public_key(&public_key_2);
         if address_2.get_thread(thread_count) == 1 {
             break;
         }

--- a/massa-consensus/src/tests/scenarios_pool_commands.rs
+++ b/massa-consensus/src/tests/scenarios_pool_commands.rs
@@ -180,21 +180,21 @@ async fn test_new_final_ops() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 
@@ -295,21 +295,21 @@ async fn test_max_attempts_get_operations() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 
@@ -417,21 +417,21 @@ async fn test_max_batch_size_get_operations() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 

--- a/massa-consensus/src/tests/scenarios_reward_split.rs
+++ b/massa-consensus/src/tests/scenarios_reward_split.rs
@@ -26,21 +26,21 @@ async fn test_reward_split() {
     // A
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
 
     // B
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
 
     let mut ledger = HashMap::new();
@@ -145,7 +145,7 @@ async fn test_reward_split() {
             // Creator of second block endorses the first.
             let index = slot_one_endorsements_addrs
                 .iter()
-                .position(|&addr| addr == Address::from_public_key(&slot_two_pub_key).unwrap())
+                .position(|&addr| addr == Address::from_public_key(&slot_two_pub_key))
                 .unwrap() as u32;
             let content = EndorsementContent {
                 sender_public_key: slot_two_pub_key,
@@ -163,7 +163,7 @@ async fn test_reward_split() {
             // Creator of first block endorses the first.
             let index = slot_one_endorsements_addrs
                 .iter()
-                .position(|&addr| addr == Address::from_public_key(&slot_one_pub_key).unwrap())
+                .position(|&addr| addr == Address::from_public_key(&slot_one_pub_key))
                 .unwrap() as u32;
             let content = EndorsementContent {
                 sender_public_key: slot_one_pub_key,
@@ -181,7 +181,7 @@ async fn test_reward_split() {
             // Creator of second block endorses the first, again.
             let index = slot_one_endorsements_addrs
                 .iter()
-                .position(|&addr| addr == Address::from_public_key(&slot_two_pub_key).unwrap())
+                .position(|&addr| addr == Address::from_public_key(&slot_two_pub_key))
                 .unwrap() as u32;
             let content = EndorsementContent {
                 sender_public_key: slot_two_pub_key,

--- a/massa-consensus/src/tests/tools.rs
+++ b/massa-consensus/src/tests/tools.rs
@@ -583,7 +583,7 @@ pub fn generate_default_roll_counts_file(stakers: Vec<PrivateKey>) -> NamedTempF
     let mut roll_counts = RollCounts::default();
     for key in stakers.iter() {
         let pub_key = derive_public_key(key);
-        let address = Address::from_public_key(&pub_key).unwrap();
+        let address = Address::from_public_key(&pub_key);
         let update = RollUpdate {
             roll_purchases: 1,
             roll_sales: 0,
@@ -598,7 +598,7 @@ pub fn generate_default_roll_counts_file(stakers: Vec<PrivateKey>) -> NamedTempF
 pub fn get_creator_for_draw(draw: &Address, nodes: &Vec<PrivateKey>) -> PrivateKey {
     for key in nodes.iter() {
         let pub_key = derive_public_key(key);
-        let address = Address::from_public_key(&pub_key).unwrap();
+        let address = Address::from_public_key(&pub_key);
         if address == *draw {
             return *key;
         }

--- a/massa-execution/src/sce_ledger.rs
+++ b/massa-execution/src/sce_ledger.rs
@@ -13,8 +13,13 @@ use serde::{Deserialize, Serialize};
 /// an entry in the SCE ledger
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SCELedgerEntry {
+    // SCE balance
     pub balance: Amount,
+
+    // optional executable module
     pub opt_module: Option<Bytecode>,
+
+    // datastore
     pub data: HHashMap<Hash, Vec<u8>>,
 }
 
@@ -196,7 +201,7 @@ impl DeserializeCompact for SCELedgerEntry {
 pub struct SCELedgerEntryUpdate {
     pub update_balance: Option<Amount>,
     pub update_opt_module: Option<Option<Bytecode>>,
-    pub update_data: HHashMap<Hash, Option<Bytecode>>, // None for row deletion
+    pub update_data: HHashMap<Hash, Option<Vec<u8>>>, // None for row deletion
 }
 
 impl SCELedgerEntryUpdate {

--- a/massa-execution/src/tests/scenarios_mandatories.rs
+++ b/massa-execution/src/tests/scenarios_mandatories.rs
@@ -25,7 +25,7 @@ pub fn generate_ledger_initial_file(values: &AddressHashMap<Amount>) -> NamedTem
 pub fn get_random_address() -> Address {
     let priv_key = generate_random_private_key();
     let pub_key = derive_public_key(&priv_key);
-    Address::from_public_key(&pub_key).unwrap()
+    Address::from_public_key(&pub_key)
 }
 
 fn get_sample_settings() -> (NamedTempFile, ExecutionSettings) {

--- a/massa-execution/src/types.rs
+++ b/massa-execution/src/types.rs
@@ -1,6 +1,6 @@
 use crate::sce_ledger::{FinalLedger, SCELedger, SCELedgerChanges, SCELedgerStep};
 /// Define types used while executing block bytecodes
-use massa_models::{Address, Amount, OperationContent, OperationType};
+use massa_models::{Address, Amount};
 use massa_models::{Block, BlockId, Slot};
 use std::sync::{Condvar, Mutex};
 use std::{collections::VecDeque, sync::Arc};
@@ -19,16 +19,6 @@ pub(crate) struct StepHistoryItem {
 
     // list of SCE ledger changes caused by this execution step
     pub ledger_changes: SCELedgerChanges,
-}
-
-/// Operation should be used to communicate with the VM, TODO, it doesn't need everything in.
-/// TODO May be the max_gas, the module and the sender address are enough
-pub(crate) struct OperationSC {
-    pub _module: Bytecode,
-    pub max_gas: u64,
-    pub coins: Amount,
-    pub gas_price: Amount,
-    pub sender: Address,
 }
 
 #[derive(Clone)]
@@ -71,30 +61,6 @@ impl ExecutionContext {
             opt_block_id: Default::default(),
             opt_block_creator_addr: Default::default(),
             call_stack: Default::default(),
-        }
-    }
-}
-
-impl TryFrom<OperationContent> for OperationSC {
-    type Error = ();
-
-    fn try_from(content: OperationContent) -> Result<Self, Self::Error> {
-        match content.op {
-            OperationType::ExecuteSC {
-                data,
-                max_gas,
-                coins,
-                gas_price,
-            } => {
-                Ok(OperationSC {
-                    _module: data, // todo use the external lib to check if module is valid
-                    max_gas,
-                    coins,
-                    gas_price,
-                    sender: Address::from_public_key(&content.sender_public_key).unwrap(),
-                })
-            }
-            _ => Err(()),
         }
     }
 }

--- a/massa-execution/src/vm.rs
+++ b/massa-execution/src/vm.rs
@@ -139,6 +139,12 @@ impl VM {
     ) -> SCELedgerChanges {
         let mut context = self.execution_context.lock().unwrap();
 
+        // credit the sender with "coins"
+        let _result =
+            context
+                .ledger_step
+                .set_balance_delta(operation.sender, operation.coins, true);
+
         // credit the block creator with max_gas*gas_price
         let _result = context.ledger_step.set_balance_delta(
             block_creator_addr,
@@ -148,12 +154,6 @@ impl VM {
                 .unwrap(),
             true,
         );
-
-        // credit the sender with "coins"
-        let _result =
-            context
-                .ledger_step
-                .set_balance_delta(operation.sender, operation.coins, true);
 
         // fill context for execution
         context.gas_price = operation.gas_price;

--- a/massa-execution/src/vm.rs
+++ b/massa-execution/src/vm.rs
@@ -163,7 +163,7 @@ impl VM {
         context.opt_block_id = Some(block_id);
         context.opt_block_creator_addr = Some(block_creator_addr);
         context.call_stack = vec![operation.sender].into();
-        context.ledger_step.caused_changes.clone();
+        context.ledger_step.caused_changes.clone()
     }
 
     /// runs an SCE-active execution step

--- a/massa-execution/src/vm.rs
+++ b/massa-execution/src/vm.rs
@@ -134,10 +134,10 @@ impl VM {
             SCELedgerChanges::from(self.step_history.clone());
     }
 
-    /// Prepare (update) the shared context before the new operation
-    /// returns a snapshot copy of the current caused ledger changes
+    /// Prepares (updates) the shared context before the new operation.
+    /// Returns a snapshot of the current caused ledger changes.
     /// TODO: do not ignore the results
-    /// TODO consider dispatching with edorsers/endorsed as well
+    /// TODO: consider dispatching gas fees with edorsers/endorsees as well
     fn prepare_context(
         &self,
         sender: Address,
@@ -150,7 +150,7 @@ impl VM {
     ) -> SCELedgerChanges {
         let mut context = self.execution_context.lock().unwrap();
 
-        // credit the sender with "coins"
+        // Credit the sender with "coins"
         let _result = context.ledger_step.set_balance_delta(sender, coins, true);
 
         // credit the block creator with max_gas*gas_price
@@ -213,9 +213,9 @@ impl VM {
                         continue;
                     };
 
-                // Prepare context and save the Initial ledger changes before execution
-                // The returned snapshot contains a copy of the initial coin credits
-                // that will be popped back if bytecode execution fails in order to cancel its effects only
+                // Prepare context and save the initial ledger changes before execution.
+                // The returned snapshot takes into account the initial coin credits.
+                // This snapshot will be popped back if bytecode execution fails.
                 let ledger_changes_backup = self.prepare_context(
                     sender,
                     gas_price,

--- a/massa-execution/src/vm.rs
+++ b/massa-execution/src/vm.rs
@@ -68,6 +68,8 @@ impl VM {
     }
 
     /// runs an SCE-final execution step
+    /// See https://github.com/massalabs/massa/wiki/vm_ledger_interaction
+    ///
     /// # Parameters
     ///   * step: execution step to run
     pub(crate) fn run_final_step(&mut self, step: &ExecutionStep) {
@@ -136,6 +138,7 @@ impl VM {
 
     /// Prepares (updates) the shared context before the new operation.
     /// Returns a snapshot of the current caused ledger changes.
+    /// See https://github.com/massalabs/massa/wiki/vm_ledger_interaction
     /// TODO: do not ignore the results
     /// TODO: consider dispatching gas fees with edorsers/endorsees as well
     fn prepare_context(
@@ -150,10 +153,10 @@ impl VM {
     ) -> SCELedgerChanges {
         let mut context = self.execution_context.lock().unwrap();
 
-        // Credit the sender with "coins"
+        // make context.ledger_step credit Op's sender with Op.coins in the SCE ledger
         let _result = context.ledger_step.set_balance_delta(sender, coins, true);
 
-        // credit the block creator with max_gas*gas_price
+        // make context.ledger_step credit the producer of the block B with Op.max_gas * Op.gas_price in the SCE ledger
         let _result = context.ledger_step.set_balance_delta(
             block_creator_addr,
             gas_price.saturating_mul_u64(max_gas),
@@ -172,6 +175,7 @@ impl VM {
     }
 
     /// Runs an active step
+    /// See https://github.com/massalabs/massa/wiki/vm_ledger_interaction
     ///
     /// 1. Get step history (cache of final ledger changes by slot and block_id history)
     /// 2. clear caused changes
@@ -254,6 +258,7 @@ impl VM {
     }
 
     /// runs an SCE-active execution step
+    /// See https://github.com/massalabs/massa/wiki/vm_ledger_interaction
     ///
     /// # Parameters
     ///   * step: execution step to run

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -39,8 +39,8 @@ impl Address {
     }
 
     /// Computes address associated with given public key
-    pub fn from_public_key(public_key: &PublicKey) -> Result<Self, ModelsError> {
-        Ok(Address(Hash::from(&public_key.to_bytes())))
+    pub fn from_public_key(public_key: &PublicKey) -> Self {
+        Address(Hash::from(&public_key.to_bytes()))
     }
 
     /// ## Example

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -135,7 +135,7 @@ impl Block {
             .endorsements
             .iter()
             .try_for_each::<_, Result<(), ModelsError>>(|e| {
-                let address = Address::from_public_key(&e.content.sender_public_key)?;
+                let address = Address::from_public_key(&e.content.sender_public_key);
                 if let Some(old) = res.get_mut(&address) {
                     old.insert(e.compute_endorsement_id()?);
                 } else {

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -87,8 +87,7 @@ impl std::fmt::Display for Operation {
             }
         )?;
         writeln!(f, "Signature: {}", self.signature)?;
-        let addr = Address::from_public_key(&self.content.sender_public_key)
-            .map_err(|_| std::fmt::Error)?;
+        let addr = Address::from_public_key(&self.content.sender_public_key);
         let amount = self.content.fee.to_string();
         writeln!(
             f,
@@ -400,7 +399,7 @@ impl Operation {
 
     pub fn get_ledger_involved_addresses(&self) -> Result<AddressHashSet, ModelsError> {
         let mut res = AddressHashSet::default();
-        let emitter_address = Address::from_public_key(&self.content.sender_public_key)?;
+        let emitter_address = Address::from_public_key(&self.content.sender_public_key);
         res.insert(emitter_address);
         match self.content.op {
             OperationType::Transaction {
@@ -420,10 +419,10 @@ impl Operation {
         match self.content.op {
             OperationType::Transaction { .. } => {}
             OperationType::RollBuy { .. } => {
-                res.insert(Address::from_public_key(&self.content.sender_public_key)?);
+                res.insert(Address::from_public_key(&self.content.sender_public_key));
             }
             OperationType::RollSell { .. } => {
-                res.insert(Address::from_public_key(&self.content.sender_public_key)?);
+                res.insert(Address::from_public_key(&self.content.sender_public_key));
             }
             OperationType::ExecuteSC { .. } => {}
         }
@@ -484,7 +483,7 @@ mod tests {
         let recv_pub = derive_public_key(&recv_priv);
 
         let op = OperationType::Transaction {
-            recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+            recipient_address: Address::from_public_key(&recv_pub),
             amount: Amount::default(),
         };
         let ser_type = op.to_bytes_compact().unwrap();

--- a/massa-network/src/tests/tools.rs
+++ b/massa-network/src/tests/tools.rs
@@ -359,7 +359,7 @@ pub fn get_transaction(expire_period: u64, fee: u64) -> (Operation, u8) {
     let recv_pub = derive_public_key(&recv_priv);
 
     let op = OperationType::Transaction {
-        recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+        recipient_address: Address::from_public_key(&recv_pub),
         amount: Amount::default(),
     };
     let content = OperationContent {
@@ -373,7 +373,7 @@ pub fn get_transaction(expire_period: u64, fee: u64) -> (Operation, u8) {
 
     (
         Operation { content, signature },
-        Address::from_public_key(&sender_pub).unwrap().get_thread(2),
+        Address::from_public_key(&sender_pub).get_thread(2),
     )
 }
 

--- a/massa-pool/src/endorsement_pool.rs
+++ b/massa-pool/src/endorsement_pool.rs
@@ -51,11 +51,7 @@ impl EndorsementPool {
             .endorsements
             .iter()
             .filter_map(|(endo_id, endorsement)| {
-                let creator = match Address::from_public_key(&endorsement.content.sender_public_key)
-                {
-                    Ok(addr) => addr,
-                    Err(e) => return Some(Err(e.into())),
-                };
+                let creator = Address::from_public_key(&endorsement.content.sender_public_key);
                 if endorsement.content.endorsed_block == parent
                     && endorsement.content.slot == target_slot
                     && creators.get(endorsement.content.index as usize) == Some(&creator)
@@ -159,7 +155,7 @@ impl EndorsementPool {
     ) -> Result<EndorsementHashMap<Endorsement>, PoolError> {
         let mut res = EndorsementHashMap::default();
         for (id, ed) in self.endorsements.iter() {
-            if Address::from_public_key(&ed.content.sender_public_key)? == address {
+            if Address::from_public_key(&ed.content.sender_public_key) == address {
                 res.insert(*id, ed.clone());
             }
         }

--- a/massa-pool/src/operation_pool.rs
+++ b/massa-pool/src/operation_pool.rs
@@ -46,7 +46,7 @@ impl WrappedOperation {
     fn new(op: Operation, thread_count: u8) -> Result<Self, PoolError> {
         Ok(WrappedOperation {
             byte_count: op.to_bytes_compact()?.len() as u64,
-            thread: Address::from_public_key(&op.content.sender_public_key)?
+            thread: Address::from_public_key(&op.content.sender_public_key)
                 .get_thread(thread_count),
             op,
         })
@@ -435,7 +435,7 @@ pub mod tests {
         let recv_pub = derive_public_key(&recv_priv);
 
         let op = OperationType::Transaction {
-            recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+            recipient_address: Address::from_public_key(&recv_pub),
             amount: Amount::default(),
         };
         let content = OperationContent {
@@ -449,7 +449,7 @@ pub mod tests {
 
         (
             Operation { content, signature },
-            Address::from_public_key(&sender_pub).unwrap().get_thread(2),
+            Address::from_public_key(&sender_pub).get_thread(2),
         )
     }
 

--- a/massa-pool/src/tests/scenario.rs
+++ b/massa-pool/src/tests/scenario.rs
@@ -297,7 +297,9 @@ async fn test_pool_propagate_newly_added_endorsements() {
                 .get_endorsements(
                     target_slot,
                     endorsement.content.endorsed_block,
-                    vec![Address::from_public_key(&endorsement.content.sender_public_key).unwrap()],
+                    vec![Address::from_public_key(
+                        &endorsement.content.sender_public_key,
+                    )],
                 )
                 .await
                 .unwrap();
@@ -360,21 +362,21 @@ async fn test_get_involved_operations() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 1 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(1, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 1 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(1, address_b.get_thread(thread_count));
 
@@ -516,21 +518,21 @@ async fn test_new_final_ops() {
     // addresses a and b both in thread 0
     let mut priv_a = generate_random_private_key();
     let mut pubkey_a = derive_public_key(&priv_a);
-    let mut address_a = Address::from_public_key(&pubkey_a).unwrap();
+    let mut address_a = Address::from_public_key(&pubkey_a);
     while 0 != address_a.get_thread(thread_count) {
         priv_a = generate_random_private_key();
         pubkey_a = derive_public_key(&priv_a);
-        address_a = Address::from_public_key(&pubkey_a).unwrap();
+        address_a = Address::from_public_key(&pubkey_a);
     }
     assert_eq!(0, address_a.get_thread(thread_count));
 
     let mut priv_b = generate_random_private_key();
     let mut pubkey_b = derive_public_key(&priv_b);
-    let mut address_b = Address::from_public_key(&pubkey_b).unwrap();
+    let mut address_b = Address::from_public_key(&pubkey_b);
     while 0 != address_b.get_thread(thread_count) {
         priv_b = generate_random_private_key();
         pubkey_b = derive_public_key(&priv_b);
-        address_b = Address::from_public_key(&pubkey_b).unwrap();
+        address_b = Address::from_public_key(&pubkey_b);
     }
     assert_eq!(0, address_b.get_thread(thread_count));
 

--- a/massa-pool/src/tests/tools.rs
+++ b/massa-pool/src/tests/tools.rs
@@ -49,7 +49,7 @@ pub fn get_transaction(expire_period: u64, fee: u64) -> (Operation, u8) {
     let recv_pub = derive_public_key(&recv_priv);
 
     let op = OperationType::Transaction {
-        recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+        recipient_address: Address::from_public_key(&recv_pub),
         amount: Amount::default(),
     };
     let content = OperationContent {
@@ -63,7 +63,7 @@ pub fn get_transaction(expire_period: u64, fee: u64) -> (Operation, u8) {
 
     (
         Operation { content, signature },
-        Address::from_public_key(&sender_pub).unwrap().get_thread(2),
+        Address::from_public_key(&sender_pub).get_thread(2),
     )
 }
 
@@ -91,7 +91,7 @@ pub fn get_transaction_with_addresses(
     recv_pub: PublicKey,
 ) -> (Operation, u8) {
     let op = OperationType::Transaction {
-        recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+        recipient_address: Address::from_public_key(&recv_pub),
         amount: Amount::default(),
     };
     let content = OperationContent {
@@ -105,6 +105,6 @@ pub fn get_transaction_with_addresses(
 
     (
         Operation { content, signature },
-        Address::from_public_key(&sender_pub).unwrap().get_thread(2),
+        Address::from_public_key(&sender_pub).get_thread(2),
     )
 }

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -187,7 +187,7 @@ pub fn create_operation_with_expire_period(
     let recv_pub = derive_public_key(&recv_priv);
 
     let op = OperationType::Transaction {
-        recipient_address: Address::from_public_key(&recv_pub).unwrap(),
+        recipient_address: Address::from_public_key(&recv_pub),
         amount: Amount::default(),
     };
     let content = OperationContent {

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -1138,21 +1138,13 @@ impl ProtocolWorker {
             }
 
             // check address and thread
-            match Address::from_public_key(&op.content.sender_public_key) {
-                Ok(addr) => {
-                    if addr.get_thread(serialization_context.parent_count)
-                        != block.header.content.slot.thread
-                    {
-                        massa_trace!("protocol.protocol_worker.note_block_from_node.err_op_thread",
-                            { "node": source_node_id,"block_id":block_id, "block": block, "op": op});
-                        return Ok(None);
-                    }
-                }
-                Err(err) => {
-                    massa_trace!("protocol.protocol_worker.note_block_from_node.err_op_creator_address",
-                        { "node": source_node_id,"block_id":block_id, "block": block, "op": op, "err": format!("{}", err)});
-                    return Ok(None);
-                }
+            let addr = Address::from_public_key(&op.content.sender_public_key);
+            if addr.get_thread(serialization_context.parent_count)
+                != block.header.content.slot.thread
+            {
+                massa_trace!("protocol.protocol_worker.note_block_from_node.err_op_thread",
+                    { "node": source_node_id,"block_id":block_id, "block": block, "op": op});
+                return Ok(None);
             }
         }
 

--- a/massa-protocol-worker/src/tests/cache_scenarios.rs
+++ b/massa-protocol-worker/src/tests/cache_scenarios.rs
@@ -35,7 +35,7 @@ async fn test_noting_block_does_not_panic_with_zero_max_node_known_blocks_size()
             // Create 1 node.
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -293,7 +293,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             // Create 1 node.
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -398,7 +398,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             // Create 1 node.
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -508,7 +508,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             // Create 2 nodes.
             let nodes = tools::create_and_connect_nodes(2, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 

--- a/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
@@ -40,13 +40,13 @@ async fn test_protocol_sends_blocks_with_operations_to_consensus() {
 
             let mut private_key = generate_random_private_key();
             let mut public_key = derive_public_key(&private_key);
-            let mut address = Address::from_public_key(&public_key).unwrap();
+            let mut address = Address::from_public_key(&public_key);
             let mut thread = address.get_thread(serialization_context.parent_count);
 
             while thread != 0 {
                 private_key = generate_random_private_key();
                 public_key = derive_public_key(&private_key);
-                address = Address::from_public_key(&public_key).unwrap();
+                address = Address::from_public_key(&public_key);
                 thread = address.get_thread(serialization_context.parent_count);
             }
 

--- a/massa-protocol-worker/src/tests/operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/operations_scenarios.rs
@@ -294,7 +294,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             // Create 1 node.
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -404,7 +404,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             // Create 1 node.
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -513,7 +513,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             // Create 2 nodes.
             let nodes = tools::create_and_connect_nodes(2, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -602,7 +602,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             // Create 3 nodes.
             let nodes = tools::create_and_connect_nodes(3, &mut network_controller).await;
 
-            let address = Address::from_public_key(&nodes[0].id.0).unwrap();
+            let address = Address::from_public_key(&nodes[0].id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 
@@ -703,7 +703,7 @@ async fn test_protocol_does_not_propagates_operations_when_receiving_those_insid
             let operation =
                 tools::create_operation_with_expire_period(&creator_node.private_key, 1);
 
-            let address = Address::from_public_key(&creator_node.id.0).unwrap();
+            let address = Address::from_public_key(&creator_node.id.0);
             let serialization_context = massa_models::get_serialization_context();
             let thread = address.get_thread(serialization_context.parent_count);
 

--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -34,7 +34,7 @@ impl Wallet {
             .iter()
             .map(|key| {
                 let pub_key = derive_public_key(key);
-                Ok((Address::from_public_key(&pub_key)?, (pub_key, *key)))
+                Ok((Address::from_public_key(&pub_key), (pub_key, *key)))
             })
             .collect::<Result<AddressHashMap<_>, WalletError>>()?;
         Ok(Wallet {
@@ -62,7 +62,7 @@ impl Wallet {
     pub fn add_private_key(&mut self, key: PrivateKey) -> Result<Address, WalletError> {
         if !self.keys.iter().any(|(_, (_, file_key))| file_key == &key) {
             let pub_key = derive_public_key(&key);
-            let ad = Address::from_public_key(&pub_key)?;
+            let ad = Address::from_public_key(&pub_key);
             self.keys.insert(ad, (pub_key, key));
             self.save()?;
             Ok(ad)
@@ -131,7 +131,7 @@ impl std::fmt::Display for Wallet {
         for k in &self.keys {
             let private_key = k.1 .1; // TODO: why not taking other fields of this struct?
             let public_key = derive_public_key(&private_key);
-            let addr = Address::from_public_key(&public_key).map_err(|_| std::fmt::Error)?;
+            let addr = Address::from_public_key(&public_key);
             writeln!(f)?;
             writeln!(f, "Private key: {}", private_key)?;
             writeln!(f, "Public key: {}", public_key)?;


### PR DESCRIPTION
Implement the VM execution handling so that it follows https://github.com/massalabs/massa/wiki/vm_ledger_interaction

Note that I had to remove the OperationSC because it didn't readily allow implementing some failure cases (for example still paying the coins to the sender on bytrcode parse failure) and workarounds made OperationSC not very useful.

Note that I also refactored address::from_public_key so that it does not return an error (it doesn't generate any errors anyway, it was a useless complication) because we don't want execution to fail in such a way that we don't give the op.coins to the sender