### PR TITLE
Repair exec loop

### DIFF
--- a/massa-execution/src/worker.rs
+++ b/massa-execution/src/worker.rs
@@ -160,9 +160,10 @@ impl ExecutionWorker {
                         }
                     }
                     Some(ExecutionRequest::Shutdown) => return,
-                    None => { /* startup or spurious wakeup */ }
+                    None => {
+                        requests = condvar.wait(requests).unwrap();
+                    }
                 };
-                requests = condvar.wait(requests).unwrap();
             }
         });
 


### PR DESCRIPTION
On multiple condvar wakeup signals in the execution loop, only one was processed. Now all are processed. This repairs clean shutdown and improves the processing of batches of blocks.