### PR TITLE
Add a file to save commands of REPL on disk.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,6 +1375,7 @@ dependencies = [
  "massa_time",
  "massa_wallet",
  "paw",
+ "rev_lines",
  "serde 1.0.132",
  "serde_json",
  "serial_test",
@@ -2583,6 +2584,12 @@ dependencies = [
  "web-sys",
  "winreg",
 ]
+
+[[package]]
+name = "rev_lines"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18eb52b6664d331053136fcac7e4883bdc6f5fc04a6aab3b0f75eafb80ab88b3"
 
 [[package]]
 name = "rkyv"

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -29,6 +29,8 @@ massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
 massa_wallet = { path = "../massa-wallet" }
+rev_lines = "0.2.1"
+
 [dev-dependencies]
 assert_cmd = "2.0"
 serial_test = "0.5"

--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -1,4 +1,5 @@
 history = 10
+history_file_path = "config/.massa_history"
 
 [default_node]
 ip = "127.0.0.1"

--- a/massa-client/src/repl.rs
+++ b/massa-client/src/repl.rs
@@ -11,7 +11,14 @@ use massa_models::address::AddressHashSet;
 use massa_models::api::{AddressInfo, BlockInfo, EndorsementInfo, NodeStatus, OperationInfo};
 use massa_models::{Address, OperationId};
 use massa_wallet::Wallet;
+use rev_lines::RevLines;
 use std::collections::VecDeque;
+use std::io::Error;
+use std::{
+    fs::File,
+    fs::OpenOptions,
+    io::{BufReader, Write},
+};
 use strum::IntoEnumIterator;
 use strum::ParseError;
 
@@ -65,11 +72,33 @@ struct CommandHistory {
     history: VecDeque<String>,
 }
 
+impl CommandHistory {
+    fn get_saved_history() -> Result<VecDeque<String>, Error> {
+        if let Ok(file) = File::open(&SETTINGS.history_file_path) {
+            let lines = RevLines::new(BufReader::new(file))?;
+            Ok(lines.collect())
+        } else {
+            File::create(&SETTINGS.history_file_path)?;
+            Ok(VecDeque::new())
+        }
+    }
+
+    fn write_to_saved_history(command: &String) {
+        if let Ok(mut file) = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(&SETTINGS.history_file_path)
+        {
+            writeln!(file, "{}", command).ok();
+        }
+    }
+}
+
 impl Default for CommandHistory {
     fn default() -> Self {
         CommandHistory {
             max: SETTINGS.history,
-            history: VecDeque::new(),
+            history: CommandHistory::get_saved_history().unwrap_or_default(),
         }
     }
 }
@@ -83,7 +112,9 @@ impl<T: ToString> History<T> for CommandHistory {
         if self.history.len() == self.max {
             self.history.pop_back();
         }
-        self.history.push_front(val.to_string());
+        let string_value = val.to_string();
+        CommandHistory::write_to_saved_history(&string_value);
+        self.history.push_front(string_value);
     }
 }
 

--- a/massa-client/src/settings.rs
+++ b/massa-client/src/settings.rs
@@ -2,7 +2,7 @@
 
 use directories::ProjectDirs;
 use serde::Deserialize;
-use std::{net::IpAddr, path::Path};
+use std::{net::IpAddr, path::Path, path::PathBuf};
 
 lazy_static::lazy_static! {
     // TODO: this code is duplicated from /massa-node/settings.rs and should be part of a custom crate
@@ -33,6 +33,7 @@ lazy_static::lazy_static! {
 pub struct Settings {
     pub default_node: DefaultNode,
     pub history: usize,
+    pub history_file_path: PathBuf,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
This feature allow to be able to store each command typed in the REPL.

It load them at each start of the REPL to be able to navigate through commands typed in an older REPL.
The commands are stored in the file specified in `base_cofing/config.toml`.

The REPL try to create the file if it doesn't exist each time.