### PR TITLE
Fix: `wallet_remove_addresses` does not update wallet file

### DIFF
--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -471,11 +471,11 @@ impl Command {
                 let mut res = "".to_string();
                 for key in parse_vec::<Address>(parameters)?.into_iter() {
                     match wallet.remove_address(key) {
-                        Some(_) => {
+                        Ok(_) => {
                             res.push_str(&format!("Removed address {} from the wallet\n", key));
                         }
-                        None => {
-                            res.push_str(&format!("Address {} wasn't in the wallet\n", key));
+                        Err(err) => {
+                            res.push_str(&err.to_string());
                         }
                     }
                 }

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -12,7 +12,7 @@ use massa_models::{
 };
 use massa_signature::{generate_random_private_key, PrivateKey, PublicKey};
 use massa_time::MassaTime;
-use massa_wallet::Wallet;
+use massa_wallet::{Wallet, WalletError};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
@@ -474,8 +474,14 @@ impl Command {
                         Ok(_) => {
                             res.push_str(&format!("Removed address {} from the wallet\n", key));
                         }
-                        Err(err) => {
-                            res.push_str(&err.to_string());
+                        Err(WalletError::MissingKeyError(_)) => {
+                            res.push_str(&format!("Address {} wasn't in the wallet\n", key));
+                        }
+                        Err(_) => {
+                            res.push_str(&format!(
+                                "Failed to remove address {} from the wallet\n",
+                                key
+                            ));
                         }
                     }
                 }

--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -78,7 +78,9 @@ impl Wallet {
     }
 
     pub fn remove_address(&mut self, address: Address) -> Result<(), WalletError> {
-        self.keys.remove(&address).ok_or(WalletError::MissingKeyError(address))?;
+        self.keys
+            .remove(&address)
+            .ok_or(WalletError::MissingKeyError(address))?;
         self.save()
     }
 

--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -77,8 +77,9 @@ impl Wallet {
         }
     }
 
-    pub fn remove_address(&mut self, address: Address) -> Option<(PublicKey, PrivateKey)> {
-        self.keys.remove(&address)
+    pub fn remove_address(&mut self, address: Address) -> Result<(), WalletError> {
+        self.keys.remove(&address).ok_or(WalletError::MissingKeyError(address))?;
+        self.save()
     }
 
     /// Finds the private key associated with given address


### PR DESCRIPTION
I have fixed by calling `save()`. `save()` can fail with a Result so I changed the return type to be able to propagate the error.

Fix #2172.