### PR TITLE
repair config override

### DIFF
--- a/massa-client/src/settings.rs
+++ b/massa-client/src/settings.rs
@@ -2,14 +2,21 @@
 
 use directories::ProjectDirs;
 use serde::Deserialize;
-use std::net::IpAddr;
+use std::{net::IpAddr, path::Path};
 
 lazy_static::lazy_static! {
     // TODO: this code is duplicated from /massa-node/settings.rs and should be part of a custom crate
     pub static ref SETTINGS: Settings = {
         let mut settings = config::Config::default();
+
         let config_path = std::env::var("MASSA_CONFIG_PATH").unwrap_or_else(|_| "base_config/config.toml".to_string());
         settings.merge(config::File::with_name(&config_path)).unwrap_or_else(|_| panic!("failed to read {} config {}", config_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+
+        let config_override_path = std::env::var("MASSA_CONFIG_OVERRIDE_PATH").unwrap_or_else(|_| "config/config.toml".to_string());
+        if Path::new(&config_override_path).is_file() {
+            settings.merge(config::File::with_name(&config_override_path)).unwrap_or_else(|_| panic!("failed to read {} override config {}", config_override_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+        }
+
         if let Some(proj_dirs) = ProjectDirs::from("com", "MassaLabs", "massa-client") { // Portable user config loading
             let user_config_path = proj_dirs.config_dir();
             if user_config_path.exists() {

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -1,5 +1,7 @@
 // Copyright (c) 2021 MASSA LABS <info@massa.net>
 
+use std::path::Path;
+
 use directories::ProjectDirs;
 use massa_bootstrap::settings::BootstrapSettings;
 use massa_consensus::ConsensusSettings;
@@ -16,8 +18,15 @@ lazy_static::lazy_static! {
     // TODO: this code is duplicated from /massa-client/settings.rs and should be part of a custom crate
     pub static ref SETTINGS: Settings = {
         let mut settings = config::Config::default();
+
         let config_path = std::env::var("MASSA_CONFIG_PATH").unwrap_or_else(|_| "base_config/config.toml".to_string());
         settings.merge(config::File::with_name(&config_path)).unwrap_or_else(|_| panic!("failed to read {} config {}", config_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+
+        let config_override_path = std::env::var("MASSA_CONFIG_OVERRIDE_PATH").unwrap_or_else(|_| "config/config.toml".to_string());
+        if Path::new(&config_override_path).is_file() {
+            settings.merge(config::File::with_name(&config_override_path)).unwrap_or_else(|_| panic!("failed to read {} override config {}", config_override_path, std::env::current_dir().unwrap().as_path().to_str().unwrap()));
+        }
+
         if let Some(proj_dirs) = ProjectDirs::from("com", "MassaLabs", "massa-node") { // Portable user config loading
             let user_config_path = proj_dirs.config_dir();
             if user_config_path.exists() {
@@ -25,6 +34,7 @@ lazy_static::lazy_static! {
                 settings.merge(config::File::with_name(path_str)).unwrap_or_else(|_| panic!("failed to read {} user config", path_str));
             }
         }
+
         settings.merge(config::Environment::with_prefix("MASSA_NODE")).unwrap();
         settings.try_into().unwrap()
     };


### PR DESCRIPTION
 config/config.toml was not loaded anymore to override the default config. This PR restores the documented behavior