### PR TITLE
Set-up `tracing-subscriber` for instrumentation with `tokio-console`

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,9 +48,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arrayvec"
@@ -133,21 +133,24 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.63"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
 dependencies = [
  "addr2line",
  "cc",
@@ -184,7 +187,7 @@ checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
- "serde 1.0.134",
+ "serde 1.0.136",
  "tap",
  "wyz",
 ]
@@ -331,7 +334,7 @@ dependencies = [
  "lazy_static",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -368,16 +371,16 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829835c211a0247cd11e65e13cec8696b879374879c35ce162ce8098b23c90d4"
+checksum = "d7a4aa62cefeef6d5a2bfcf638818b7950329a6c3ad919f89f04d60174f217f4"
 dependencies = [
  "console-api",
  "crossbeam-channel",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hdrhistogram",
  "humantime",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "thread_local",
  "tokio",
@@ -396,9 +399,9 @@ checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6888e10551bb93e424d8df1d07f1a8b4fceb0001a3a4b048bfc47554946f47b3"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -494,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -524,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -537,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -762,11 +765,11 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a5d80251b806a14cd3e4e1a582e912d5cbf6904ab19fdefbd7a56adca088e1"
+checksum = "56047058e1ab118075ca22f9ecd737bcc961aa3566a3019cb71388afa280bd8a"
 dependencies = [
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -777,9 +780,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -863,9 +866,9 @@ checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -878,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -888,15 +891,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -906,15 +909,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -923,21 +926,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
 
 [[package]]
 name = "futures-util"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -1025,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
 dependencies = [
  "bytes",
  "fnv",
@@ -1053,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "hdrhistogram"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
 dependencies = [
  "base64",
  "byteorder",
@@ -1090,7 +1093,7 @@ checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.1",
+ "itoa",
 ]
 
 [[package]]
@@ -1106,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
 
 [[package]]
 name = "httpdate"
@@ -1124,9 +1127,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.16"
+version = "0.14.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1137,7 +1140,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 0.4.8",
+ "itoa",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1205,9 +1208,9 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1242,12 +1245,6 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
@@ -1268,13 +1265,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b99d4207e2a04fb4581746903c2bb7eb376f88de9c699d0f3e10feeac0cd3a"
 dependencies = [
  "derive_more",
- "futures 0.3.19",
+ "futures 0.3.21",
  "hyper",
  "hyper-tls",
  "jsonrpc-core",
  "jsonrpc-pubsub",
  "log",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "tokio",
  "url 1.7.2",
@@ -1286,11 +1283,11 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "futures-executor",
  "futures-util",
  "log",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_derive",
  "serde_json",
 ]
@@ -1301,7 +1298,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b51da17abecbdab3e3d4f26b01c5ec075e88d3abe3ab3b05dc9aa69392764ec0"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-client-transports",
 ]
 
@@ -1323,7 +1320,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1dea6e07251d9ce6a552abfb5d7ad6bc290a4596c8dcc3d795fae2bbdc1f3ff"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "hyper",
  "jsonrpc-core",
  "jsonrpc-server-utils",
@@ -1339,13 +1336,13 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240f87695e6c6f62fb37f05c02c04953cf68d6408b8c1c89de85c7a0125b1011"
 dependencies = [
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "lazy_static",
  "log",
  "parking_lot",
  "rand 0.7.3",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1355,7 +1352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4fdea130485b572c39a460d50888beb00afb3e35de23ccd7fad8ff19f0e0d4"
 dependencies = [
  "bytes",
- "futures 0.3.19",
+ "futures 0.3.21",
  "globset",
  "jsonrpc-core",
  "lazy_static",
@@ -1372,7 +1369,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b310ccceade8121d7d77fee406160e457c2f4e7c7982d589da3499bc7ea4526"
 dependencies = [
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -1402,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "06e509672465a0504304aa87f9f176f2b2b716ed8fb105ebe5c02dc6dce96a94"
 
 [[package]]
 name = "libloading"
@@ -1424,9 +1421,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
 dependencies = [
  "scopeguard",
 ]
@@ -1482,7 +1479,7 @@ dependencies = [
  "dialoguer",
  "directories",
  "erased-serde",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core-client",
  "lazy_static",
  "massa_models",
@@ -1491,7 +1488,7 @@ dependencies = [
  "massa_wallet",
  "paw",
  "rev_lines",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "structopt",
@@ -1508,7 +1505,7 @@ dependencies = [
  "config",
  "console-subscriber",
  "directories",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "massa_api",
  "massa_bootstrap",
@@ -1524,7 +1521,7 @@ dependencies = [
  "massa_protocol_worker",
  "massa_time",
  "pretty_assertions",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tokio",
@@ -1544,7 +1541,7 @@ dependencies = [
  "cornetto",
  "lazy_static",
  "loupe",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "wasmer",
@@ -1558,7 +1555,7 @@ name = "massa_api"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "jsonrpc-core",
  "jsonrpc-derive",
  "jsonrpc-http-server",
@@ -1583,7 +1580,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "massa_consensus_exports",
  "massa_execution",
@@ -1597,8 +1594,8 @@ dependencies = [
  "massa_time",
  "num_enum",
  "pretty_assertions",
- "rand 0.8.4",
- "serde 1.0.134",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "thiserror",
@@ -1612,7 +1609,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "massa_execution",
  "massa_graph",
@@ -1626,9 +1623,9 @@ dependencies = [
  "massa_time",
  "num",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xoshiro",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "sled",
@@ -1644,7 +1641,7 @@ version = "0.1.0"
 dependencies = [
  "bitvec",
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "massa_consensus_exports",
  "massa_execution",
@@ -1659,9 +1656,9 @@ dependencies = [
  "massa_time",
  "num",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xoshiro",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "sled",
@@ -1685,9 +1682,9 @@ dependencies = [
  "massa_time",
  "parking_lot",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xoshiro",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1712,9 +1709,9 @@ dependencies = [
  "massa_time",
  "num",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xoshiro",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "sled",
@@ -1732,9 +1729,9 @@ dependencies = [
  "bs58",
  "displaydoc",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "secp256k1",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "thiserror",
@@ -1766,10 +1763,10 @@ dependencies = [
  "num-traits 0.2.14",
  "num_enum",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "reqwest",
  "rust_decimal",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serial_test",
  "thiserror",
  "tokio",
@@ -1780,7 +1777,7 @@ name = "massa_network"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "itertools",
  "massa_hash",
  "massa_logging",
@@ -1789,8 +1786,8 @@ dependencies = [
  "massa_time",
  "num_enum",
  "pretty_assertions",
- "rand 0.8.4",
- "serde 1.0.134",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1804,7 +1801,7 @@ name = "massa_pool"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "lazy_static",
  "massa_hash",
  "massa_logging",
@@ -1814,7 +1811,7 @@ dependencies = [
  "massa_time",
  "num",
  "pretty_assertions",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "thiserror",
@@ -1834,9 +1831,9 @@ dependencies = [
  "massa_signature",
  "num",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "rand_xoshiro",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1850,7 +1847,7 @@ name = "massa_protocol_exports"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "itertools",
  "lazy_static",
  "massa_hash",
@@ -1861,8 +1858,8 @@ dependencies = [
  "massa_time",
  "num_enum",
  "pretty_assertions",
- "rand 0.8.4",
- "serde 1.0.134",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1876,7 +1873,7 @@ name = "massa_protocol_worker"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
- "futures 0.3.19",
+ "futures 0.3.21",
  "itertools",
  "lazy_static",
  "massa_hash",
@@ -1888,8 +1885,8 @@ dependencies = [
  "massa_time",
  "num_enum",
  "pretty_assertions",
- "rand 0.8.4",
- "serde 1.0.134",
+ "rand 0.8.5",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -1907,9 +1904,9 @@ dependencies = [
  "displaydoc",
  "massa_hash",
  "pretty_assertions",
- "rand 0.8.4",
+ "rand 0.8.5",
  "secp256k1",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serial_test",
  "thiserror",
@@ -1922,7 +1919,7 @@ dependencies = [
  "chrono",
  "displaydoc",
  "pretty_assertions",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serial_test",
  "thiserror",
  "tokio",
@@ -1937,7 +1934,7 @@ dependencies = [
  "massa_models",
  "massa_signature",
  "massa_time",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serde_qs",
  "thiserror",
@@ -1957,9 +1954,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memmap2"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3179b85e1fd8b14447cbebadb75e45a1002f541b925f0bfec366d56a81c56d"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
 dependencies = [
  "libc",
 ]
@@ -1970,7 +1967,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1992,7 +1989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2082,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
@@ -2109,10 +2106,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2122,7 +2119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits 0.2.14",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2131,7 +2128,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits 0.2.14",
 ]
 
@@ -2141,7 +2138,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits 0.2.14",
 ]
@@ -2152,11 +2149,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.14",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -2174,7 +2171,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2267,7 +2264,7 @@ version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -2276,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "output_vt100"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
 dependencies = [
  "winapi",
 ]
@@ -2430,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0cfe1b2403f172ba0f234e500906ee0a3e493fb81092dac23ebefe129301cc"
+checksum = "76d5b548b725018ab5496482b45cb8bef21e9fed1858a6d674e3a8a0f0bb5d50"
 dependencies = [
  "ansi_term",
  "ctor",
@@ -2567,9 +2564,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -2586,7 +2583,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "libc",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
@@ -2614,14 +2611,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
- "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -2630,7 +2626,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.3.1",
 ]
 
@@ -2706,15 +2702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core 0.6.3",
-]
-
-[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,7 +2741,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 0.1.8",
  "rand_core 0.4.2",
 ]
 
@@ -2782,7 +2769,7 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -2917,7 +2904,7 @@ dependencies = [
  "native-tls",
  "percent-encoding 2.1.0",
  "pin-project-lite",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -2937,9 +2924,9 @@ checksum = "18eb52b6664d331053136fcac7e4883bdc6f5fc04a6aab3b0f75eafb80ab88b3"
 
 [[package]]
 name = "rkyv"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a37de5dfc60bae2d94961dacd03c7b80e426b66a99fa1b17799570dbdd8f96"
+checksum = "439655b8d657bcb28264da8e5380d55549e34ffc4149bea9e3521890a122a7bd"
 dependencies = [
  "bytecheck",
  "hashbrown",
@@ -2951,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.29"
+version = "0.7.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719d447dd0e84b23cee6cb5b32d97e21efb112a3e3c636c8da36647b938475a1"
+checksum = "cded413ad606a80291ca84bedba137093807cf4f5b36be8c60f57a7e790d48f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2968,13 +2955,13 @@ checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 
 [[package]]
 name = "rust_decimal"
-version = "1.20.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0593ce4677e3800ddafb3de917e8397b1348e06e688128ade722d88fbe11ebf"
+checksum = "4214023b1223d02a4aad9f0bb9828317634a56530870a2eaf7200a99c0c10f68"
 dependencies = [
  "arrayvec 0.7.2",
  "num-traits 0.2.14",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3053,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3066,9 +3053,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3076,9 +3063,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "serde"
@@ -3088,9 +3075,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -3113,14 +3100,14 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.134"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3129,13 +3116,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
- "itoa 1.0.1",
+ "itoa",
  "ryu",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3145,7 +3132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding 2.1.0",
- "serde 1.0.134",
+ "serde 1.0.136",
  "thiserror",
 ]
 
@@ -3156,9 +3143,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa",
  "ryu",
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3244,9 +3231,9 @@ checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi",
@@ -3338,9 +3325,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
@@ -3437,9 +3424,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -3517,7 +3504,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.134",
+ "serde 1.0.136",
 ]
 
 [[package]]
@@ -3586,7 +3573,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.4",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-stream",
@@ -3610,9 +3597,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -3623,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3715,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"
@@ -3910,7 +3897,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_bytes",
  "smallvec",
  "target-lexicon",
@@ -3985,7 +3972,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.134",
+ "serde 1.0.136",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -4008,7 +3995,7 @@ dependencies = [
  "loupe",
  "object 0.28.3",
  "rkyv",
- "serde 1.0.134",
+ "serde 1.0.136",
  "tempfile",
  "tracing",
  "wasmer-compiler",
@@ -4072,7 +4059,7 @@ dependencies = [
  "indexmap",
  "loupe",
  "rkyv",
- "serde 1.0.134",
+ "serde 1.0.136",
  "thiserror",
 ]
 
@@ -4093,7 +4080,7 @@ dependencies = [
  "more-asserts",
  "region",
  "rkyv",
- "serde 1.0.134",
+ "serde 1.0.136",
  "thiserror",
  "wasmer-types",
  "winapi",
@@ -4137,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",
@@ -4197,6 +4184,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc222aec311c323c717f56060324f32b82da1ce1dd81d9a09aa6a9030bfe08db"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,7 +329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 5.1.2",
  "rust-ini",
  "serde 1.0.134",
  "serde-hjson",
@@ -319,6 +351,41 @@ dependencies = [
  "terminal_size",
  "unicode-width",
  "winapi",
+]
+
+[[package]]
+name = "console-api"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc347c19eb5b940f396ac155822caee6662f850d97306890ac3773ed76c90c5a"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-build",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829835c211a0247cd11e65e13cec8696b879374879c35ce162ce8098b23c90d4"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "futures 0.3.19",
+ "hdrhistogram",
+ "humantime",
+ "serde 1.0.134",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -718,6 +785,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +1052,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6490be71f07a5f62b564bc58e36953f675833df11c7e4a0647bee7a07ca1ec5e"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom 7.1.0",
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,6 +1117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1144,18 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1390,6 +1506,7 @@ name = "massa-node"
 version = "0.1.0"
 dependencies = [
  "config",
+ "console-subscriber",
  "directories",
  "futures 0.3.19",
  "lazy_static",
@@ -1515,7 +1632,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sled",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1549,7 +1665,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sled",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1603,7 +1718,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sled",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1679,7 +1793,6 @@ dependencies = [
  "serde 1.0.134",
  "serde_json",
  "serial_test",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1726,7 +1839,6 @@ dependencies = [
  "serde 1.0.134",
  "serde_json",
  "serial_test",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1753,7 +1865,6 @@ dependencies = [
  "serde 1.0.134",
  "serde_json",
  "serial_test",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1781,7 +1892,6 @@ dependencies = [
  "serde 1.0.134",
  "serde_json",
  "serial_test",
- "stderrlog",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1870,6 +1980,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +2024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2066,17 @@ checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
  "version_check",
 ]
 
@@ -2215,6 +2348,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,6 +2490,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -3049,19 +3265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stderrlog"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a53e2eff3e94a019afa6265e8ee04cb05b9d33fe9f5078b14e4e391d155a38"
-dependencies = [
- "atty",
- "chrono",
- "log",
- "termcolor",
- "thread_local",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3154,15 +3357,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,11 +3403,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -3257,7 +3451,18 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
+ "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3328,6 +3533,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
+dependencies = [
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.4",
+ "slab",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343bc9466d3fe6b0f960ef45960509f84480bf4fd96f92901afe7ff3df9d3a62"
+
+[[package]]
 name = "tower-service"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3359,11 +3634,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -3379,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77be66445c4eeebb934a7340f227bfe7b338173d3f8c00a60a5a58005c9faecf"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term",
  "sharded-slab",
@@ -3467,6 +3753,12 @@ dependencies = [
  "matches",
  "percent-encoding 2.1.0",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -3869,15 +4161,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/massa-api/Cargo.toml
+++ b/massa-api/Cargo.toml
@@ -12,8 +12,8 @@ jsonrpc-core = "18.0.0"
 jsonrpc-derive = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_consensus_exports = { path = "../massa-consensus-exports" }
 massa_execution = { path = "../massa-execution" }

--- a/massa-api/Cargo.toml
+++ b/massa-api/Cargo.toml
@@ -8,15 +8,16 @@ edition = "2021"
 [dependencies]
 displaydoc = "0.2"
 futures = "0.3"
-jsonrpc-core = "18.0.0"
-jsonrpc-derive = "18.0.0"
-jsonrpc-http-server = "18.0.0"
+jsonrpc-core = "18.0"
+jsonrpc-derive = "18.0"
+jsonrpc-http-server = "18.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_consensus_exports = { path = "../massa-consensus-exports" }
 massa_execution = { path = "../massa-execution" }
+massa_graph = { path = "../massa-graph" }
 massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }
 massa_network = { path = "../massa-network" }
@@ -24,4 +25,6 @@ massa_pool = { path = "../massa-pool" }
 massa_protocol_exports = { path = "../massa-protocol-exports" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
-massa_graph = { path = "../massa-graph" }
+
+[features]
+instrument = ["tokio/tracing", "massa_consensus_exports/instrument", "massa_execution/instrument", "massa_graph/instrument", "massa_models/instrument", "massa_network/instrument", "massa_pool/instrument", "massa_protocol_exports/instrument", "massa_time/instrument"]

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -15,21 +15,24 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_consensus_exports = { path = "../massa-consensus-exports" }
+massa_execution = { path = "../massa-execution" }
+massa_graph = { path = "../massa-graph" }
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
 massa_models = { path = "../massa-models" }
 massa_network = { path = "../massa-network" }
+massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
-massa_execution = { path = "../massa-execution" }
-massa_graph = { path = "../massa-graph" }
-massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 
 [dev-dependencies]
 bitvec = { version = "0.22", features = ["serde"] }
 pretty_assertions = "1.0"
 serial_test = "0.5"
+
+[features]
+instrument = ["tokio/tracing", "massa_consensus_exports/instrument", "massa_execution/instrument", "massa_graph/instrument", "massa_models/instrument", "massa_network/instrument", "massa_proof_of_stake_exports/instrument", "massa_time/instrument"]

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -15,8 +15,8 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_consensus_exports = { path = "../massa-consensus-exports" }
 massa_hash = { path = "../massa-hash" }

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -15,27 +15,27 @@ dialoguer = { version = "0.9", git = "https://github.com/yvan-sraka/dialoguer.gi
 directories = "4.0"
 erased-serde = "0.3"
 futures = "0.3"
-jsonrpc-core-client = { version = "18.0.0", features = ["http", "tls"] }
-lazy_static = "1.4.0"
+jsonrpc-core-client = { version = "18.0", features = ["http", "tls"] }
+lazy_static = "1.4"
 paw = "1.0"
+rev_lines = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 structopt = { version = "0.3", features = ["paw"] }
 strum = "0.22"
 strum_macros = "0.22"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 # custom modules
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
 massa_wallet = { path = "../massa-wallet" }
-rev_lines = "0.2.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"
 serial_test = "0.5"
 toml_edit = "0.8"
 
-
 [features]
 hash-prefix = ["massa_models/hash-prefix", "massa_signature/hash-prefix"]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_time/instrument"]

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 structopt = { version = "0.3", features = ["paw"] }
 strum = "0.22"
 strum_macros = "0.22"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
 # custom modules
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }

--- a/massa-consensus-exports/Cargo.toml
+++ b/massa-consensus-exports/Cargo.toml
@@ -18,11 +18,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = { version = "0.1", features = [
-    "max_level_debug",
-    "release_max_level_debug",
-] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 tempfile = "3.2"
 # custom modules
 massa_execution = { path = "../massa-execution" }
@@ -39,8 +36,8 @@ massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
-stderrlog = "0.5"
 massa_models = { path = "../massa-models", features = ["testing"] }
 
 [features]
+sandbox = []
 testing = []

--- a/massa-consensus-exports/Cargo.toml
+++ b/massa-consensus-exports/Cargo.toml
@@ -18,20 +18,20 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 tempfile = "3.2"
 # custom modules
 massa_execution = { path = "../massa-execution" }
+massa_graph = { path = "../massa-graph" }
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
 massa_models = { path = "../massa-models" }
 massa_pool = { path = "../massa-pool" }
+massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 massa_protocol_exports = { path = "../massa-protocol-exports" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
-massa_graph = { path = "../massa-graph" }
-massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
@@ -39,5 +39,6 @@ serial_test = "0.5"
 massa_models = { path = "../massa-models", features = ["testing"] }
 
 [features]
+instrument = ["tokio/tracing", "massa_execution/instrument", "massa_graph/instrument", "massa_models/instrument", "massa_pool/instrument", "massa_proof_of_stake_exports/instrument", "massa_protocol_exports/instrument", "massa_time/instrument"]
 sandbox = []
 testing = []

--- a/massa-consensus-worker/Cargo.toml
+++ b/massa-consensus-worker/Cargo.toml
@@ -18,20 +18,20 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
+massa_consensus_exports = { path = "../massa-consensus-exports" }
 massa_execution = { path = "../massa-execution" }
+massa_graph = { path = "../massa-graph" }
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
 massa_models = { path = "../massa-models" }
 massa_pool = { path = "../massa-pool" }
+massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
 massa_protocol_exports = { path = "../massa-protocol-exports" }
-massa_consensus_exports = { path = "../massa-consensus-exports" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
-massa_proof_of_stake_exports = { path = "../massa-proof-of-stake-exports" }
-massa_graph = { path = "../massa-graph" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
@@ -41,4 +41,5 @@ massa_models = { path = "../massa-models", features = ["testing"] }
 massa_consensus_exports = { path = "../massa-consensus-exports", features = ["testing"] }
 
 [features]
-sandbox = []
+instrument = ["tokio/tracing", "massa_consensus_exports/instrument", "massa_execution/instrument", "massa_graph/instrument", "massa_models/instrument", "massa_pool/instrument", "massa_proof_of_stake_exports/instrument", "massa_protocol_exports/instrument", "massa_time/instrument"]
+sandbox = ["massa_consensus_exports/sandbox"]

--- a/massa-consensus-worker/Cargo.toml
+++ b/massa-consensus-worker/Cargo.toml
@@ -18,8 +18,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_execution = { path = "../massa-execution" }
 massa_hash = { path = "../massa-hash" }
@@ -36,10 +36,9 @@ massa_graph = { path = "../massa-graph" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
-stderrlog = "0.5"
 tempfile = "3.2"
 massa_models = { path = "../massa-models", features = ["testing"] }
 massa_consensus_exports = { path = "../massa-consensus-exports", features = ["testing"] }
 
 [features]
-test = []
+sandbox = []

--- a/massa-execution/Cargo.toml
+++ b/massa-execution/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1"
+anyhow = "1.0"
 displaydoc = "0.2"
-lazy_static = "1.4.0"
-parking_lot = { version = "0.11.2" }
+lazy_static = "1.4"
+parking_lot = { version = "0.11" }
 rand = "0.8"
 rand_xoshiro = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
@@ -29,3 +29,6 @@ massa_signature = { path = "../massa-signature" }
 pretty_assertions = "1.0"
 serial_test = "0.5"
 tempfile = "3.2"
+
+[features]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_time/instrument"]

--- a/massa-execution/Cargo.toml
+++ b/massa-execution/Cargo.toml
@@ -16,17 +16,14 @@ rand_xoshiro = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = { version = "0.1", features = [
-    "max_level_debug",
-    "release_max_level_debug",
-] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
-massa_models = { path = "../massa-models" }
 massa_hash = { path = "../massa-hash" }
+massa_models = { path = "../massa-models" }
+massa_time = { path = "../massa-time" }
 massa-sc-runtime = { git = "https://github.com/massalabs/massa-sc-runtime", tag = "v0.4.4" }
 massa_signature = { path = "../massa-signature" }
-massa_time = { path = "../massa-time" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/massa-graph/Cargo.toml
+++ b/massa-graph/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_execution = { path = "../massa-execution" }
@@ -34,4 +34,4 @@ serial_test = "0.5"
 tempfile = "3.2"
 
 [features]
-test = []
+instrument = ["tokio/tracing", "massa_execution/instrument", "massa_models/instrument", "massa_proof_of_stake_exports/instrument", "massa_time/instrument"]

--- a/massa-graph/Cargo.toml
+++ b/massa-graph/Cargo.toml
@@ -17,8 +17,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sled = "0.34"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_execution = { path = "../massa-execution" }
 massa_hash = { path = "../massa-hash" }
@@ -31,5 +31,7 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
-stderrlog = "0.5"
 tempfile = "3.2"
+
+[features]
+test = []

--- a/massa-logging/Cargo.toml
+++ b/massa-logging/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0"
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tracing = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -3,14 +3,6 @@
 #[macro_export]
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::trace!(
-            "massa_trace:{}",
-            serde_json::json!({
-                // "origin": function_path!(),
-                "event": $evt,
-                "parameters": $params
-            })
-            .to_string()
-        );
+        tracing::trace!("massa_trace:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -3,6 +3,6 @@
 #[macro_export]
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::trace!("massa_trace:{}:{}", $evt, serde_json::json!($params));
+        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-models/Cargo.toml
+++ b/massa-models/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 rust_decimal = "1.15"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
 num = { version = "0.4", features = ["serde"] }
 directories = "4.0"
 config = "0.11"

--- a/massa-models/Cargo.toml
+++ b/massa-models/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.11", features = ["blocking", "json"] }
 rust_decimal = "1.15"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 num = { version = "0.4", features = ["serde"] }
 directories = "4.0"
 config = "0.11"
@@ -30,6 +30,7 @@ pretty_assertions = "1.0"
 serial_test = "0.5"
 
 [features]
-testing = []
-hash-prefix = []
+hash-prefix = ["massa_signature/hash-prefix"]
+instrument = ["tokio/tracing", "massa_time/instrument"]
 sandbox = []
+testing = []

--- a/massa-network/Cargo.toml
+++ b/massa-network/Cargo.toml
@@ -15,8 +15,8 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
@@ -27,6 +27,5 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5.1"
-stderrlog = "0.5"
 tempfile = "3.2"
 massa_models = { path = "../massa-models", features = ["testing"] }

--- a/massa-network/Cargo.toml
+++ b/massa-network/Cargo.toml
@@ -15,7 +15,7 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
@@ -29,3 +29,6 @@ pretty_assertions = "1.0"
 serial_test = "0.5.1"
 tempfile = "3.2"
 massa_models = { path = "../massa-models", features = ["testing"] }
+
+[features]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_time/instrument"]

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -9,17 +9,15 @@ build = "../build.rs"
 
 [dependencies]
 config = "0.11"
+console-subscriber = "0.1.1"
 directories = "4.0"
 futures = "0.3"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
 tokio-util = { version = "0.6", features = ["codec"] }
-tracing = { version = "0.1", features = [
-    "max_level_debug",
-    "release_max_level_debug",
-] }
+tracing = "0.1"
 tracing-subscriber = "0.3"
 # custom modules
 
@@ -44,4 +42,7 @@ serial_test = "0.5"
 [features]
 # nightly = ["beta"]
 beta = []
-sandbox = ["massa_models/sandbox"]
+sandbox = ["massa_consensus_exports/sandbox", "massa_models/sandbox"]
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -15,12 +15,11 @@ futures = "0.3"
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tokio-util = { version = "0.6", features = ["codec"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 # custom modules
-
 massa_api = { path = "../massa-api" }
 massa_bootstrap = { path = "../massa-bootstrap" }
 massa_consensus_exports = { path = "../massa-consensus-exports" }
@@ -42,7 +41,9 @@ serial_test = "0.5"
 [features]
 # nightly = ["beta"]
 beta = []
-sandbox = ["massa_consensus_exports/sandbox", "massa_models/sandbox"]
+instrument = ["tokio/tracing", "massa_api/instrument", "massa_bootstrap/instrument", "massa_consensus_exports/instrument", "massa_consensus_worker/instrument", "massa_execution/instrument", "massa_network/instrument", "massa_pool/instrument", "massa_protocol_exports/instrument", "massa_protocol_worker/instrument"]
+sandbox = ["massa_consensus_exports/sandbox", "massa_consensus_worker/sandbox", "massa_models/sandbox"]
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -30,10 +30,6 @@ use std::process;
 use tokio::signal;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
-use tracing_subscriber::{
-    filter::{filter_fn, LevelFilter},
-    prelude::*,
-};
 
 mod settings;
 
@@ -272,19 +268,32 @@ async fn stop(
 
 #[tokio::main]
 async fn main() {
-    // setup logging
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_filter(match SETTINGS.logging.level {
-            4 => LevelFilter::TRACE,
-            3 => LevelFilter::DEBUG,
-            2 => LevelFilter::INFO,
-            1 => LevelFilter::WARN,
-            _ => LevelFilter::ERROR,
-        })
-        .with_filter(filter_fn(|metadata| {
-            metadata.target().starts_with("massa") // ignore non-massa logs
-        }));
-    tracing_subscriber::registry().with(fmt_layer).init();
+    use tracing_subscriber::prelude::*;
+
+    // spawn the console server in the background,
+    // returning a `Layer`:
+    let console_layer = console_subscriber::spawn();
+
+    // let fmt_layer = tracing_subscriber::fmt::layer()
+    //     .with_filter(match SETTINGS.logging.level {
+    //         4 => LevelFilter::TRACE,
+    //         3 => LevelFilter::DEBUG,
+    //         2 => LevelFilter::INFO,
+    //         1 => LevelFilter::WARN,
+    //         _ => LevelFilter::ERROR,
+    //     })
+    //     .with_filter(filter_fn(|metadata| {
+    //         metadata.target().starts_with("massa:") // ignore non-massa logs
+    //     }));
+
+    // build a `Subscriber` by combining layers with a
+    // `tracing_subscriber::Registry`:
+    tracing_subscriber::registry()
+        // add the console layer to the subscriber
+        .with(console_layer)
+        // add other layers...
+        // .with(fmt_layer)
+        .init();
 
     // run
     loop {

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -30,6 +30,8 @@ use std::process;
 use tokio::signal;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
+#[cfg(not(feature = "instrument"))]
+use tracing_subscriber::filter::{filter_fn, LevelFilter};
 
 mod settings;
 
@@ -266,33 +268,32 @@ async fn stop(
         .expect("network shutdown failed");
 }
 
+/// To instrument `massa-node` with `tokio-console` run
+/// ```shell
+/// RUSTFLAGS="--cfg tokio_unstable" cargo run --bin massa-node --features instrument
+/// ```
 #[tokio::main]
 async fn main() {
     use tracing_subscriber::prelude::*;
-
-    // spawn the console server in the background,
-    // returning a `Layer`:
-    let console_layer = console_subscriber::spawn();
-
-    // let fmt_layer = tracing_subscriber::fmt::layer()
-    //     .with_filter(match SETTINGS.logging.level {
-    //         4 => LevelFilter::TRACE,
-    //         3 => LevelFilter::DEBUG,
-    //         2 => LevelFilter::INFO,
-    //         1 => LevelFilter::WARN,
-    //         _ => LevelFilter::ERROR,
-    //     })
-    //     .with_filter(filter_fn(|metadata| {
-    //         metadata.target().starts_with("massa:") // ignore non-massa logs
-    //     }));
-
-    // build a `Subscriber` by combining layers with a
-    // `tracing_subscriber::Registry`:
+    // spawn the console server in the background, returning a `Layer`:
+    #[cfg(feature = "instrument")]
+    let tracing_layer = console_subscriber::spawn();
+    #[cfg(not(feature = "instrument"))]
+    let tracing_layer = tracing_subscriber::fmt::layer()
+        .with_filter(match SETTINGS.logging.level {
+            4 => LevelFilter::TRACE,
+            3 => LevelFilter::DEBUG,
+            2 => LevelFilter::INFO,
+            1 => LevelFilter::WARN,
+            _ => LevelFilter::ERROR,
+        })
+        .with_filter(filter_fn(|metadata| {
+            metadata.target().starts_with("massa:") // ignore non-massa logs
+        }));
+    // build a `Subscriber` by combining layers with a `tracing_subscriber::Registry`:
     tracing_subscriber::registry()
-        // add the console layer to the subscriber
-        .with(console_layer)
-        // add other layers...
-        // .with(fmt_layer)
+        // add the console layer to the subscriber or default layers...
+        .with(tracing_layer)
         .init();
 
     // run

--- a/massa-pool/Cargo.toml
+++ b/massa-pool/Cargo.toml
@@ -12,8 +12,8 @@ num = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }

--- a/massa-pool/Cargo.toml
+++ b/massa-pool/Cargo.toml
@@ -12,7 +12,7 @@ num = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
@@ -25,3 +25,6 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
+
+[features]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_protocol_exports/instrument", "massa_time/instrument"]

--- a/massa-proof-of-stake-exports/Cargo.toml
+++ b/massa-proof-of-stake-exports/Cargo.toml
@@ -16,12 +16,12 @@ rand_xoshiro = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
+massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
-massa_hash = { path = "../massa-hash" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
@@ -29,4 +29,4 @@ serial_test = "0.5"
 tempfile = "3.2"
 
 [features]
-test = []
+instrument = ["tokio/tracing", "massa_models/instrument"]

--- a/massa-proof-of-stake-exports/Cargo.toml
+++ b/massa-proof-of-stake-exports/Cargo.toml
@@ -16,8 +16,8 @@ rand_xoshiro = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
@@ -26,7 +26,6 @@ massa_hash = { path = "../massa-hash" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
-stderrlog = "0.5"
 tempfile = "3.2"
 
 [features]

--- a/massa-protocol-exports/Cargo.toml
+++ b/massa-protocol-exports/Cargo.toml
@@ -16,8 +16,8 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
@@ -29,5 +29,4 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5.1"
-stderrlog = "0.5"
 tempfile = "3.2"

--- a/massa-protocol-exports/Cargo.toml
+++ b/massa-protocol-exports/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 displaydoc = "0.2"
 futures = "0.3"
 itertools = "0.10"
-lazy_static = "1.4.0"
+lazy_static = "1.4"
 num_enum = "0.5"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
@@ -28,5 +28,8 @@ massa_time = { path = "../massa-time" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
-serial_test = "0.5.1"
+serial_test = "0.5"
 tempfile = "3.2"
+
+[features]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_network/instrument", "massa_time/instrument"]

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2021"
 displaydoc = "0.2"
 futures = "0.3"
 itertools = "0.10"
-lazy_static = "1.4.0"
+lazy_static = "1.4"
 num_enum = "0.5"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
@@ -29,5 +29,8 @@ massa_time = { path = "../massa-time" }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
-serial_test = "0.5.1"
+serial_test = "0.5"
 tempfile = "3.2"
+
+[features]
+instrument = ["tokio/tracing", "massa_models/instrument", "massa_network/instrument", "massa_protocol_exports/instrument", "massa_time/instrument"]

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -16,8 +16,8 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
-tracing = {version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
+tracing = "0.1"
 # custom modules
 massa_hash = { path = "../massa-hash" }
 massa_logging = { path = "../massa-logging" }
@@ -30,5 +30,4 @@ massa_time = { path = "../massa-time" }
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5.1"
-stderrlog = "0.5"
 tempfile = "3.2"

--- a/massa-time/Cargo.toml
+++ b/massa-time/Cargo.toml
@@ -11,7 +11,7 @@ chrono = "0.4"
 displaydoc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.15", features = ["full", "tracing"] }
 
 [dev-dependencies]
 pretty_assertions = "1.0"

--- a/massa-time/Cargo.toml
+++ b/massa-time/Cargo.toml
@@ -11,8 +11,11 @@ chrono = "0.4"
 displaydoc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-tokio = { version = "1.15", features = ["full", "tracing"] }
+tokio = { version = "1.15", features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = "1.0"
 serial_test = "0.5"
+
+[features]
+instrument = ["tokio/tracing"]


### PR DESCRIPTION
Before merge it, I will hide the changes required by `tokio-tracing` behind an `cargo run --feature instrument`?

_Originally posted by @yvan-sraka in https://github.com/massalabs/massa/issues/2190#issuecomment-1032341384_