### PR TITLE
Temporary set a version of rust

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           target: "x86_64-unknown-linux-musl"
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -51,7 +51,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           target: "x86_64-pc-windows-gnu"
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -81,7 +81,7 @@ jobs:
     - run: |
         export HOME=/root
         rustup update
-        rustup default nightly
+        rustup default nightly-2021-12-03
         rustup target add x86_64-apple-darwin
         cargo update
         rm -rf massa/*

--- a/.github/workflows/ci-light.yml
+++ b/.github/workflows/ci-light.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           components: rustfmt
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -60,7 +60,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           components: rustfmt
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -59,7 +59,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -78,7 +78,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -98,7 +98,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           components: clippy
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -126,7 +126,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -151,7 +151,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -184,7 +184,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-12-03
           components: rustfmt
           override: true
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
Set a version temporary, waiting for a nightly release compatible.
Version rustc: 1.59.0

> If you see this commit in a month and it's not already revert, try to revert it quick!