### PR TITLE
resolve readony addres creation ambiguity

### DIFF
--- a/massa-execution/src/interface_impl.rs
+++ b/massa-execution/src/interface_impl.rs
@@ -65,6 +65,11 @@ impl Interface for InterfaceImpl {
         let (slot, created_addr_index) = (context.slot, context.created_addr_index);
         let mut data: Vec<u8> = slot.to_bytes_key().to_vec();
         data.append(&mut created_addr_index.to_be_bytes().to_vec());
+        if context.read_only {
+            data.push(0u8);
+        } else {
+            data.push(1u8);
+        }
         let address = Address(massa_hash::hash::Hash::from(&data));
         let res = address.to_bs58_check();
         context.ledger_step.set_module(address, module.clone());

--- a/massa-execution/src/types.rs
+++ b/massa-execution/src/types.rs
@@ -36,6 +36,7 @@ pub(crate) struct ExecutionContext {
     pub opt_block_creator_addr: Option<Address>,
     pub call_stack: VecDeque<Address>,
     pub owned_addresses: AddressHashSet,
+    pub read_only: bool,
 }
 
 #[derive(Clone)]
@@ -67,6 +68,7 @@ impl ExecutionContext {
             call_stack: Default::default(),
             owned_addresses: Default::default(),
             created_addr_index: Default::default(),
+            read_only: Default::default(),
         }
     }
 }

--- a/massa-execution/src/vm.rs
+++ b/massa-execution/src/vm.rs
@@ -143,6 +143,7 @@ impl VM {
         context.created_addr_index = 0;
         context.owned_addresses.clear();
         context.call_stack.clear();
+        context.read_only = false;
     }
 
     /// Prepares (updates) the shared context before the new operation.
@@ -211,6 +212,9 @@ impl VM {
                 Address::from_public_key(&public_key)
             });
             context.call_stack = vec![address].into();
+
+            // Set read-only
+            context.read_only = true;
 
             // Set the max gas.
             context.max_gas = max_gas;


### PR DESCRIPTION
If there are address creations at slot B's execution, and then a readonly call at that same slot that also creates addresses, the new creations will overwrite the ones created at the slot. This PR removes this ambiguity.