### PR TITLE
Feature/docker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "docs"]
 	path = docs
 	url = https://github.com/massalabs/massa.wiki.git
+[submodule "massa"]
+	path = massa
+	url = https://github.com/massalabs/massa.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3-labs
-FROM rust:bullseye AS builder
+FROM jonoh/sccache-rust AS builder
 
 ENV PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_HOME=/usr/local/rustup \
@@ -22,8 +22,6 @@ RUN <<END
 END
 
 ARG BUILD_ENV=dev
-ARG CI_COMMIT_SHORT_SHA
-ARG CI_JOB_URL
 ARG RUSTC_WRAPPER
 ARG SCCACHE_BUCKET
 ARG SCCACHE_S3_KEY_PREFIX
@@ -42,13 +40,13 @@ RUN --mount=type=secret,id=git \
         ;;
       (release)
         target=/tmp/target/release
-        apps="masa-node --release"
+        apps="massa-node --release"
         ;;
     esac
 
     echo "${apps}" | tr ';' '\n' | awk NF | while read bin args; do
       rm -f ${target}/${bin}
-      RUST_BACKTRACE=full cargo build --bin ${bin} ${args} 
+      RUST_BACKTRACE=full cargo build --bin ${bin} ${args}
       cp ${target}/${bin} /
     done
 
@@ -75,9 +73,9 @@ WORKDIR /app
 
 COPY --from=builder /massa-node .
 COPY /entrypoint.sh .
-COPY /massa-node/base_config .
-COPY /massa-node/config .
-COPY /massa-node/storage .
+COPY /massa-node/base_config ./base_config
+COPY /massa-node/config ./config
+COPY /massa-node/storage ./storage
 
 ENTRYPOINT ["/app/entrypoint.sh"]
 
@@ -101,9 +99,9 @@ WORKDIR /app
 
 COPY --from=builder /massa-node .
 COPY /entrypoint.sh .
-COPY /massa-node/base_config .
-COPY /massa-node/config .
-COPY /massa-node/storage .
+COPY /massa-node/base_config ./base_config
+COPY /massa-node/config ./config
+COPY /massa-node/storage ./storage
 
 ENV APP_BIN=/app/massa-node
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,109 @@
+# syntax=docker/dockerfile:1.3-labs
+FROM rust:bullseye AS builder
+
+ENV PATH=/usr/local/cargo/bin:$PATH \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    CARGO_TARGET_DIR=/tmp/target \
+    CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+ARG RUST_VERSION="nightly"
+RUN <<END
+    if [ "${RUST_VERSION}" != "stable" ]; then
+        rustup toolchain install "${RUST_VERSION}"
+        rustup default "${RUST_VERSION}"
+    fi
+END
+
+RUN <<END
+    apt-get update && \
+    apt-get install -y clang \
+        && rm -rf /var/lib/apt/lists/*
+END
+
+ARG BUILD_ENV=dev
+ARG CI_COMMIT_SHORT_SHA
+ARG CI_JOB_URL
+ARG RUSTC_WRAPPER
+ARG SCCACHE_BUCKET
+ARG SCCACHE_S3_KEY_PREFIX
+RUN --mount=type=secret,id=git \
+    --mount=type=cache,target=/tmp/target \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=bind,target=/src <<END
+    set -eu
+
+    cd /src
+    case "${BUILD_ENV}" in
+      (dev)
+        target=/tmp/target/debug
+        apps="massa-node"
+        ;;
+      (release)
+        target=/tmp/target/release
+        apps="masa-node --release"
+        ;;
+    esac
+
+    echo "${apps}" | tr ';' '\n' | awk NF | while read bin args; do
+      rm -f ${target}/${bin}
+      RUST_BACKTRACE=full cargo build --bin ${bin} ${args} 
+      cp ${target}/${bin} /
+    done
+
+    echo ${RUSTC_WRAPPER} | grep -q sccache && sccache --show-stats || true
+END
+
+# Build a dev image
+FROM debian:bullseye-slim AS dev
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    dnsutils \
+    jq \
+    libmcrypt4 \
+    libssl1.1 \
+    netcat \
+    net-tools \
+    procps \
+    telnet \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /massa-node .
+COPY /entrypoint.sh .
+COPY /massa-node/base_config .
+COPY /massa-node/config .
+COPY /massa-node/storage .
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+
+# Build a release image
+FROM debian:bullseye-slim AS release
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    dnsutils \
+    jq \
+    libmcrypt4 \
+    libssl1.1 \
+    netcat \
+    net-tools \
+    procps \
+    telnet \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /massa-node .
+COPY /entrypoint.sh .
+COPY /massa-node/base_config .
+COPY /massa-node/config .
+COPY /massa-node/storage .
+
+ENV APP_BIN=/app/massa-node
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,27 +6,12 @@ set -euo pipefail
 readonly APP_DIR="${APP_DIR:-/app}"
 readonly APP_BIN="${APP_BIN:-${APP_DIR}/massa-node}"
 readonly CONFIG="${CONFIG:-${APP_DIR}/config.toml}"
-readonly SECRETS_DIR="${SECRETS_DIR:-/etc/.secrets}"
-
-wait_for_secrets() {
-  if [[ -d ${SECRETS_DIR} ]]; then
-    echo "[INFO]: waiting for ${SECRETS_DIR}/.mounted..."
-    [[ -f "${SECRETS_DIR}/.mounted" ]] && return
-    sleep 1s
-  fi
-}
 
 start_app() {
   local args=("$@")
-
-  re=" (--config|-c) "
-  if [[ ! " ${args[@]} " =~ $re && -f "${CONFIG}" ]]; then
-      args+=( --config "${CONFIG}" )
-  fi
 
   echo "Starting: ${APP_BIN} ${args[*]}"
   exec "${APP_BIN}" "${args[@]}"
 }
 
-#wait_for_secrets
 start_app ${@}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+[[ $DEBUG = true ]] && set -x
+set -euo pipefail
+
+readonly APP_DIR="${APP_DIR:-/app}"
+readonly APP_BIN="${APP_BIN:-${APP_DIR}/massa-node}"
+readonly CONFIG="${CONFIG:-${APP_DIR}/config.toml}"
+readonly SECRETS_DIR="${SECRETS_DIR:-/etc/.secrets}"
+
+wait_for_secrets() {
+  if [[ -d ${SECRETS_DIR} ]]; then
+    echo "[INFO]: waiting for ${SECRETS_DIR}/.mounted..."
+    [[ -f "${SECRETS_DIR}/.mounted" ]] && return
+    sleep 1s
+  fi
+}
+
+start_app() {
+  local args=("$@")
+
+  re=" (--config|-c) "
+  if [[ ! " ${args[@]} " =~ $re && -f "${CONFIG}" ]]; then
+      args+=( --config "${CONFIG}" )
+  fi
+
+  echo "Starting: ${APP_BIN} ${args[*]}"
+  exec "${APP_BIN}" "${args[@]}"
+}
+
+#wait_for_secrets
+start_app ${@}


### PR DESCRIPTION
The MR contains a Dockerfile for containerizing the massa node (labnet). 
The build is to be run as follows:

DOCKER_BUILDKIT=1 docker build --file Dockerfile --target release --tag massa-node . (target dev is probably not very adequate as we dont want running the node using cargo run). Maybe we should remove it ?

I have tested it and it works quite well. I am welcome to suggestions regarding adding further options such as ENV variables, mapping config folders etc. 