### PR TITLE
Prefix hash string representation.

### DIFF
--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -35,3 +35,7 @@ rev_lines = "0.2.1"
 assert_cmd = "2.0"
 serial_test = "0.5"
 toml_edit = "0.8"
+
+
+[features]
+hash-prefix = ["massa_models/hash-prefix", "massa_signature/hash-prefix"]

--- a/massa-hash/src/error.rs
+++ b/massa-hash/src/error.rs
@@ -11,4 +11,7 @@ pub enum MassaHashError {
 
     /// error forwarded by engine: {0}
     EngineError(#[from] secp256k1::Error),
+
+    /// Wrong prefix for hash: expected {0}, got {1}
+    WrongPrefix(String, String),
 }

--- a/massa-models/Cargo.toml
+++ b/massa-models/Cargo.toml
@@ -24,3 +24,6 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
+
+[features]
+hash-prefix = []

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -15,24 +15,32 @@ const ADDRESS_STRING_PREFIX: &str = "ADR";
 
 impl std::fmt::Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", ADDRESS_STRING_PREFIX, self.0.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", ADDRESS_STRING_PREFIX, self.0.to_bs58_check())
+        } else {
+            write!(f, "{}", self.0.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for Address {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Ok(Address(Hash::from_str(s)?))
-        } else if v[0] != ADDRESS_STRING_PREFIX {
-            Err(ModelsError::WrongPrefix(
-                ADDRESS_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Ok(Address(Hash::from_str(s)?))
+            } else if v[0] != ADDRESS_STRING_PREFIX {
+                Err(ModelsError::WrongPrefix(
+                    ADDRESS_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Ok(Address(Hash::from_str(v[1])?))
+            }
         } else {
-            Ok(Address(Hash::from_str(v[1])?))
+            Ok(Address(Hash::from_str(s)?))
         }
     }
 }

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -23,7 +23,6 @@ impl FromStr for Address {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let v: Vec<_> = s.split('-').collect();
-        println!("{:?}", v);
         if v.len() != 2 {
             // assume there is no prefix
             Ok(Address(Hash::from_str(s)?))

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -11,17 +11,30 @@ use std::str::FromStr;
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct Address(pub Hash);
+const ADDRESS_STRING_PREFIX: &str = "ADR";
 
 impl std::fmt::Display for Address {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0.to_bs58_check())
+        write!(f, "{}-{}", ADDRESS_STRING_PREFIX, self.0.to_bs58_check())
     }
 }
 
 impl FromStr for Address {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Address(Hash::from_str(s)?))
+        let v: Vec<_> = s.split('-').collect();
+        println!("{:?}", v);
+        if v.len() != 2 {
+            // assume there is no prefix
+            Ok(Address(Hash::from_str(s)?))
+        } else if v[0] != ADDRESS_STRING_PREFIX {
+            Err(ModelsError::WrongPrefix(
+                ADDRESS_STRING_PREFIX.to_string(),
+                v[0].to_string(),
+            ))
+        } else {
+            Ok(Address(Hash::from_str(v[1])?))
+        }
     }
 }
 

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -27,30 +27,42 @@ impl PreHashed for BlockId {}
 
 impl std::fmt::Display for BlockId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", BLOCK_ID_STRING_PREFIX, self.0.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", BLOCK_ID_STRING_PREFIX, self.0.to_bs58_check())
+        } else {
+            write!(f, "{}", self.0.to_bs58_check())
+        }
     }
 }
 
 impl std::fmt::Debug for BlockId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", BLOCK_ID_STRING_PREFIX, self.0.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", BLOCK_ID_STRING_PREFIX, self.0.to_bs58_check())
