### PR TITLE
Fix wrong rooting configuration for Sandbox

### DIFF
--- a/massa-models/src/node_configuration/default_testing.rs
+++ b/massa-models/src/node_configuration/default_testing.rs
@@ -42,23 +42,13 @@ lazy_static::lazy_static! {
     };
 
     /// TESTNET: time when the blockclique is ended.
-    pub static ref END_TIMESTAMP: Option<MassaTime> = if cfg!(feature = "sandbox") || cfg!(feature = "testing") {
-        None
-    } else {
-        Some(1646078400000.into())
-    };
+    pub static ref END_TIMESTAMP: Option<MassaTime> = None;
     // Be carefull:
     // The `GENESIS_TIMESTAMP` shouldn't be used as it in test because if you start the full test
     // process, the first use is effectivelly `MassaTime::now().unwrap()` but will be outdated for
     // the latest test. That's the reason why we choose to reset it each time we get a ConsensusConfig.
     pub static ref POS_MISS_RATE_DEACTIVATION_THRESHOLD: Ratio<u64> = Ratio::new(1, 1);
-    pub static ref VERSION: Version = if cfg!(feature = "sandbox") {
-        "SAND.0.0"
-    } else {
-        "TEST.7.0"
-    }
-    .parse()
-    .unwrap();
+    pub static ref VERSION: Version = "DEVE.0.0".parse().unwrap();
 }
 
 /// Size of the random bytes array used for the bootstrap, safe to import

--- a/massa-models/src/node_configuration/mod.rs
+++ b/massa-models/src/node_configuration/mod.rs
@@ -30,6 +30,20 @@
 //! use massa_models::constants::default_testing::*;
 //! ```
 //!
+//! # Note about rooting
+//!
+//! |T|S| not(T) or S | T and not(S)
+//! |0|0| 1           | 0
+//! |1|0| 0           | 1
+//! |0|1| 1           | 0
+//! |1|1| 1           | 0
+//!
+//! #[cfg(any(not(feature = "testing"), feature = "sandbox"))]
+//! On `cargo run --release` or `cargo run --features sandbox`
+//!
+//! #[cfg(all(feature = "testing", not(feature = "sandbox")))]
+//! On `cargo run` or `cargo test`
+//!
 
 // **************************************************************
 // Note:
@@ -48,9 +62,9 @@
 pub mod default;
 pub mod default_testing;
 
-#[cfg(not(feature = "testing"))]
+#[cfg(any(not(feature = "testing"), feature = "sandbox"))]
 pub use default::*;
-#[cfg(feature = "testing")]
+#[cfg(all(feature = "testing", not(feature = "sandbox")))]
 pub use default_testing::*;
 
 mod compact_config;


### PR DESCRIPTION
Before with `cargo run --features sandbox` we launched the node with *default_testing* instead of *default*.