### PR TITLE
Only test stop_node if feature `local` activated

### DIFF
--- a/massa-client/src/tests/mod.rs
+++ b/massa-client/src/tests/mod.rs
@@ -1,2 +1,3 @@
+#[cfg(target_feature = "local")]
 mod scenarios;
 mod tools;

--- a/massa-client/src/tests/scenarios.rs
+++ b/massa-client/src/tests/scenarios.rs
@@ -1,10 +1,10 @@
+///! Tested only with feature "local"
 use anyhow::{bail, Result};
 use assert_cmd::Command;
 use massa_models::api::NodeStatus;
 use serde::de::DeserializeOwned;
 use serial_test::serial;
 use std::{thread::JoinHandle, time::Duration};
-
 const TIMEOUT: u64 = 30;
 const TENTATIVES: u64 = 5;
 

--- a/massa-consensus/src/tests/scenario_block_creation.rs
+++ b/massa-consensus/src/tests/scenario_block_creation.rs
@@ -484,7 +484,7 @@ async fn test_order_of_inclusion() {
             // wait for first slot
             pool_controller
                 .wait_command(
-                    cfg.t0.saturating_mul_u64(2).saturating_add(init_time),
+                    cfg.t0.saturating_mul(2).saturating_add(init_time),
                     |cmd| match cmd {
                         PoolCommand::UpdateCurrentSlot(s) => {
                             if s == Slot::new(1, 0) {

--- a/massa-consensus/src/tests/scenario_block_creation.rs
+++ b/massa-consensus/src/tests/scenario_block_creation.rs
@@ -464,7 +464,8 @@ async fn test_order_of_inclusion() {
     cfg.operation_batch_size = 3;
     cfg.max_operations_per_block = 50;
     // Increase timestamp a bit to avoid missing the first slot.
-    cfg.genesis_timestamp = MassaTime::now().unwrap().checked_add(1000.into()).unwrap();
+    let init_time: MassaTime = 1000.into();
+    cfg.genesis_timestamp = MassaTime::now().unwrap().checked_add(init_time).unwrap();
 
     let op1 = create_transaction(priv_a, pubkey_a, address_b, 5, 10, 1);
     let op2 = create_transaction(priv_a, pubkey_a, address_b, 50, 10, 10);
@@ -482,20 +483,23 @@ async fn test_order_of_inclusion() {
                     consensus_event_receiver| {
             // wait for first slot
             pool_controller
-                .wait_command(cfg.t0.checked_mul(2).unwrap(), |cmd| match cmd {
-                    PoolCommand::UpdateCurrentSlot(s) => {
-                        if s == Slot::new(1, 0) {
-                            Some(())
-                        } else {
+                .wait_command(
+                    cfg.t0.saturating_mul_u64(2).saturating_add(init_time),
+                    |cmd| match cmd {
+                        PoolCommand::UpdateCurrentSlot(s) => {
+                            if s == Slot::new(1, 0) {
+                                Some(())
+                            } else {
+                                None
+                            }
+                        }
+                        PoolCommand::GetEndorsements { response_tx, .. } => {
+                            response_tx.send(Vec::new()).unwrap();
                             None
                         }
-                    }
-                    PoolCommand::GetEndorsements { response_tx, .. } => {
-                        response_tx.send(Vec::new()).unwrap();
-                        None
-                    }
-                    _ => None,
-                })
+                        _ => None,
+                    },
+                )
                 .await
                 .expect("timeout while waiting for slot");
 

--- a/massa-consensus/src/tests/scenario_roll.rs
+++ b/massa-consensus/src/tests/scenario_roll.rs
@@ -568,7 +568,7 @@ async fn test_roll_block_creation() {
     // wait for first slot
     pool_controller
         .wait_command(
-            cfg.t0.saturating_mul_u64(2).saturating_add(init_time),
+            cfg.t0.saturating_mul(2).saturating_add(init_time),
             |cmd| match cmd {
                 PoolCommand::UpdateCurrentSlot(s) => {
                     if s == Slot::new(1, 0) {

--- a/massa-time/src/lib.rs
+++ b/massa-time/src/lib.rs
@@ -277,6 +277,16 @@ impl MassaTime {
     /// ```
     /// # use massa_time::*;
     /// let time_1 : MassaTime = MassaTime::from(42);
+    /// let res : MassaTime = time_1.saturating_mul(7);
+    /// assert_eq!(res,MassaTime::from(42*7))
+    /// ```
+    pub fn saturating_mul(self, n: u64) -> MassaTime {
+        MassaTime(self.0.saturating_mul(n))
+    }
+
+    /// ```
+    /// # use massa_time::*;
+    /// let time_1 : MassaTime = MassaTime::from(42);
     /// let res : MassaTime = time_1.checked_mul(7).unwrap();
     /// assert_eq!(res,MassaTime::from(42*7))
     /// ```


### PR DESCRIPTION
The scenario stop_node is really unstable for the moment because it
touch unstable topics as *config management* and *test environment*. For
the moment the test should be only be ran manually by a user with a
command line:

```bash
cargo test --package massa_client --lib --all-features -- tests::scenarios::test_run_node --exact --nocapture
```