### PR TITLE
Send a list of peer if max connection reached

### DIFF
--- a/massa-network/src/error.rs
+++ b/massa-network/src/error.rs
@@ -19,8 +19,8 @@ pub enum NetworkError {
     TokioTaskJoinError(#[from] tokio::task::JoinError),
     /// error receiving oneshot response : {0}
     TokieRecvError(#[from] tokio::sync::oneshot::error::RecvError),
-    /// Error during network connection:`{0:?}`
-    PeerConnectionError(NetworkConnectionErrorType),
+    /// Error during network connection: {0}
+    PeerConnectionError(#[from] NetworkConnectionErrorType),
     /// The ip:`{0}` address is not valid
     InvalidIpError(IpAddr),
     /// Active connection missing:`{0}`
@@ -56,12 +56,36 @@ pub enum HandshakeErrorType {
     HandshakeKey,
     HandshakeInvalidSignature,
     IncompatibleVersion,
+    /// Outgoing connection returned a bootstrapable peer list: {0:?}
+    PeerListReceived(Vec<IpAddr>),
 }
 
-#[derive(Debug)]
+macro_rules! throw_handshake_error {
+    ($err:ident) => {
+        return Err(NetworkError::HandshakeError(HandshakeErrorType::$err))
+    };
+    ($err:ident, $e:expr) => {
+        return Err(NetworkError::HandshakeError(HandshakeErrorType::$err($e)))
+    };
+}
+pub(crate) use throw_handshake_error;
+
+#[derive(Debug, Error, Display)]
+#[non_exhaustive]
+/// Incoming and outgoing connection with other peers error list
 pub enum NetworkConnectionErrorType {
+    /// Try to close connection with no connection: {0}
     CloseConnectionWithNoConnectionToClose(IpAddr),
+    /// Peer info not found for address: {0}
     PeerInfoNotFoundError(IpAddr),
+    /// Too many connection attempt: {0}
     ToManyConnectionAttempt(IpAddr),
+    /// Too many connection failure: {0}
     ToManyConnectionFailure(IpAddr),
+    /// Max connected peers reached: {0}
+    MaxPeersConnectionReached(IpAddr),
+    /// Attempt too connect from you own IP
+    SelfConnection,
+    /// A banned peer is trying to connect: {0}
+    BannedPeerTryingToConnect(IpAddr),
 }

--- a/massa-network/src/handshake_worker.rs
+++ b/massa-network/src/handshake_worker.rs
@@ -44,7 +44,6 @@ impl HandshakeWorker {
     /// Manage a new connection and perform a normal handshake
     ///
     /// Used for incomming and outgoing connections.
-    /// Add the node with
     /// It will spawn a new future with an HandshakeWorker from the given `reader`
     /// and `writer` from your current node to the distant `connectionId`
     ///

--- a/massa-network/src/handshake_worker.rs
+++ b/massa-network/src/handshake_worker.rs
@@ -115,9 +115,6 @@ impl HandshakeWorker {
         .await
         {
             Err(_) => throw!(HandshakeTimeout),
-            Ok(Err(NetworkError::HandshakeError(HandshakeErrorType::PeerListReceived(list)))) => {
-                throw!(PeerListReceived, list)
-            }
             Ok(Err(e)) => return Err(e),
             Ok(Ok((_, None))) => throw!(HandshakeInterruption, "init".into()),
             Ok(Ok((_, Some((_, msg))))) => match msg {
@@ -126,6 +123,7 @@ impl HandshakeWorker {
                     random_bytes: rb,
                     version,
                 } => (NodeId(pk), rb, version),
+                Message::PeerList(list) => throw!(PeerListReceived, list),
                 _ => throw!(HandshakeWrongMessage),
             },
         };

--- a/massa-network/src/handshake_worker.rs
+++ b/massa-network/src/handshake_worker.rs
@@ -54,6 +54,7 @@ impl HandshakeWorker {
     /// * private_key : our private key.
     /// * timeout_duration: after timeout_duration millis, the handshake attempt is dropped.
     /// * connection_id : Node we are trying to connect for debuging
+    /// * version : Node version used in handshake initialization (check peers compatibility)
     pub fn spawn(
         socket_reader: ReadHalf,
         socket_writer: WriteHalf,

--- a/massa-network/src/handshake_worker.rs
+++ b/massa-network/src/handshake_worker.rs
@@ -6,17 +6,19 @@ use super::{
     messages::Message,
 };
 use crate::{
-    error::{HandshakeErrorType, NetworkError},
-    ReadHalf, WriteHalf,
+    error::{throw_handshake_error as throw, HandshakeErrorType, NetworkError},
+    ConnectionId, ReadHalf, WriteHalf,
 };
 use futures::future::try_join;
 use massa_hash::hash::Hash;
+use massa_logging::massa_trace;
 use massa_models::node::NodeId;
 use massa_models::Version;
 use massa_signature::{sign, verify_signature, PrivateKey};
 use massa_time::MassaTime;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
-use tokio::time::timeout;
+use tokio::{task::JoinHandle, time::timeout};
+use tracing::debug;
 
 /// Type alias for more readability
 pub type HandshakeReturnType = Result<(NodeId, ReadBinder, WriteBinder), NetworkError>;
@@ -39,35 +41,57 @@ pub struct HandshakeWorker {
 impl HandshakeWorker {
     /// Creates a new handshake worker.
     ///
+    /// Manage a new connection and perform a normal handshake
+    ///
+    /// Used for incomming and outgoing connections.
+    /// Add the node with
+    /// It will spawn a new future with an HandshakeWorker from the given `reader`
+    /// and `writer` from your current node to the distant `connectionId`
+    ///
     /// # Arguments
     /// * socket_reader: receives data.
     /// * socket_writer: sends data.
     /// * self_node_id: our node id.
     /// * private_key : our private key.
     /// * timeout_duration: after timeout_duration millis, the handshake attempt is dropped.
-    pub fn new(
+    /// * connection_id : Node we are trying to connect for debuging
+    pub fn spawn(
         socket_reader: ReadHalf,
         socket_writer: WriteHalf,
         self_node_id: NodeId,
         private_key: PrivateKey,
         timeout_duration: MassaTime,
         version: Version,
-    ) -> HandshakeWorker {
-        HandshakeWorker {
-            reader: ReadBinder::new(socket_reader),
-            writer: WriteBinder::new(socket_writer),
-            self_node_id,
-            private_key,
-            timeout_duration,
-            version,
-        }
+        connection_id: ConnectionId,
+    ) -> JoinHandle<(ConnectionId, HandshakeReturnType)> {
+        debug!("starting handshake with connection_id={}", connection_id);
+        massa_trace!("network_worker.new_connection", {
+            "connection_id": connection_id
+        });
+
+        let connection_id_copy = connection_id;
+        tokio::spawn(async move {
+            (
+                connection_id_copy,
+                HandshakeWorker {
+                    reader: ReadBinder::new(socket_reader),
+                    writer: WriteBinder::new(socket_writer),
+                    self_node_id,
+                    private_key,
+                    timeout_duration,
+                    version,
+                }
+                .run()
+                .await,
+            )
+        })
     }
 
     /// Manages one on going handshake.
     /// Consumes self.
     /// Returns a tuple (ConnectionId, Result).
     /// Creates the binders to communicate with that node.
-    pub async fn run(mut self) -> HandshakeReturnType {
+    async fn run(mut self) -> HandshakeReturnType {
         // generate random bytes
         let mut self_random_bytes = [0u8; 32];
         StdRng::from_entropy().fill_bytes(&mut self_random_bytes);
@@ -90,43 +114,30 @@ impl HandshakeWorker {
         )
         .await
         {
-            Err(_) => {
-                return Err(NetworkError::HandshakeError(
-                    HandshakeErrorType::HandshakeTimeout,
-                ))
+            Err(_) => throw!(HandshakeTimeout),
+            Ok(Err(NetworkError::HandshakeError(HandshakeErrorType::PeerListReceived(list)))) => {
+                throw!(PeerListReceived, list)
             }
             Ok(Err(e)) => return Err(e),
-            Ok(Ok((_, None))) => {
-                return Err(NetworkError::HandshakeError(
-                    HandshakeErrorType::HandshakeInterruption("init".into()),
-                ))
-            }
+            Ok(Ok((_, None))) => throw!(HandshakeInterruption, "init".into()),
             Ok(Ok((_, Some((_, msg))))) => match msg {
                 Message::HandshakeInitiation {
                     public_key: pk,
                     random_bytes: rb,
                     version,
                 } => (NodeId(pk), rb, version),
-                _ => {
-                    return Err(NetworkError::HandshakeError(
-                        HandshakeErrorType::HandshakeWrongMessage,
-                    ))
-                }
+                _ => throw!(HandshakeWrongMessage),
             },
         };
 
         // check if remote node ID is the same as ours
         if other_node_id == self.self_node_id {
-            return Err(NetworkError::HandshakeError(
-                HandshakeErrorType::HandshakeKey,
-            ));
+            throw!(HandshakeKey)
         }
 
         // check if version is compatible with ours
         if !self.version.is_compatible(&other_version) {
-            return Err(NetworkError::HandshakeError(
-                HandshakeErrorType::IncompatibleVersion,
-            ));
+            throw!(IncompatibleVersion)
         }
 
         // sign their random bytes
@@ -149,24 +160,12 @@ impl HandshakeWorker {
         )
         .await
         {
-            Err(_) => {
-                return Err(NetworkError::HandshakeError(
-                    HandshakeErrorType::HandshakeTimeout,
-                ))
-            }
+            Err(_) => throw!(HandshakeTimeout),
             Ok(Err(e)) => return Err(e),
-            Ok(Ok((_, None))) => {
-                return Err(NetworkError::HandshakeError(
-                    HandshakeErrorType::HandshakeInterruption("repl".into()),
-                ))
-            }
+            Ok(Ok((_, None))) => throw!(HandshakeInterruption, "repl".into()),
             Ok(Ok((_, Some((_, msg))))) => match msg {
                 Message::HandshakeReply { signature: sig } => sig,
-                _ => {
-                    return Err(NetworkError::HandshakeError(
-                        HandshakeErrorType::HandshakeWrongMessage,
-                    ))
-                }
+                _ => throw!(HandshakeWrongMessage),
             },
         };
 

--- a/massa-network/src/network_controller.rs
+++ b/massa-network/src/network_controller.rs
@@ -221,11 +221,11 @@ impl NetworkCommandSender {
             .send(NetworkCommand::GetPeers(response_tx))
             .await
             .map_err(|_| NetworkError::ChannelError("could not send GetPeers command".into()))?;
-        Ok(response_rx.await.map_err(|_| {
+        response_rx.await.map_err(|_| {
             NetworkError::ChannelError(
                 "could not send GetAdvertisablePeerListChannelError upstream".into(),
             )
-        })?)
+        })
     }
 
     pub async fn get_network_stats(&self) -> Result<NetworkStats, NetworkError> {
@@ -234,11 +234,11 @@ impl NetworkCommandSender {
             .send(NetworkCommand::GetStats { response_tx })
             .await
             .map_err(|_| NetworkError::ChannelError("could not send GetPeers command".into()))?;
-        Ok(response_rx.await.map_err(|_| {
+        response_rx.await.map_err(|_| {
             NetworkError::ChannelError(
                 "could not send GetAdvertisablePeerListChannelError upstream".into(),
             )
-        })?)
+        })
     }
 
     /// Send the order to get bootstrap peers.
@@ -250,9 +250,9 @@ impl NetworkCommandSender {
             .map_err(|_| {
                 NetworkError::ChannelError("could not send GetBootstrapPeers command".into())
             })?;
-        Ok(response_rx.await.map_err(|_| {
+        response_rx.await.map_err(|_| {
             NetworkError::ChannelError("could not send GetBootstrapPeers response upstream".into())
-        })?)
+        })
     }
 
     pub async fn block_not_found(
@@ -306,9 +306,9 @@ impl NetworkCommandSender {
             .map_err(|_| {
                 NetworkError::ChannelError("could not send GetBootstrapPeers command".into())
             })?;
-        Ok(response_rx.await.map_err(|_| {
+        response_rx.await.map_err(|_| {
             NetworkError::ChannelError("could not send GetBootstrapPeers response upstream".into())
-        })?)
+        })
     }
 }
 

--- a/massa-network/src/network_worker.rs
+++ b/massa-network/src/network_worker.rs
@@ -1065,7 +1065,7 @@ impl NetworkWorker {
         let mut writer = WriteBinder::new(writer);
         let mut reader = ReadBinder::new(reader);
         match tokio::time::timeout(
-            std::time::Duration::from_millis(100),
+            self.cfg.peer_list_send_timeout.to_duration(),
             futures::future::try_join(writer.send(&msg), reader.next()),
         )
         .await

--- a/massa-network/src/network_worker.rs
+++ b/massa-network/src/network_worker.rs
@@ -484,6 +484,7 @@ impl NetworkWorker {
         // wait for all running handshakes
         self.running_handshakes.clear();
         while self.handshake_futures.next().await.is_some() {}
+        while self.handshake_peer_list_futures.next().await.is_some() {}
         Ok(())
     }
 

--- a/massa-network/src/network_worker.rs
+++ b/massa-network/src/network_worker.rs
@@ -15,7 +15,7 @@ use crate::{
     handshake_worker::HandshakeWorker,
     messages::Message,
 };
-use futures::{stream::FuturesUnordered, SinkExt, StreamExt};
+use futures::{stream::FuturesUnordered, StreamExt};
 use massa_hash::hash::Hash;
 use massa_logging::massa_trace;
 use massa_models::composite::PubkeySig;

--- a/massa-network/src/peer_info_database.rs
+++ b/massa-network/src/peer_info_database.rs
@@ -949,14 +949,14 @@ mod tests {
         }
 
         db.try_new_in_connection(&IpAddr::V4(std::net::Ipv4Addr::new(192, 168, 0, 11)))
-            .expect("not global ip not detected.");
+            .expect_err("not global ip not detected.");
         db.try_new_in_connection(&IpAddr::V4(std::net::Ipv4Addr::new(127, 0, 0, 1)))
-            .expect("local ip not detected.");
+            .expect_err("local ip not detected.");
 
         db.try_new_in_connection(&IpAddr::V4(std::net::Ipv4Addr::new(169, 202, 0, 11)))
             .expect("in connection not accepted.");
         db.try_new_in_connection(&IpAddr::V4(std::net::Ipv4Addr::new(169, 202, 0, 12)))
-            .expect("banned peer not detected.");
+            .expect_err("banned peer not detected.");
 
         // test with a not connected peer
         let res = db.in_connection_closed(&IpAddr::V4(std::net::Ipv4Addr::new(169, 202, 0, 12)));

--- a/massa-network/src/settings.rs
+++ b/massa-network/src/settings.rs
@@ -83,6 +83,8 @@ pub struct NetworkSettings {
     pub ban_timeout: MassaTime,
     /// Timeout Duration when we send a PeerList in handshake
     pub peer_list_send_timeout: MassaTime,
+    /// Max number of in connection overflowed managed by the handshake that send a list of peers
+    pub max_in_connection_overflow: usize,
 }
 
 #[cfg(test)]
@@ -115,7 +117,8 @@ mod tests {
                 max_send_wait: MassaTime::from(100),
                 ban_timeout: MassaTime::from(100_000_000),
                 initial_peers_file: std::path::PathBuf::new(),
-                peer_list_send_timeout: MassaTime::from(50),
+                peer_list_send_timeout: MassaTime::from(500),
+                max_in_connection_overflow: 2,
             }
         }
     }

--- a/massa-network/src/settings.rs
+++ b/massa-network/src/settings.rs
@@ -81,6 +81,8 @@ pub struct NetworkSettings {
     pub max_send_wait: MassaTime,
     /// Time after which we forget a node
     pub ban_timeout: MassaTime,
+    /// Timeout Duration when we send a PeerList in handshake
+    pub peer_list_send_timeout: MassaTime,
 }
 
 #[cfg(test)]
@@ -113,6 +115,7 @@ mod tests {
                 max_send_wait: MassaTime::from(100),
                 ban_timeout: MassaTime::from(100_000_000),
                 initial_peers_file: std::path::PathBuf::new(),
+                peer_list_send_timeout: MassaTime::from(50),
             }
         }
     }

--- a/massa-network/src/tests/mock_establisher.rs
+++ b/massa-network/src/tests/mock_establisher.rs
@@ -13,6 +13,9 @@ const CHANNEL_SIZE: usize = 256;
 pub type ReadHalf = tokio::io::ReadHalf<DuplexStream>;
 pub type WriteHalf = tokio::io::WriteHalf<DuplexStream>;
 
+pub type Receiver = mpsc::Receiver<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>;
+pub type Sender = mpsc::Sender<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>;
+
 pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
     let (connection_listener_tx, connection_listener_rx) =
         mpsc::channel::<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>(CHANNEL_SIZE);
@@ -34,7 +37,7 @@ pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
 
 #[derive(Debug)]
 pub struct MockListener {
-    connection_listener_rx: mpsc::Receiver<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>, // (controller, mock)
+    connection_listener_rx: Receiver, // (controller, mock)
 }
 
 impl MockListener {
@@ -109,8 +112,7 @@ impl MockConnector {
 
 #[derive(Debug)]
 pub struct MockEstablisher {
-    connection_listener_rx:
-        Option<mpsc::Receiver<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>>,
+    connection_listener_rx: Option<Receiver>,
     connection_connector_tx: mpsc::Sender<(ReadHalf, WriteHalf, SocketAddr, oneshot::Sender<bool>)>,
 }
 
@@ -138,8 +140,7 @@ impl MockEstablisher {
 }
 
 pub struct MockEstablisherInterface {
-    connection_listener_tx:
-        Option<mpsc::Sender<(SocketAddr, oneshot::Sender<(ReadHalf, WriteHalf)>)>>,
+    connection_listener_tx: Option<Sender>,
     connection_connector_rx:
         mpsc::Receiver<(ReadHalf, WriteHalf, SocketAddr, oneshot::Sender<bool>)>,
 }

--- a/massa-network/src/tests/scenarios.rs
+++ b/massa-network/src/tests/scenarios.rs
@@ -136,7 +136,7 @@ async fn test_multiple_connections_to_controller() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
-                ConnectionId(1),
+                ConnectionId(3),
             )
             .await;
             assert_ne!(

--- a/massa-network/src/tests/scenarios.rs
+++ b/massa-network/src/tests/scenarios.rs
@@ -2,12 +2,15 @@
 
 // To start alone RUST_BACKTRACE=1 cargo test -- --nocapture --test-threads=1
 use super::tools;
-use crate::binders::{ReadBinder, WriteBinder};
 use crate::messages::Message;
 use crate::node_worker::{NodeCommand, NodeEvent, NodeWorker};
 use crate::ConnectionClosureReason;
 use crate::NetworkEvent;
 use crate::PeerInfo;
+use crate::{
+    binders::{ReadBinder, WriteBinder},
+    ConnectionId,
+};
 use massa_hash::{self, hash::Hash};
 use massa_models::node::NodeId;
 use massa_models::{BlockId, Endorsement, EndorsementContent, SerializeCompact, Slot};
@@ -120,6 +123,7 @@ async fn test_multiple_connections_to_controller() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             let conn1_drain = tools::incoming_message_drain_start(conn1_r).await; // drained l110
@@ -132,6 +136,7 @@ async fn test_multiple_connections_to_controller() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(1),
             )
             .await;
             assert_ne!(
@@ -148,6 +153,7 @@ async fn test_multiple_connections_to_controller() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(2),
             )
             .await;
 
@@ -159,6 +165,7 @@ async fn test_multiple_connections_to_controller() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(3),
             )
             .await;
             (
@@ -226,6 +233,7 @@ async fn test_peer_ban() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             let conn1_drain = tools::incoming_message_drain_start(conn1_r).await;
@@ -240,6 +248,7 @@ async fn test_peer_ban() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(1),
             )
             .await;
             let conn2_drain = tools::incoming_message_drain_start(conn2_r).await;
@@ -275,6 +284,7 @@ async fn test_peer_ban() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(2),
             )
             .await;
 
@@ -295,6 +305,7 @@ async fn test_peer_ban() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(3),
             )
             .await;
             let conn1_drain_bis = tools::incoming_message_drain_start(conn1_r).await;
@@ -365,6 +376,7 @@ async fn test_peer_ban_by_ip() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             let conn1_drain = tools::incoming_message_drain_start(conn1_r).await;
@@ -379,6 +391,7 @@ async fn test_peer_ban_by_ip() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(1),
             )
             .await;
             let conn2_drain = tools::incoming_message_drain_start(conn2_r).await;
@@ -414,6 +427,7 @@ async fn test_peer_ban_by_ip() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(2),
             )
             .await;
 
@@ -434,6 +448,7 @@ async fn test_peer_ban_by_ip() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(3),
             )
             .await;
             let conn1_drain_bis = tools::incoming_message_drain_start(conn1_r).await;
@@ -503,6 +518,7 @@ async fn test_advertised_and_wakeup_interval() {
                     1_000u64,
                     1_000u64,
                     1_000u64,
+                    ConnectionId(0),
                 )
                 .await;
                 tools::advertise_peers_in_connection(&mut conn2_w, vec![mock_addr.ip()]).await;
@@ -554,6 +570,7 @@ async fn test_advertised_and_wakeup_interval() {
                         .unwrap(),
                     1_000u64,
                     1_000u64,
+                    ConnectionId(1),
                 )
                 .await;
                 if start_instant.elapsed() < network_conf.wakeup_interval.to_duration() {
@@ -638,6 +655,7 @@ async fn test_block_not_found() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             // let conn1_drain= tools::incoming_message_drain_start(conn1_r).await;
@@ -817,6 +835,7 @@ async fn test_retry_connection_closed() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
 
@@ -920,6 +939,7 @@ async fn test_operation_messages() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             // let conn1_drain= tools::incoming_message_drain_start(conn1_r).await;
@@ -1040,6 +1060,7 @@ async fn test_endorsements_messages() {
                 1_000u64,
                 1_000u64,
                 1_000u64,
+                ConnectionId(0),
             )
             .await;
             // let conn1_drain= tools::incoming_message_drain_start(conn1_r).await;

--- a/massa-network/src/tests/tools.rs
+++ b/massa-network/src/tests/tools.rs
@@ -164,7 +164,7 @@ pub async fn full_connection_to_controller(
     )
     .await
     .expect("did not receive NewConnection event with expected node id");
-    res
+    (mock_node_id, res.1, res.2)
 }
 
 /// try to establish a connection to the controller and expect rejection
@@ -191,7 +191,7 @@ pub async fn rejected_connection_to_controller(
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
 
-    HandshakeWorker::spawn(
+    let result = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
         mock_node_id,
@@ -202,8 +202,12 @@ pub async fn rejected_connection_to_controller(
     )
     .await
     .expect("handshake creation failed")
-    .1
-    .expect("handshake failed");
+    .1;
+
+    assert!(
+        result.is_err(),
+        "Handshake Operation was supposed to failed"
+    );
 
     // wait for NetworkEvent::NewConnection or NetworkEvent::ConnectionClosed events to NOT happen
     if wait_network_event(
@@ -300,7 +304,7 @@ pub async fn full_connection_from_controller(
     .await
     .expect("did not receive expected node connection event");
 
-    res
+    (mock_node_id, res.1, res.2)
 }
 
 pub async fn wait_network_event<F, T>(

--- a/massa-network/src/tests/tools.rs
+++ b/massa-network/src/tests/tools.rs
@@ -100,6 +100,7 @@ pub fn create_network_config(
         max_send_wait: MassaTime::from(100),
         ban_timeout: MassaTime::from(100_000_000),
         initial_peers_file: peers_file_path.to_path_buf(),
+        ..Default::default()
     }
 }
 

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -134,6 +134,9 @@
     max_send_wait = 500
     # we forget we banned a node after ban_timeout milliseconds
     ban_timeout = 3600000
+    # Timeout duration when in handshake we respond with a PeerList
+    # (on max in connection reached we send a list of peers)
+    peer_list_send_timeout = 100
 
 [bootstrap]
     # list of bootstrap (ip, node id)

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -134,9 +134,13 @@
     max_send_wait = 500
     # we forget we banned a node after ban_timeout milliseconds
     ban_timeout = 3600000
+
     # Timeout duration when in handshake we respond with a PeerList
     # (on max in connection reached we send a list of peers)
     peer_list_send_timeout = 100
+    # Max number of in connection overflowed managed by the handshake
+    # that send a list of peers
+    max_in_connection_overflow = 100
 
 [bootstrap]
     # list of bootstrap (ip, node id)


### PR DESCRIPTION
Manage a special operation if the handshake return an error with
a peer list.

Link to the issue : #2222 

In this PR I did some modification in handshake errors and network errors in order to get a list of new candidates nodes when a candidate has too many connections. The main logic is done in the handshake.

I also planned to remove some warnings and simplify the `HandshakeWorker` object. I think it would be great to move the implementation of all _connecting's_ functions into a dedicated file with a cool flowchart. Furthermore, I think I can now do that.