### PR TITLE
Fix security audit - get rid of chrono and use time directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,19 +279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits 0.2.14",
- "time",
- "winapi",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,12 +1959,12 @@ dependencies = [
 name = "massa_time"
 version = "0.1.0"
 dependencies = [
- "chrono",
  "displaydoc",
  "pretty_assertions",
  "serde 1.0.136",
  "serial_test",
  "thiserror",
+ "time",
  "tokio",
 ]
 
@@ -2259,6 +2246,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ba99ba6393e2c3734791401b66902d981cb03bf190af674ca69949b6d5fb15"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3478,12 +3474,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
+ "itoa",
  "libc",
- "winapi",
+ "num_threads",
+ "serde 1.0.136",
 ]
 
 [[package]]

--- a/massa-time/Cargo.toml
+++ b/massa-time/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = "0.4"
+time = { version = "0.3", features = ["serde", "formatting"] }
 displaydoc = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
Chrono still use a very old version of time (0.1 now it's 0.3). They have a PR running since months for updating but it seems that there is communication problems that lead to long time development. The PR : https://github.com/chronotope/chrono/pull/639

This break our CI like a lot of others projects that use `cargo audit`. A lot of projects that use chrono to do things that are now implemented in the new version of `time` has switched to use `time` directly instead of using tokio. Some examples : 
- https://github.com/brave/brave-browser/issues/20568
- https://github.com/meilisearch/milli/pull/450

So as we also only use chrono to make things that now possible in `time` which is more maintained I suggest in this PR a change to use `time` instead of `chrono`.