### PR TITLE
Proposition: Refactor whitelist peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-map"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82605a2a3d13a9661b07ba27f39d00496aa347c9c236b1a3b8201c1b6d761408"
+dependencies = [
+ "enum-map-derive",
+ "serde 1.0.136",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63b7a0ddec6f38dcec5e36257750b7a8fcaf4227e12ceb306e341d63634da05"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumset"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1798,7 @@ name = "massa_network"
 version = "0.1.0"
 dependencies = [
  "displaydoc",
+ "enum-map",
  "futures 0.3.21",
  "itertools",
  "massa_hash",

--- a/massa-network/Cargo.toml
+++ b/massa-network/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [dependencies]
 displaydoc = "0.2"
+enum-map = { version = "2.0.3", features = ["serde"] }
 futures = "0.3"
 itertools = "0.10"
 num_enum = "0.5"

--- a/massa-network/src/error.rs
+++ b/massa-network/src/error.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use crate::ConnectionId;
+use crate::{peer_info_database::PeerType, ConnectionId};
 use displaydoc::Display;
 use massa_models::ModelsError;
 use std::net::IpAddr;
@@ -78,6 +78,8 @@ pub enum NetworkConnectionErrorType {
     CloseConnectionWithNoConnectionToClose(IpAddr),
     /// Peer info not found for address: {0}
     PeerInfoNotFoundError(IpAddr),
+    /// Peer info not found for address: {0}
+    PeerTypeNotFoundError(PeerType),
     /// Too many connection attempt: {0}
     TooManyConnectionAttempts(IpAddr),
     /// Too many connection failure: {0}

--- a/massa-network/src/lib.rs
+++ b/massa-network/src/lib.rs
@@ -3,6 +3,8 @@
 #![feature(async_closure)]
 #![feature(drain_filter)]
 #![feature(ip)]
+#![feature(is_some_with)]
+#![feature(half_open_range_patterns)]
 
 //! Manages a connection with a node
 pub use common::{ConnectionClosureReason, ConnectionId};

--- a/massa-network/src/tests/scenarios.rs
+++ b/massa-network/src/tests/scenarios.rs
@@ -18,6 +18,7 @@ use crate::{
     ConnectionId, NetworkSettings,
 };
 use enum_map::enum_map;
+use enum_map::EnumMap;
 use massa_hash::{self, hash::Hash};
 use massa_models::node::NodeId;
 use massa_models::{BlockId, Endorsement, EndorsementContent, SerializeCompact, Slot};
@@ -32,6 +33,26 @@ use std::{
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use tracing::trace;
+
+fn default_testing_peer_type_enum_map() -> EnumMap<PeerType, PeerTypeConnectionConfig> {
+    enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
+            target_out_connections: 1,
+            max_out_attempts: 1,
+            max_in_connections: 1,
+        },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
+            max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
+            target_out_connections: 0,
+            max_out_attempts: 0,
+            max_in_connections: 2,
+        }
+    }
+}
 
 /// Test that a node worker can shutdown even if the event channel is full,
 /// and that sending additional node commands during shutdown does not deadlock.
@@ -103,25 +124,8 @@ async fn test_multiple_connections_to_controller() {
     // test config
     let bind_port: u16 = 50_000;
     let temp_peers_file = super::tools::generate_peers_file(&[]);
-    let peer_types_config = enum_map! {
-        PeerType::Bootstrap => PeerTypeConnectionConfig {
-            target_out_connections: 1,
-            max_out_attempts: 1,
-            max_in_connections: 1,
-        },
-        PeerType::WhiteListed => PeerTypeConnectionConfig {
-            target_out_connections: 3,
-            max_out_attempts: 2,
-            max_in_connections: 2,
-        },
-        PeerType::Standard => PeerTypeConnectionConfig {
-            target_out_connections: 0,
-            max_out_attempts: 0,
-            max_in_connections: 2,
-        }
-    };
     let network_conf = NetworkSettings {
-        peer_types_config,
+        peer_types_config: default_testing_peer_type_enum_map(),
         max_in_connections_per_ip: 1,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
@@ -651,25 +655,8 @@ async fn test_block_not_found() {
         active_in_connections: 0,
         banned: false,
     }]);
-    let peer_types_config = enum_map! {
-        PeerType::Bootstrap => PeerTypeConnectionConfig {
-            target_out_connections: 1,
-            max_out_attempts: 1,
-            max_in_connections: 1,
-        },
-        PeerType::WhiteListed => PeerTypeConnectionConfig {
-            target_out_connections: 3,
-            max_out_attempts: 2,
-            max_in_connections: 2,
-        },
-        PeerType::Standard => PeerTypeConnectionConfig {
-            target_out_connections: 0,
-            max_out_attempts: 0,
-            max_in_connections: 2,
-        }
-    };
     let network_conf = NetworkSettings {
-        peer_types_config,
+        peer_types_config: default_testing_peer_type_enum_map(),
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -855,25 +842,8 @@ async fn test_retry_connection_closed() {
         active_in_connections: 0,
         banned: false,
     }]);