+        } else {
+            write!(f, "{}", self.0.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for BlockId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Ok(BlockId(Hash::from_str(s)?))
-        } else if v[0] != BLOCK_ID_STRING_PREFIX {
-            Err(ModelsError::WrongPrefix(
-                BLOCK_ID_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Ok(BlockId(Hash::from_str(s)?))
+            } else if v[0] != BLOCK_ID_STRING_PREFIX {
+                Err(ModelsError::WrongPrefix(
+                    BLOCK_ID_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Ok(BlockId(Hash::from_str(v[1])?))
+            }
         } else {
-            Ok(BlockId(Hash::from_str(v[1])?))
+            Ok(BlockId(Hash::from_str(s)?))
         }
     }
 }

--- a/massa-models/src/error.rs
+++ b/massa-models/src/error.rs
@@ -32,4 +32,6 @@ pub enum ModelsError {
     TimeOverflowError,
     /// Time error {0}
     TimeError(#[from] massa_time::TimeError),
+    /// Wrong prefix for hash: expected {0}, got {1}
+    WrongPrefix(String, String),
 }

--- a/massa-models/src/node.rs
+++ b/massa-models/src/node.rs
@@ -3,28 +3,39 @@
 use massa_signature::PublicKey;
 use serde::{Deserialize, Serialize};
 
+use crate::ModelsError;
+
+const NODE_ID_STRING_PREFIX: &str = "NOD";
 /// NodeId wraps a public key to uniquely identify a node.
 #[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct NodeId(pub PublicKey);
 
 impl std::fmt::Display for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0)
     }
 }
 
 impl std::fmt::Debug for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0.to_bs58_check())
+        write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0.to_bs58_check())
     }
 }
 
 impl std::str::FromStr for NodeId {
-    type Err = ();
+    type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match PublicKey::from_bs58_check(s) {
-            Ok(x) => Ok(NodeId(x)),
-            Err(_) => Err(()),
+        let v: Vec<_> = s.split('-').collect();
+        if v.len() != 2 {
+            // assume there is no prefix
+            Ok(NodeId(PublicKey::from_bs58_check(s)?))
+        } else if v[0] != NODE_ID_STRING_PREFIX {
+            Err(ModelsError::WrongPrefix(
+                NODE_ID_STRING_PREFIX.to_string(),
+                v[0].to_string(),
+            ))
+        } else {
+            Ok(NodeId(PublicKey::from_bs58_check(v[1])?))
         }
     }
 }

--- a/massa-models/src/node.rs
+++ b/massa-models/src/node.rs
@@ -12,30 +12,42 @@ pub struct NodeId(pub PublicKey);
 
 impl std::fmt::Display for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0)
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
     }
 }
 
 impl std::fmt::Debug for NodeId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", NODE_ID_STRING_PREFIX, self.0)
+        } else {
+            write!(f, "{}", self.0)
+        }
     }
 }
 
 impl std::str::FromStr for NodeId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Ok(NodeId(PublicKey::from_bs58_check(s)?))
-        } else if v[0] != NODE_ID_STRING_PREFIX {
-            Err(ModelsError::WrongPrefix(
-                NODE_ID_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Ok(NodeId(PublicKey::from_bs58_check(s)?))
+            } else if v[0] != NODE_ID_STRING_PREFIX {
+                Err(ModelsError::WrongPrefix(
+                    NODE_ID_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Ok(NodeId(PublicKey::from_bs58_check(v[1])?))
+            }
         } else {
-            Ok(NodeId(PublicKey::from_bs58_check(v[1])?))
+            Ok(NodeId(PublicKey::from_bs58_check(s)?))
         }
     }
 }

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -24,40 +24,52 @@ pub struct OperationId(Hash);
 
 impl std::fmt::Display for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}-{}",
-            OPERATION_ID_STRING_PREFIX,
-            self.0.to_bs58_check()
-        )
+        if cfg!(feature = "hash-prefix") {
+            write!(
+                f,
+                "{}-{}",
+                OPERATION_ID_STRING_PREFIX,
+                self.0.to_bs58_check()
+            )
+        } else {
+            write!(f, "{}", self.0.to_bs58_check())
+        }
     }
 }
 
 impl std::fmt::Debug for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "{}-{}",
