### PR TITLE
Quick fix release compilation & config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "massa-time",
   "massa-wallet",
 ]
+resolver = "2"
 
 # From https://doc.rust-lang.org/cargo/reference/profiles.html#overrides
 [profile.dev.package."*"]


### PR DESCRIPTION
- Building the workspace with `--release` and the old resolver wasn't working
- Just remove a duplicated parameter