### PR TITLE
Change default version to `LABN.0.0`

### DIFF
--- a/massa-models/src/node_configuration/default.rs
+++ b/massa-models/src/node_configuration/default.rs
@@ -60,7 +60,7 @@ lazy_static::lazy_static! {
         if cfg!(feature = "sandbox") {
             "SAND.0.0"
         } else {
-            "TEST.7.0"
+            "LABN.0.0"
         }
         .parse()
         .unwrap()


### PR DESCRIPTION
Attempts to resolve the issue https://github.com/massalabs/massa/issues/2313.

With the change I get the good version, it verifies that the dispatch work correctly.

```zsh
2022-02-21T08:58:59.847604Z  INFO massa_node: Node version : LABN.0.0
2022-02-21T08:58:59.847690Z  INFO massa_bootstrap: Start bootstrapping from 158.69.120.215:31245
2022-02-21T08:59:00.058700Z  WARN massa_bootstrap: error while bootstrapping: io error: early eof
^C2022-02-21T08:59:01.983847Z  INFO massa_node: interrupt signal received in bootstrap loop
```