-            OPERATION_ID_STRING_PREFIX,
-            self.0.to_bs58_check()
-        )
+        if cfg!(feature = "hash-prefix") {
+            write!(
+                f,
+                "{}-{}",
+                OPERATION_ID_STRING_PREFIX,
+                self.0.to_bs58_check()
+            )
+        } else {
+            write!(f, "{}", self.0.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for OperationId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Ok(OperationId(Hash::from_str(s)?))
-        } else if v[0] != OPERATION_ID_STRING_PREFIX {
-            Err(ModelsError::WrongPrefix(
-                OPERATION_ID_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Ok(OperationId(Hash::from_str(s)?))
+            } else if v[0] != OPERATION_ID_STRING_PREFIX {
+                Err(ModelsError::WrongPrefix(
+                    OPERATION_ID_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Ok(OperationId(Hash::from_str(v[1])?))
+            }
         } else {
-            Ok(OperationId(Hash::from_str(v[1])?))
+            Ok(OperationId(Hash::from_str(s)?))
         }
     }
 }

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -18,25 +18,47 @@ use std::convert::TryInto;
 use std::fmt::Formatter;
 use std::{ops::RangeInclusive, str::FromStr};
 
+const OPERATION_ID_STRING_PREFIX: &str = "OPE";
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct OperationId(Hash);
 
 impl std::fmt::Display for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0.to_bs58_check())
+        write!(
+            f,
+            "{}-{}",
+            OPERATION_ID_STRING_PREFIX,
+            self.0.to_bs58_check()
+        )
     }
 }
 
 impl std::fmt::Debug for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.0.to_bs58_check())
+        write!(
+            f,
+            "{}-{}",
+            OPERATION_ID_STRING_PREFIX,
+            self.0.to_bs58_check()
+        )
     }
 }
 
 impl FromStr for OperationId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(OperationId(Hash::from_str(s)?))
+        let v: Vec<_> = s.split('-').collect();
+        if v.len() != 2 {
+            // assume there is no prefix
+            Ok(OperationId(Hash::from_str(s)?))
+        } else if v[0] != OPERATION_ID_STRING_PREFIX {
+            Err(ModelsError::WrongPrefix(
+                OPERATION_ID_STRING_PREFIX.to_string(),
+                v[0].to_string(),
+            ))
+        } else {
+            Ok(OperationId(Hash::from_str(v[1])?))
+        }
     }
 }
 

--- a/massa-models/src/output_event.rs
+++ b/massa-models/src/output_event.rs
@@ -25,17 +25,21 @@ pub struct SCOutputEventId(pub Hash);
 impl FromStr for SCOutputEventId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Ok(SCOutputEventId(Hash::from_str(s)?))
-        } else if v[0] != SC_OUTPUT_EVENT_ID_STRING_PREFIX {
-            Err(ModelsError::WrongPrefix(
-                SC_OUTPUT_EVENT_ID_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Ok(SCOutputEventId(Hash::from_str(s)?))
+            } else if v[0] != SC_OUTPUT_EVENT_ID_STRING_PREFIX {
+                Err(ModelsError::WrongPrefix(
+                    SC_OUTPUT_EVENT_ID_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Ok(SCOutputEventId(Hash::from_str(v[1])?))
+            }
         } else {
-            Ok(SCOutputEventId(Hash::from_str(v[1])?))
+            Ok(SCOutputEventId(Hash::from_str(s)?))
         }
     }
 }

--- a/massa-models/src/output_event.rs
+++ b/massa-models/src/output_event.rs
@@ -17,13 +17,26 @@ pub struct SCOutputEvent {
     pub data: String,
 }
 
+const SC_OUTPUT_EVENT_ID_STRING_PREFIX: &str = "SCE";
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct SCOutputEventId(pub Hash);
 
 impl FromStr for SCOutputEventId {
     type Err = ModelsError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(SCOutputEventId(Hash::from_str(s)?))
+        let v: Vec<_> = s.split('-').collect();
+        if v.len() != 2 {
+            // assume there is no prefix
+            Ok(SCOutputEventId(Hash::from_str(s)?))
+        } else if v[0] != SC_OUTPUT_EVENT_ID_STRING_PREFIX {
+            Err(ModelsError::WrongPrefix(
+                SC_OUTPUT_EVENT_ID_STRING_PREFIX.to_string(),
+                v[0].to_string(),
+            ))
+        } else {
+            Ok(SCOutputEventId(Hash::from_str(v[1])?))
+        }
     }
 }
 

--- a/massa-signature/Cargo.toml
+++ b/massa-signature/Cargo.toml
@@ -21,3 +21,6 @@ massa_hash = { path = "../massa-hash" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
+
+[features]
+hash-prefix = []

--- a/massa-signature/src/signature_impl.rs
+++ b/massa-signature/src/signature_impl.rs
@@ -22,24 +22,32 @@ pub struct PrivateKey(secp256k1::SecretKey);
 
 impl std::fmt::Display for PrivateKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}-{}", PRIVATE_KEY_STRING_PREFIX, self.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", PRIVATE_KEY_STRING_PREFIX, self.to_bs58_check())
