### PR TITLE
Add t0 and thread_count in env variable when using sandbox feature.

### DIFF
--- a/massa-consensus-exports/src/settings.rs
+++ b/massa-consensus-exports/src/settings.rs
@@ -332,13 +332,21 @@ impl From<&ConsensusSettings> for ConsensusConfig {
         use massa_models::constants::default_testing::*;
         #[cfg(not(feature = "testing"))]
         use massa_models::constants::*;
+        #[cfg(not(feature = "sandbox"))]
+        let thread_count = THREAD_COUNT;
+        #[cfg(not(feature = "sandbox"))]
+        let t0 = T0;
+        #[cfg(feature = "sandbox")]
+        let thread_count = *THREAD_COUNT;
+        #[cfg(feature = "sandbox")]
+        let t0 = *T0;
         ConsensusConfig {
             #[cfg(feature = "testing")]
             temp_files: TempFiles::default(), // No need to clone
             genesis_timestamp: *GENESIS_TIMESTAMP,
             end_timestamp: *END_TIMESTAMP,
-            thread_count: THREAD_COUNT,
-            t0: T0,
+            thread_count,
+            t0,
             genesis_key: *GENESIS_KEY,
             staking_keys_path: settings.staking_keys_path.clone(),
             max_discarded_blocks: settings.max_discarded_blocks,
@@ -385,13 +393,21 @@ impl From<ConsensusSettings> for ConsensusConfig {
         use massa_models::constants::default_testing::*;
         #[cfg(not(feature = "testing"))]
         use massa_models::constants::*;
+        #[cfg(not(feature = "sandbox"))]
+        let thread_count = THREAD_COUNT;
+        #[cfg(not(feature = "sandbox"))]
+        let t0 = T0;
+        #[cfg(feature = "sandbox")]
+        let thread_count = *THREAD_COUNT;
+        #[cfg(feature = "sandbox")]
+        let t0 = *T0;
         ConsensusConfig {
             #[cfg(feature = "testing")]
             temp_files: Default::default(),
             genesis_timestamp: *GENESIS_TIMESTAMP,
             end_timestamp: *END_TIMESTAMP,
-            thread_count: THREAD_COUNT,
-            t0: T0,
+            thread_count,
+            t0,
             genesis_key: *GENESIS_KEY,
             staking_keys_path: settings.staking_keys_path,
             max_discarded_blocks: settings.max_discarded_blocks,

--- a/massa-models/src/node_configuration/compact_config.rs
+++ b/massa-models/src/node_configuration/compact_config.rs
@@ -35,11 +35,19 @@ pub struct CompactConfig {
 
 impl Default for CompactConfig {
     fn default() -> Self {
+        #[cfg(not(feature = "sandbox"))]
+        let thread_count = THREAD_COUNT;
+        #[cfg(not(feature = "sandbox"))]
+        let t0 = T0;
+        #[cfg(feature = "sandbox")]
+        let thread_count = *THREAD_COUNT;
+        #[cfg(feature = "sandbox")]
+        let t0 = *T0;
         Self {
             genesis_timestamp: *GENESIS_TIMESTAMP,
             end_timestamp: *END_TIMESTAMP,
-            thread_count: THREAD_COUNT,
-            t0: T0,
+            thread_count,
+            t0,
             delta_f0: DELTA_F0,
             operation_validity_periods: OPERATION_VALIDITY_PERIODS,
             periods_per_cycle: PERIODS_PER_CYCLE,

--- a/massa-models/src/node_configuration/default.rs
+++ b/massa-models/src/node_configuration/default.rs
@@ -69,14 +69,26 @@ lazy_static::lazy_static! {
     };
 }
 
+#[cfg(feature = "sandbox")]
+lazy_static::lazy_static! {
+    pub static ref T0: MassaTime = std::env::var("T0").map(|timestamp| timestamp.parse::<u64>().unwrap().into()).unwrap_or_else(|_|
+        MassaTime::from(16000)
+    );
+    pub static ref THREAD_COUNT: u8 = std::env::var("THREAD_COUNT").map(|timestamp| timestamp.parse::<u8>().unwrap().into()).unwrap_or_else(|_|
+        32
+    );
+}
+
 /// Price of a roll in the network
 pub const ROLL_PRICE: Amount = Amount::from_raw(100 * AMOUNT_DECIMAL_FACTOR);
 /// Block reward is given for each block creation
 pub const BLOCK_REWARD: Amount = Amount::from_raw((0.3 * AMOUNT_DECIMAL_FACTOR as f64) as u64);
+#[cfg(not(feature = "sandbox"))]
 /// Time between the periods in the same thread.
 pub const T0: MassaTime = MassaTime::from(16000);
 /// Proof of stake seed for the initial draw
 pub const INITIAL_DRAW_SEED: &str = "massa_genesis_seed";
+#[cfg(not(feature = "sandbox"))]
 /// Number of threads
 pub const THREAD_COUNT: u8 = 32;
 /// Number of endorsement
@@ -148,6 +160,7 @@ pub const SLOT_KEY_SIZE: usize = 9;
 /// Size of the event id hash used in execution module, safe to import
 pub const EVENT_ID_SIZE_BYTES: usize = massa_hash::HASH_SIZE_BYTES;
 
+#[cfg(not(feature = "sandbox"))]
 // Some checks at compile time that should not be ignored!
 #[allow(clippy::assertions_on_constants)]
 const _: () = {

--- a/massa-models/src/serialization_context.rs
+++ b/massa-models/src/serialization_context.rs
@@ -79,6 +79,8 @@ impl Default for SerializationContext {
     }
 }
 
+/// Create a specific default implementation for sandbox because the constants are not declared
+/// at compile time but at runtime using `lazy_static` so they need to be deref.
 #[cfg(feature = "sandbox")]
 impl Default for SerializationContext {
     fn default() -> Self {

--- a/massa-models/src/serialization_context.rs
+++ b/massa-models/src/serialization_context.rs
@@ -72,13 +72,43 @@ pub struct SerializationContext {
     pub max_bootstrap_pos_entries: u32,
     pub max_bootstrap_message_size: u32,
 }
-
+#[cfg(not(feature = "sandbox"))]
 impl Default for SerializationContext {
     fn default() -> Self {
         SerializationContext::const_default()
     }
 }
 
+#[cfg(feature = "sandbox")]
+impl Default for SerializationContext {
+    fn default() -> Self {
+        #[cfg(feature = "testing")]
+        // Overide normal constants on testing
+        use crate::constants::default_testing::*;
+        #[cfg(not(feature = "testing"))]
+        use crate::constants::*;
+        Self {
+            max_operations_per_block: MAX_OPERATIONS_PER_BLOCK,
+            thread_count: *THREAD_COUNT,
+            max_block_size: MAX_BLOCK_SIZE,
+            endorsement_count: ENDORSEMENT_COUNT,
+            max_advertise_length: MAX_ADVERTISE_LENGTH,
+            max_message_size: MAX_MESSAGE_SIZE,
+            max_bootstrap_blocks: MAX_BOOTSTRAP_BLOCKS,
+            max_bootstrap_cliques: MAX_BOOTSTRAP_CLIQUES,
+            max_bootstrap_deps: MAX_BOOTSTRAP_DEPS,
+            max_bootstrap_children: MAX_BOOTSTRAP_CHILDREN,
+            max_ask_blocks_per_message: MAX_ASK_BLOCKS_PER_MESSAGE,
+            max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
+            max_endorsements_per_message: MAX_ENDORSEMENTS_PER_MESSAGE,
+            max_bootstrap_message_size: MAX_BOOTSTRAP_MESSAGE_SIZE,
+            max_bootstrap_pos_cycles: MAX_BOOTSTRAP_POS_CYCLES,
+            max_bootstrap_pos_entries: MAX_BOOTSTRAP_POS_ENTRIES,
+        }
+    }
+}
+
+#[cfg(not(feature = "sandbox"))]
 impl SerializationContext {
     pub const fn const_default() -> Self {
         #[cfg(feature = "testing")]

--- a/massa-models/src/signed.rs
+++ b/massa-models/src/signed.rs
@@ -14,6 +14,7 @@ where
 {
     pub content: T,
     pub signature: Signature,
+    #[serde(skip_deserializing)]
     phantom: PhantomData<U>,
 }
 pub trait Id {

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -122,13 +122,22 @@ async fn launch() -> (
     .await
     .expect("could not start pool controller");
 
+    #[cfg(not(feature = "sandbox"))]
+    let thread_count = THREAD_COUNT;
+    #[cfg(not(feature = "sandbox"))]
+    let t0 = T0;
+    #[cfg(feature = "sandbox")]
+    let thread_count = *THREAD_COUNT;
+    #[cfg(feature = "sandbox")]
+    let t0 = *T0;
+
     // init final state
     let ledger_config = LedgerConfig {
         initial_sce_ledger_path: SETTINGS.ledger.initial_sce_ledger_path.clone(),
     };
     let final_state_config = FinalStateConfig {
         final_history_length: SETTINGS.ledger.final_history_length,
-        thread_count: THREAD_COUNT,
+        thread_count,
         ledger_config,
     };
     let final_state = Arc::new(RwLock::new(match bootstrap_state.final_state {
@@ -142,8 +151,8 @@ async fn launch() -> (
         readonly_queue_length: SETTINGS.execution.readonly_queue_length,
         cursor_delay: SETTINGS.execution.cursor_delay,
         clock_compensation: bootstrap_state.compensation_millis,
-        thread_count: THREAD_COUNT,
-        t0: T0,
+        thread_count,
+        t0,
         genesis_timestamp: *GENESIS_TIMESTAMP,
     };
     let (execution_manager, execution_controller) =

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -15,11 +15,22 @@ use massa_protocol_exports::ProtocolSettings;
 use massa_time::MassaTime;
 use serde::Deserialize;
 
+#[cfg(not(feature = "sandbox"))]
 lazy_static::lazy_static! {
     pub static ref SETTINGS: Settings = build_massa_settings("massa-node", "MASSA_NODE");
     pub static ref POOL_CONFIG: PoolConfig = PoolConfig {
         settings: SETTINGS.pool,
         thread_count: THREAD_COUNT,
+        operation_validity_periods: OPERATION_VALIDITY_PERIODS
+    };
+}
+
+#[cfg(feature = "sandbox")]
+lazy_static::lazy_static! {
+    pub static ref SETTINGS: Settings = build_massa_settings("massa-node", "MASSA_NODE");
+    pub static ref POOL_CONFIG: PoolConfig = PoolConfig {
+        settings: SETTINGS.pool,
+        thread_count: *THREAD_COUNT,
         operation_validity_periods: OPERATION_VALIDITY_PERIODS
     };
 }


### PR DESCRIPTION
Fix #2423 .

A bit hacky. I think we could make a more generic switch between the two configs but for the moment it's ok imo because it's two variable and also that the config is well managed in the whole project. It should be part of a more bigger refactor on the config.
