### PR TITLE
Put back `test roll block creation`

### DIFF
--- a/massa-consensus/src/tests/scenario_roll.rs
+++ b/massa-consensus/src/tests/scenario_roll.rs
@@ -476,7 +476,6 @@ async fn test_roll() {
     .await;
 }
 
-#[ignore]
 #[tokio::test]
 #[serial]
 async fn test_roll_block_creation() {


### PR DESCRIPTION
We need to make the test pass on macos!