-    let peer_types_config = enum_map! {
-        PeerType::Bootstrap => PeerTypeConnectionConfig {
-            target_out_connections: 1,
-            max_out_attempts: 1,
-            max_in_connections: 1,
-        },
-        PeerType::WhiteListed => PeerTypeConnectionConfig {
-            target_out_connections: 3,
-            max_out_attempts: 2,
-            max_in_connections: 2,
-        },
-        PeerType::Standard => PeerTypeConnectionConfig {
-            target_out_connections: 0,
-            max_out_attempts: 0,
-            max_in_connections: 2,
-        }
-    };
     let network_conf = NetworkSettings {
-        peer_types_config,
+        peer_types_config: default_testing_peer_type_enum_map(),
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -971,25 +941,8 @@ async fn test_operation_messages() {
         active_in_connections: 0,
         banned: false,
     }]);
-    let peer_types_config = enum_map! {
-        PeerType::Bootstrap => PeerTypeConnectionConfig {
-            target_out_connections: 1,
-            max_out_attempts: 1,
-            max_in_connections: 1,
-        },
-        PeerType::WhiteListed => PeerTypeConnectionConfig {
-            target_out_connections: 3,
-            max_out_attempts: 2,
-            max_in_connections: 2,
-        },
-        PeerType::Standard => PeerTypeConnectionConfig {
-            target_out_connections: 0,
-            max_out_attempts: 0,
-            max_in_connections: 2,
-        }
-    };
     let network_conf = NetworkSettings {
-        peer_types_config,
+        peer_types_config: default_testing_peer_type_enum_map(),
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -1110,25 +1063,8 @@ async fn test_endorsements_messages() {
         active_in_connections: 0,
         banned: false,
     }]);
-    let peer_types_config = enum_map! {
-        PeerType::Bootstrap => PeerTypeConnectionConfig {
-            target_out_connections: 1,
-            max_out_attempts: 1,
-            max_in_connections: 1,
-        },
-        PeerType::WhiteListed => PeerTypeConnectionConfig {
-            target_out_connections: 3,
-            max_out_attempts: 2,
-            max_in_connections: 2,
-        },
-        PeerType::Standard => PeerTypeConnectionConfig {
-            target_out_connections: 0,
-            max_out_attempts: 0,
-            max_in_connections: 2,
-        }
-    };
     let network_conf = NetworkSettings {
-        peer_types_config,
+        peer_types_config: default_testing_peer_type_enum_map(),
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 

--- a/massa-network/src/tests/scenarios.rs
+++ b/massa-network/src/tests/scenarios.rs
@@ -17,6 +17,7 @@ use crate::{
     binders::{ReadBinder, WriteBinder},
     ConnectionId, NetworkSettings,
 };
+use enum_map::enum_map;
 use massa_hash::{self, hash::Hash};
 use massa_models::node::NodeId;
 use massa_models::{BlockId, Endorsement, EndorsementContent, SerializeCompact, Slot};
@@ -102,12 +103,25 @@ async fn test_multiple_connections_to_controller() {
     // test config
     let bind_port: u16 = 50_000;
     let temp_peers_file = super::tools::generate_peers_file(&[]);
-    let network_conf = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
+    let peer_types_config = enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
+            target_out_connections: 1,
+            max_out_attempts: 1,
+            max_in_connections: 1,
+        },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
             max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
             target_out_connections: 0,
             max_out_attempts: 0,
-        },
+            max_in_connections: 2,
+        }
+    };
+    let network_conf = NetworkSettings {
+        peer_types_config,
         max_in_connections_per_ip: 1,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
@@ -637,13 +651,25 @@ async fn test_block_not_found() {
         active_in_connections: 0,
         banned: false,
     }]);
