### PR TITLE
Correct execution truncation

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -154,7 +154,11 @@ impl ExecutionState {
     /// # Arguments
     /// * active_slots: A HashMap mapping each active slot to a block or None if the slot is a miss
     /// * ready_final_slots:  A HashMap mapping each ready-to-execute final slot to a block or None if the slot is a miss
-    pub fn truncate_history(&mut self, active_slots: &HashMap<Slot, Option<(BlockId, Block)>>, ready_final_slots: &HashMap<Slot, Option<(BlockId, Block)>>) {
+    pub fn truncate_history(
+        &mut self,
+        active_slots: &HashMap<Slot, Option<(BlockId, Block)>>,
+        ready_final_slots: &HashMap<Slot, Option<(BlockId, Block)>>,
+    ) {
         // find mismatch point (included)
         let mut truncate_at = None;
         // iterate over the output history, in chronological order

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -152,15 +152,17 @@ impl ExecutionState {
     /// Slots after that point will need to be (re-executed) to account for the new sequence.
     ///
     /// # Arguments
-    /// * active_slots: A HashMap mapping each slot to a block or None if the slot is a miss
-    pub fn truncate_history(&mut self, active_slots: &HashMap<Slot, Option<(BlockId, Block)>>) {
+    /// * active_slots: A HashMap mapping each active slot to a block or None if the slot is a miss
+    /// * ready_final_slots:  A HashMap mapping each ready-to-execute final slot to a block or None if the slot is a miss
+    pub fn truncate_history(&mut self, active_slots: &HashMap<Slot, Option<(BlockId, Block)>>, ready_final_slots: &HashMap<Slot, Option<(BlockId, Block)>>) {
         // find mismatch point (included)
         let mut truncate_at = None;
         // iterate over the output history, in chronological order
         for (hist_index, exec_output) in self.active_history.iter().enumerate() {
-            // try to find the corresponding slot in active_slots
+            // try to find the corresponding slot in active_slots or ready_final_slots
             let found_block_id = active_slots
                 .get(&exec_output.slot)
+                .or_else(|| ready_final_slots.get(&exec_output.slot))
                 .map(|opt_b| opt_b.as_ref().map(|(b_id, _b)| *b_id));
             if found_block_id == Some(exec_output.block_id) {
                 // the slot number and block ID still match. Continue scanning

--- a/massa-execution-worker/src/worker.rs
+++ b/massa-execution-worker/src/worker.rs
@@ -329,7 +329,7 @@ impl ExecutionThread {
             .last_active_slot
             .get_next_slot(self.config.thread_count)
             .expect("active slot overflow in VM");
-        let next_timestmap = get_block_slot_timestamp(
+        let next_timestamp = get_block_slot_timestamp(
             self.config.thread_count,
             self.config.t0,
             self.config.genesis_timestamp,
@@ -343,7 +343,7 @@ impl ExecutionThread {
             .saturating_sub(self.config.cursor_delay);
 
         // compute the time difference, saturating down to zero
-        next_timestmap.saturating_sub(end_time)
+        next_timestamp.saturating_sub(end_time)
     }
 
     /// Tells the execution state about the new sequence of active slots.

--- a/massa-execution-worker/src/worker.rs
+++ b/massa-execution-worker/src/worker.rs
@@ -358,7 +358,7 @@ impl ExecutionThread {
 
         // tells the execution state to truncate its execution output history
         // given the new list of active slots
-        exec_state.truncate_history(&self.active_slots);
+        exec_state.truncate_history(&self.active_slots, &self.ready_final_slots);
     }
 
     /// Append incoming read-only requests to the relevant queue,


### PR DESCRIPTION
Truncation only looked into active slots, but it did not look into the final slots that were ready for execution, which caused premature truncation in some cases.