### PR TITLE
Split interaction with API from client to create an SDK.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,11 +610,11 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.9.0"
-source = "git+https://github.com/yvan-sraka/dialoguer.git?branch=completion-feature#e25c3868ec88f76e84c41edd433a793b3cd146b4"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349d6b4fabcd9e97e1df1ae15395ac7e49fb144946a0d453959dc2696273b9da"
 dependencies = [
  "console",
- "lazy_static",
  "tempfile",
  "zeroize",
 ]
@@ -1501,6 +1501,7 @@ dependencies = [
  "jsonrpc-core-client",
  "lazy_static",
  "massa_models",
+ "massa_sdk",
  "massa_signature",
  "massa_time",
  "massa_wallet",
@@ -1957,6 +1958,19 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "massa_sdk"
+version = "0.1.0"
+dependencies = [
+ "jsonrpc-core-client",
+ "massa_models",
+ "massa_signature",
+ "massa_time",
+ "massa_wallet",
+ "serde 1.0.136",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,6 @@ dependencies = [
  "erased-serde",
  "futures 0.3.21",
  "glob",
- "jsonrpc-core-client",
  "lazy_static",
  "massa_models",
  "massa_sdk",
@@ -1967,8 +1966,6 @@ dependencies = [
  "jsonrpc-core-client",
  "massa_models",
  "massa_signature",
- "massa_time",
- "massa_wallet",
  "serde 1.0.136",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "massa-models",
   "massa-network",
   "massa-node",
+  "massa-sdk",
   "massa-pool",
   "massa-proof-of-stake-exports",
   "massa-protocol-exports",

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -16,7 +16,6 @@ directories = "4.0"
 erased-serde = "0.3"
 futures = "0.3"
 glob = "0.3.0"
-jsonrpc-core-client = { version = "18.0", features = ["http", "tls"] }
 lazy_static = "1.4"
 paw = "1.0"
 rev_lines = "0.2"

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0"
 atty = "0.2"
 config = "0.11"
 console = "0.15"
-dialoguer = { version = "0.9", git = "https://github.com/yvan-sraka/dialoguer.git", branch = "completion-feature", features = ["history", "completion"] }
+dialoguer = { version = "0.10", features = ["history", "completion"] }
 directories = "4.0"
 erased-serde = "0.3"
 futures = "0.3"
@@ -30,6 +30,7 @@ tokio = { version = "1.15", features = ["full"] }
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
+massa_sdk = { path = "../massa-sdk" }
 massa_wallet = { path = "../massa-wallet" }
 
 [target.'cfg(not(windows))'.dependencies]

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::repl::Output;
-use crate::rpc::Client;
+use massa_sdk::Client;
 use anyhow::{anyhow, bail, Result};
 use console::style;
 use massa_models::api::ReadOnlyExecution;

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::repl::Output;
-use massa_sdk::Client;
 use anyhow::{anyhow, bail, Result};
 use console::style;
 use massa_models::api::ReadOnlyExecution;
@@ -11,6 +10,7 @@ use massa_models::timeslots::get_current_latest_block_slot;
 use massa_models::{
     Address, Amount, BlockId, EndorsementId, OperationContent, OperationId, OperationType, Slot,
 };
+use massa_sdk::Client;
 use massa_signature::{generate_random_private_key, PrivateKey, PublicKey};
 use massa_time::MassaTime;
 use massa_wallet::{Wallet, WalletError};

--- a/massa-client/src/main.rs
+++ b/massa-client/src/main.rs
@@ -2,7 +2,7 @@
 
 #![feature(str_split_whitespace_as_str)]
 
-use crate::rpc::Client;
+use massa_sdk::Client;
 use crate::settings::SETTINGS;
 use anyhow::Result;
 use atty::Stream;
@@ -16,7 +16,6 @@ use structopt::StructOpt;
 
 mod cmds;
 mod repl;
-mod rpc;
 mod settings;
 mod utils;
 

--- a/massa-client/src/main.rs
+++ b/massa-client/src/main.rs
@@ -2,12 +2,12 @@
 
 #![feature(str_split_whitespace_as_str)]
 
-use massa_sdk::Client;
 use crate::settings::SETTINGS;
 use anyhow::Result;
 use atty::Stream;
 use cmds::Command;
 use console::style;
+use massa_sdk::Client;
 use massa_wallet::Wallet;
 use serde::Serialize;
 use std::net::IpAddr;

--- a/massa-client/src/repl.rs
+++ b/massa-client/src/repl.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::cmds::{Command, ExtendedWallet};
-use crate::rpc::Client;
+use massa_sdk::Client;
 use crate::settings::SETTINGS;
 use crate::utils::longest_common_prefix;
 use console::style;

--- a/massa-client/src/repl.rs
+++ b/massa-client/src/repl.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::cmds::{Command, ExtendedWallet};
-use massa_sdk::Client;
 use crate::settings::SETTINGS;
 use crate::utils::longest_common_prefix;
 use console::style;
@@ -13,6 +12,7 @@ use massa_models::composite::PubkeySig;
 use massa_models::execution::ExecuteReadOnlyResponse;
 use massa_models::prehash::Set;
 use massa_models::{Address, OperationId};
+use massa_sdk::Client;
 use massa_wallet::Wallet;
 use rev_lines::RevLines;
 use std::collections::VecDeque;

--- a/massa-sdk/Cargo.toml
+++ b/massa-sdk/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "massa_sdk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+jsonrpc-core-client = { version = "18.0", features = ["http", "tls"] }
+tokio = { version = "1.15", features = ["full"] }
+massa_models = { path = "../massa-models" }
+massa_signature = { path = "../massa-signature" }
+massa_time = { path = "../massa-time" }
+massa_wallet = { path = "../massa-wallet" }
+serde = { version = "1.0", features = ["derive"] }

--- a/massa-sdk/Cargo.toml
+++ b/massa-sdk/Cargo.toml
@@ -8,6 +8,4 @@ jsonrpc-core-client = { version = "18.0", features = ["http", "tls"] }
 tokio = { version = "1.15", features = ["full"] }
 massa_models = { path = "../massa-models" }
 massa_signature = { path = "../massa-signature" }
-massa_time = { path = "../massa-time" }
-massa_wallet = { path = "../massa-wallet" }
 serde = { version = "1.0", features = ["derive"] }

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -142,14 +142,14 @@ impl RpcClient {
         self.call_method("get_status", "NodeStatus", ()).await
     }
 
-    pub async fn _get_cliques(&self) -> RpcResult<Vec<Clique>> {
+    pub(crate) async fn _get_cliques(&self) -> RpcResult<Vec<Clique>> {
         self.call_method("get_cliques", "Vec<Clique>", ()).await
     }
 
     // Debug (specific information)
 
     /// Returns the active stakers and their roll counts for the current cycle.
-    pub async fn _get_stakers(&self) -> RpcResult<Map<Address, u64>> {
+    pub(crate) async fn _get_stakers(&self) -> RpcResult<Map<Address, u64>> {
         self.call_method("get_stakers", "Map<Address, u64>", ())
             .await
     }
@@ -183,7 +183,7 @@ impl RpcClient {
 
     /// Get the block graph within the specified time interval.
     /// Optional parameters: from <time_start> (included) and to <time_end> (excluded) millisecond timestamp
-    pub async fn _get_graph_interval(
+    pub(crate) async fn _get_graph_interval(
         &self,
         time_interval: TimeInterval,
     ) -> RpcResult<Vec<BlockSummary>> {

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -21,7 +21,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn new(ip: IpAddr, public_port: u16, private_port: u16, ) -> Client {
+    pub async fn new(ip: IpAddr, public_port: u16, private_port: u16) -> Client {
         let public_socket_addr = SocketAddr::new(ip, public_port);
         let private_socket_addr = SocketAddr::new(ip, private_port);
         let public_url = format!("http://{}", public_socket_addr);
@@ -33,9 +33,9 @@ impl Client {
     }
 }
 
-pub struct RpcClient{
+pub struct RpcClient {
     client: TypedClient,
-    timeout: u64
+    timeout: u64,
 }
 
 /// This is required by `jsonrpc_core_client::transports::http::connect`
@@ -43,7 +43,7 @@ impl From<RpcChannel> for RpcClient {
     fn from(channel: RpcChannel) -> Self {
         RpcClient {
             client: channel.into(),
-            timeout: 10000
+            timeout: 10000,
         }
     }
 }
@@ -64,9 +64,12 @@ impl RpcClient {
         returns: &str,
         args: T,
     ) -> RpcResult<R> {
-        tokio::time::timeout(tokio::time::Duration::from_millis(self.timeout), self.client.call_method(method, returns, args))
-            .await
-            .map_err(|e| RpcError::Client(format!("timeout during {}: {}", method, e)))?
+        tokio::time::timeout(
+            tokio::time::Duration::from_millis(self.timeout),
+            self.client.call_method(method, returns, args),
+        )
+        .await
+        .map_err(|e| RpcError::Client(format!("timeout during {}: {}", method, e)))?
     }
 
     /// Gracefully stop the node.
@@ -83,10 +86,7 @@ impl RpcClient {
 
     /// Add a vec of new private keys for the node to use to stake.
     /// No confirmation to expect.
-    pub async fn add_staking_private_keys(
-        &self,
-        private_keys: Vec<PrivateKey>,
-    ) -> RpcResult<()> {
+    pub async fn add_staking_private_keys(&self, private_keys: Vec<PrivateKey>) -> RpcResult<()> {
         self.call_method("add_staking_private_keys", "()", vec![private_keys])
             .await
     }
@@ -191,10 +191,7 @@ impl RpcClient {
             .await
     }
 
-    pub async fn get_addresses(
-        &self,
-        addresses: Vec<Address>,
-    ) -> RpcResult<Vec<AddressInfo>> {
+    pub async fn get_addresses(&self, addresses: Vec<Address>) -> RpcResult<Vec<AddressInfo>> {
         self.call_method("get_addresses", "Vec<AddressInfo>", vec![addresses])
             .await
     }
@@ -202,10 +199,7 @@ impl RpcClient {
     // User (interaction with the node)
 
     /// Adds operations to pool. Returns operations that were ok and sent to pool.
-    pub async fn send_operations(
-        &self,
-        operations: Vec<Operation>,
-    ) -> RpcResult<Vec<OperationId>> {
+    pub async fn send_operations(&self, operations: Vec<Operation>) -> RpcResult<Vec<OperationId>> {
         self.call_method("send_operations", "Vec<OperationId>", vec![operations])
             .await
     }

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -1,6 +1,5 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use crate::SETTINGS;
 use jsonrpc_core_client::transports::http;
 use jsonrpc_core_client::{RpcChannel, RpcError, RpcResult, TypedClient};
 use massa_models::api::{
@@ -22,7 +21,7 @@ pub struct Client {
 }
 
 impl Client {
-    pub(crate) async fn new(ip: IpAddr, public_port: u16, private_port: u16) -> Client {
+    pub async fn new(ip: IpAddr, public_port: u16, private_port: u16, ) -> Client {
         let public_socket_addr = SocketAddr::new(ip, public_port);
         let private_socket_addr = SocketAddr::new(ip, private_port);
         let public_url = format!("http://{}", public_socket_addr);
@@ -34,18 +33,24 @@ impl Client {
     }
 }
 
-pub struct RpcClient(TypedClient);
+pub struct RpcClient{
+    client: TypedClient,
+    timeout: u64
+}
 
 /// This is required by `jsonrpc_core_client::transports::http::connect`
 impl From<RpcChannel> for RpcClient {
     fn from(channel: RpcChannel) -> Self {
-        RpcClient(channel.into())
+        RpcClient {
+            client: channel.into(),
+            timeout: 10000
+        }
     }
 }
 
 impl RpcClient {
     /// Default constructor
-    pub(crate) async fn from_url(url: &str) -> RpcClient {
+    pub async fn from_url(url: &str) -> RpcClient {
         match http::connect::<RpcClient>(url).await {
             Ok(client) => client,
             Err(_) => panic!("unable to connect to Node."),
@@ -59,27 +64,26 @@ impl RpcClient {
         returns: &str,
         args: T,
     ) -> RpcResult<R> {
-        let time = SETTINGS.timeout.to_duration();
-        tokio::time::timeout(time, self.0.call_method(method, returns, args))
+        tokio::time::timeout(tokio::time::Duration::from_millis(self.timeout), self.client.call_method(method, returns, args))
             .await
             .map_err(|e| RpcError::Client(format!("timeout during {}: {}", method, e)))?
     }
 
     /// Gracefully stop the node.
-    pub(crate) async fn stop_node(&self) -> RpcResult<()> {
+    pub async fn stop_node(&self) -> RpcResult<()> {
         self.call_method("stop_node", "()", ()).await
     }
 
     /// Sign message with node's key.
     /// Returns the public key that signed the message and the signature.
-    pub(crate) async fn node_sign_message(&self, message: Vec<u8>) -> RpcResult<PubkeySig> {
+    pub async fn node_sign_message(&self, message: Vec<u8>) -> RpcResult<PubkeySig> {
         self.call_method("node_sign_message", "PubkeySig", vec![message])
             .await
     }
 
     /// Add a vec of new private keys for the node to use to stake.
     /// No confirmation to expect.
-    pub(crate) async fn add_staking_private_keys(
+    pub async fn add_staking_private_keys(
         &self,
         private_keys: Vec<PrivateKey>,
     ) -> RpcResult<()> {
@@ -89,31 +93,31 @@ impl RpcClient {
 
     /// Remove a vec of addresses used to stake.
     /// No confirmation to expect.
-    pub(crate) async fn remove_staking_addresses(&self, addresses: Vec<Address>) -> RpcResult<()> {
+    pub async fn remove_staking_addresses(&self, addresses: Vec<Address>) -> RpcResult<()> {
         self.call_method("remove_staking_addresses", "()", vec![addresses])
             .await
     }
 
     /// Return hashset of staking addresses.
-    pub(crate) async fn get_staking_addresses(&self) -> RpcResult<Set<Address>> {
+    pub async fn get_staking_addresses(&self) -> RpcResult<Set<Address>> {
         self.call_method("get_staking_addresses", "Set<Address>", ())
             .await
     }
 
     /// Bans given node id
     /// No confirmation to expect.
-    pub(crate) async fn ban(&self, ips: Vec<IpAddr>) -> RpcResult<()> {
+    pub async fn ban(&self, ips: Vec<IpAddr>) -> RpcResult<()> {
         self.call_method("ban", "()", vec![ips]).await
     }
 
     /// Unbans given ip addr
     /// No confirmation to expect.
-    pub(crate) async fn unban(&self, ips: Vec<IpAddr>) -> RpcResult<()> {
+    pub async fn unban(&self, ips: Vec<IpAddr>) -> RpcResult<()> {
         self.call_method("unban", "()", vec![ips]).await
     }
 
     /// execute read only bytecode
-    pub(crate) async fn execute_read_only_request(
+    pub async fn execute_read_only_request(
         &self,
         read_only_execution: ReadOnlyExecution,
     ) -> RpcResult<ExecuteReadOnlyResponse> {
@@ -134,24 +138,24 @@ impl RpcClient {
     // Explorer (aggregated stats)
 
     /// summary of the current state: time, last final blocks (hash, thread, slot, timestamp), clique count, connected nodes count
-    pub(crate) async fn get_status(&self) -> RpcResult<NodeStatus> {
+    pub async fn get_status(&self) -> RpcResult<NodeStatus> {
         self.call_method("get_status", "NodeStatus", ()).await
     }
 
-    pub(crate) async fn _get_cliques(&self) -> RpcResult<Vec<Clique>> {
+    pub async fn _get_cliques(&self) -> RpcResult<Vec<Clique>> {
         self.call_method("get_cliques", "Vec<Clique>", ()).await
     }
 
     // Debug (specific information)
 
     /// Returns the active stakers and their roll counts for the current cycle.
-    pub(crate) async fn _get_stakers(&self) -> RpcResult<Map<Address, u64>> {
+    pub async fn _get_stakers(&self) -> RpcResult<Map<Address, u64>> {
         self.call_method("get_stakers", "Map<Address, u64>", ())
             .await
     }
 
     /// Returns operations information associated to a given list of operations' IDs.
-    pub(crate) async fn get_operations(
+    pub async fn get_operations(
         &self,
         operation_ids: Vec<OperationId>,
     ) -> RpcResult<Vec<OperationInfo>> {
@@ -159,7 +163,7 @@ impl RpcClient {
             .await
     }
 
-    pub(crate) async fn get_endorsements(
+    pub async fn get_endorsements(
         &self,
         endorsement_ids: Vec<EndorsementId>,
     ) -> RpcResult<Vec<EndorsementInfo>> {
@@ -172,14 +176,14 @@ impl RpcClient {
     }
 
     /// Get information on a block given its BlockId
-    pub(crate) async fn get_block(&self, block_id: BlockId) -> RpcResult<BlockInfo> {
+    pub async fn get_block(&self, block_id: BlockId) -> RpcResult<BlockInfo> {
         self.call_method("get_block", "BlockInfo", vec![block_id])
             .await
     }
 
     /// Get the block graph within the specified time interval.
     /// Optional parameters: from <time_start> (included) and to <time_end> (excluded) millisecond timestamp
-    pub(crate) async fn _get_graph_interval(
+    pub async fn _get_graph_interval(
         &self,
         time_interval: TimeInterval,
     ) -> RpcResult<Vec<BlockSummary>> {
@@ -187,7 +191,7 @@ impl RpcClient {
             .await
     }
 
-    pub(crate) async fn get_addresses(
+    pub async fn get_addresses(
         &self,
         addresses: Vec<Address>,
     ) -> RpcResult<Vec<AddressInfo>> {
@@ -198,7 +202,7 @@ impl RpcClient {
     // User (interaction with the node)
 
     /// Adds operations to pool. Returns operations that were ok and sent to pool.
-    pub(crate) async fn send_operations(
+    pub async fn send_operations(
         &self,
         operations: Vec<Operation>,
     ) -> RpcResult<Vec<OperationId>> {


### PR DESCRIPTION
Fix #2280 

### Motivations

Currently, if someone wants to develop a tool on massa he will have to create his own interactions with the API but we already have one that we use for the client. I think we could make those interactions as a new package that can be consider as a SDK.

### Follow-up questions

I think it's a package to be published so that people can directly refer to it easily. Two problems I see with the publish : 
- Need a better documentation
- What about the versioning ? Should we have a version for each testnet ? Auto update on CI ?