-
-    let network_conf = NetworkSettings {
-        bootstrap_peers_config: PeerTypeConnectionConfig {
-            max_in_connections: 1,
+    let peer_types_config = enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
             target_out_connections: 1,
             max_out_attempts: 1,
+            max_in_connections: 1,
         },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
+            max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
+            target_out_connections: 0,
+            max_out_attempts: 0,
+            max_in_connections: 2,
+        }
+    };
+    let network_conf = NetworkSettings {
+        peer_types_config,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -829,13 +855,25 @@ async fn test_retry_connection_closed() {
         active_in_connections: 0,
         banned: false,
     }]);
-
-    let network_conf = NetworkSettings {
-        bootstrap_peers_config: PeerTypeConnectionConfig {
-            max_in_connections: 1,
+    let peer_types_config = enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
             target_out_connections: 1,
             max_out_attempts: 1,
+            max_in_connections: 1,
         },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
+            max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
+            target_out_connections: 0,
+            max_out_attempts: 0,
+            max_in_connections: 2,
+        }
+    };
+    let network_conf = NetworkSettings {
+        peer_types_config,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -933,13 +971,25 @@ async fn test_operation_messages() {
         active_in_connections: 0,
         banned: false,
     }]);
-
-    let network_conf = NetworkSettings {
-        bootstrap_peers_config: PeerTypeConnectionConfig {
-            max_in_connections: 1,
+    let peer_types_config = enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
             target_out_connections: 1,
             max_out_attempts: 1,
+            max_in_connections: 1,
         },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
+            max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
+            target_out_connections: 0,
+            max_out_attempts: 0,
+            max_in_connections: 2,
+        }
+    };
+    let network_conf = NetworkSettings {
+        peer_types_config,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 
@@ -1060,13 +1110,25 @@ async fn test_endorsements_messages() {
         active_in_connections: 0,
         banned: false,
     }]);
