### PR TITLE
correct crash on node close

### DIFF
--- a/massa-network/src/network_worker.rs
+++ b/massa-network/src/network_worker.rs
@@ -441,10 +441,11 @@ impl NetworkWorker {
         for (_, (_, node_tx)) in self.active_nodes.drain() {
             // close opened connection.
             trace!("before sending  NodeCommand::Close(ConnectionClosureReason::Normal) from node_tx in network_worker run_loop");
-            node_tx
+            // send a close command to every node
+            // note that we ignore any error here because nodes might have closed by themselves just before
+            let _ = node_tx
                 .send(NodeCommand::Close(ConnectionClosureReason::Normal))
-                .await
-                .map_err(|_| NetworkError::ChannelError("node close command send failed".into()))?;
+                .await;
             trace!("after sending  NodeCommand::Close(ConnectionClosureReason::Normal) from node_tx in network_worker run_loop");
         }
         // drain incoming node events


### PR DESCRIPTION
Node workers might close just before we ask them to do so on cleanup => ignore Stop send errors.