### PR TITLE
Fix #1315: use Cargo profiles to speed up CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,7 @@ members = [
   "massa-time",
   "massa-wallet",
 ]
+
+# From https://doc.rust-lang.org/cargo/reference/profiles.html#overrides
+[profile.dev.package."*"]
+opt-level = 3 # Speed-up the CI


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/profiles.html#overrides