-
-    let network_conf = NetworkSettings {
-        bootstrap_peers_config: PeerTypeConnectionConfig {
-            max_in_connections: 1,
+    let peer_types_config = enum_map! {
+        PeerType::Bootstrap => PeerTypeConnectionConfig {
             target_out_connections: 1,
             max_out_attempts: 1,
+            max_in_connections: 1,
         },
+        PeerType::WhiteListed => PeerTypeConnectionConfig {
+            target_out_connections: 3,
+            max_out_attempts: 2,
+            max_in_connections: 2,
+        },
+        PeerType::Standard => PeerTypeConnectionConfig {
+            target_out_connections: 0,
+            max_out_attempts: 0,
+            max_in_connections: 2,
+        }
+    };
+    let network_conf = NetworkSettings {
+        peer_types_config,
         ..NetworkSettings::scenarios_default(bind_port, temp_peers_file.path())
     };
 

--- a/massa-network/src/tests/test_peer_db.rs
+++ b/massa-network/src/tests/test_peer_db.rs
@@ -4,6 +4,7 @@ use crate::{
     settings::PeerTypeConnectionConfig,
     NetworkError, NetworkSettings, PeerInfo,
 };
+use enum_map::enum_map;
 use massa_time::MassaTime;
 use serial_test::serial;
 use std::{collections::HashMap, net::IpAddr};
@@ -12,12 +13,19 @@ use tokio::sync::watch;
 #[tokio::test]
 #[serial]
 async fn test_try_new_in_connection_in_connection_closed() {
-    let network_settings = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
-            target_out_connections: 5,
-            max_in_connections: 5,
-            max_out_attempts: 5,
+    let peer_types_config = enum_map! {
+        PeerType::Standard => {
+            PeerTypeConnectionConfig {
+                target_out_connections: 5,
+                max_in_connections: 5,
+                max_out_attempts: 5,
+            }
         },
+        PeerType::Bootstrap => Default::default(),
+        PeerType::WhiteListed => Default::default()
+    };
+    let network_settings = NetworkSettings {
+        peer_types_config,
         ..Default::default()
     };
     let mut peers: HashMap<IpAddr, PeerInfo> = HashMap::new();
@@ -46,9 +54,7 @@ async fn test_try_new_in_connection_in_connection_closed() {
         saver_watch_tx,
         wakeup_interval,
         clock_compensation: 0,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
     };
 
     // test with no connection attempt before
@@ -110,12 +116,19 @@ async fn test_try_new_in_connection_in_connection_closed() {
 #[tokio::test]
 #[serial]
 async fn test_out_connection_attempt_failed() {
-    let network_settings = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
-            target_out_connections: 5,
-            max_in_connections: 5,
-            max_out_attempts: 5,
+    let peer_types_config = enum_map! {
+        PeerType::Standard => {
+            PeerTypeConnectionConfig {
+                target_out_connections: 5,
+                max_in_connections: 5,
+                max_out_attempts: 5,
+            }
         },
+        PeerType::Bootstrap => Default::default(),
+        PeerType::WhiteListed => Default::default()
+    };
+    let network_settings = NetworkSettings {
+        peer_types_config,
         ..Default::default()
     };
     let mut peers: HashMap<IpAddr, PeerInfo> = HashMap::new();
@@ -142,9 +155,7 @@ async fn test_out_connection_attempt_failed() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -208,12 +219,19 @@ async fn test_out_connection_attempt_failed() {
 #[tokio::test]
 #[serial]
 async fn test_try_out_connection_attempt_success() {
-    let network_settings = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
-            target_out_connections: 5,
-            max_in_connections: 5,
-            max_out_attempts: 5,
+    let peer_types_config = enum_map! {
+        PeerType::Standard => {
+            PeerTypeConnectionConfig {
+                target_out_connections: 5,
+                max_in_connections: 5,
+                max_out_attempts: 5,
+            }
         },
+        PeerType::Bootstrap => Default::default(),
+        PeerType::WhiteListed => Default::default()
+    };
+    let network_settings = NetworkSettings {
+        peer_types_config,
         ..Default::default()
     };
     let mut peers: HashMap<IpAddr, PeerInfo> = HashMap::new();
@@ -240,9 +258,7 @@ async fn test_try_out_connection_attempt_success() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -302,12 +318,19 @@ async fn test_try_out_connection_attempt_success() {
 #[tokio::test]
 #[serial]
 async fn test_new_out_connection_closed() {
-    let network_settings = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
-            target_out_connections: 5,
-            max_in_connections: 5,
-            max_out_attempts: 5,
+    let peer_types_config = enum_map! {
+        PeerType::Standard => {
+            PeerTypeConnectionConfig {
+                target_out_connections: 5,
+                max_in_connections: 5,
+                max_out_attempts: 5,
+            }
         },
+        PeerType::Bootstrap => Default::default(),
+        PeerType::WhiteListed => Default::default()
+    };
+    let network_settings = NetworkSettings {
+        peer_types_config,
         ..Default::default()
     };
     let mut peers: HashMap<IpAddr, PeerInfo> = HashMap::new();
@@ -327,9 +350,7 @@ async fn test_new_out_connection_closed() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -379,12 +400,19 @@ async fn test_new_out_connection_closed() {
 #[tokio::test]
 #[serial]
 async fn test_new_out_connection_attempt() {
-    let network_settings = NetworkSettings {
-        standard_peers_config: PeerTypeConnectionConfig {
-            target_out_connections: 5,
-            max_in_connections: 5,
-            max_out_attempts: 5,
+    let peer_types_config = enum_map! {
+        PeerType::Standard => {
+            PeerTypeConnectionConfig {
+                target_out_connections: 5,
+                max_in_connections: 5,
+                max_out_attempts: 5,
+            }
         },
+        PeerType::Bootstrap => Default::default(),
+        PeerType::WhiteListed => Default::default()
+    };
+    let network_settings = NetworkSettings {
+        peer_types_config,
         ..Default::default()
     };
     let mut peers: HashMap<IpAddr, PeerInfo> = HashMap::new();
@@ -403,9 +431,7 @@ async fn test_new_out_connection_attempt() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -492,9 +518,7 @@ async fn test_get_advertisable_peer_ips() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -606,9 +630,7 @@ async fn test_get_out_connection_candidate_ips() {
         peers,
         saver_join_handle,
         saver_watch_tx,
-        whitelist_connection_count: Default::default(),
-        bootstrap_connection_count: Default::default(),
-        standard_connection_count: Default::default(),
+        peer_types_connection_count: Default::default(),
         wakeup_interval,
         clock_compensation: 0,
     };
@@ -838,9 +860,7 @@ impl From<u32> for PeerInfoDatabase {
             peers,
             saver_join_handle,
             saver_watch_tx,
-            whitelist_connection_count: Default::default(),
-            bootstrap_connection_count: Default::default(),
-            standard_connection_count: Default::default(),
+            peer_types_connection_count: Default::default(),
             wakeup_interval,
             clock_compensation: 0,
         }


### PR DESCRIPTION
I have made this pull request to give my proposal on how to improve the PR #2297 . The PR responds to those problems : 

- Rolls backs on the peer type operations : The check if the operation can be done is splitted and made before doing it.
- The peertype genericity ( #2319 ) : The config and connection informations are stored in `EnumMap` (https://crates.io/crates/enum-map) and so you can add more variant to the enum and it will scale the whole process. It will simplify the implementation of #2334.