+        } else {
+            write!(f, "{}", self.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for PrivateKey {
     type Err = MassaHashError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            PrivateKey::from_bs58_check(s)
-        } else if v[0] != PRIVATE_KEY_STRING_PREFIX {
-            Err(MassaHashError::WrongPrefix(
-                PRIVATE_KEY_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                PrivateKey::from_bs58_check(s)
+            } else if v[0] != PRIVATE_KEY_STRING_PREFIX {
+                Err(MassaHashError::WrongPrefix(
+                    PRIVATE_KEY_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                PrivateKey::from_bs58_check(v[1])
+            }
         } else {
-            PrivateKey::from_bs58_check(v[1])
+            PrivateKey::from_bs58_check(s)
         }
     }
 }
@@ -241,24 +249,32 @@ pub struct PublicKey(secp256k1::PublicKey);
 
 impl std::fmt::Display for PublicKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", PUBLIC_KEY_STRING_PREFIX, self.to_bs58_check())
+        } else {
+            write!(f, "{}", self.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for PublicKey {
     type Err = MassaHashError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            PublicKey::from_bs58_check(s)
-        } else if v[0] != PUBLIC_KEY_STRING_PREFIX {
-            Err(MassaHashError::WrongPrefix(
-                PUBLIC_KEY_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                PublicKey::from_bs58_check(s)
+            } else if v[0] != PUBLIC_KEY_STRING_PREFIX {
+                Err(MassaHashError::WrongPrefix(
+                    PUBLIC_KEY_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                PublicKey::from_bs58_check(v[1])
+            }
         } else {
-            PublicKey::from_bs58_check(v[1])
+            PublicKey::from_bs58_check(s)
         }
     }
 }
@@ -467,24 +483,32 @@ pub struct Signature(secp256k1::Signature);
 
 impl std::fmt::Display for Signature {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.to_bs58_check())
+        if cfg!(feature = "hash-prefix") {
+            write!(f, "{}-{}", SIGNATURE_STRING_PREFIX, self.to_bs58_check())
+        } else {
+            write!(f, "{}", self.to_bs58_check())
+        }
     }
 }
 
 impl FromStr for Signature {
     type Err = MassaHashError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: Vec<_> = s.split('-').collect();
-        if v.len() != 2 {
-            // assume there is no prefix
-            Signature::from_bs58_check(s)
-        } else if v[0] != SIGNATURE_STRING_PREFIX {
-            Err(MassaHashError::WrongPrefix(
-                SIGNATURE_STRING_PREFIX.to_string(),
-                v[0].to_string(),
-            ))
+        if cfg!(feature = "hash-prefix") {
+            let v: Vec<_> = s.split('-').collect();
+            if v.len() != 2 {
+                // assume there is no prefix
+                Signature::from_bs58_check(s)
+            } else if v[0] != SIGNATURE_STRING_PREFIX {
+                Err(MassaHashError::WrongPrefix(
+                    SIGNATURE_STRING_PREFIX.to_string(),
+                    v[0].to_string(),
+                ))
+            } else {
+                Signature::from_bs58_check(v[1])
+            }
         } else {
-            Signature::from_bs58_check(v[1])
+            Signature::from_bs58_check(s)
         }
     }
 }


### PR DESCRIPTION
Fix #1105

If there is no prefix, it will work just as it used to.

* [x] ADR - Address
* [x] PRI - Private key
* [x] PUB - Public Key
* [x] SIG - Signature
* [x] END - Endorsement Id
* [x] OPE - Operation Id
* [x] BLO - Block id
* [x] SCE - SC output event id
* [x] NOD - Node id


## Example outputs
`cargo run --features hash-prefix -- wallet_info`
```shell
Private key: PRI-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Public key: PUB-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Address: ADR-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

 `cargo run -- wallet_info`
``` shell
Private key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Public key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
Address: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
```

`cargo run --features hash-prefix --  --json wallet_info`
```
{
  "keys": {
    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": [
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    ],
    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": [
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    ],
    "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx": [
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
      "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
    ]
  },
  "wallet_path": "wallet.dat"
}
```

Note that event with the feature activated, the json output does not change.

With this feature activated, the client can take both prefixed and raw hashes.