### PR TITLE
Move params to protocol settings

### DIFF
--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -500,6 +500,12 @@ pub struct OperationBatchItem {
 #[derive(Default)]
 pub struct OperationBatchBuffer(VecDeque<OperationBatchItem>);
 
+impl OperationBatchBuffer {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(VecDeque::with_capacity(capacity))
+    }
+}
+
 impl std::ops::Deref for OperationBatchBuffer {
     type Target = VecDeque<OperationBatchItem>;
     fn deref(&self) -> &Self::Target {
@@ -512,6 +518,7 @@ impl std::ops::DerefMut for OperationBatchBuffer {
         &mut self.0
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/massa-network-worker/src/network_cmd_impl.rs
+++ b/massa-network-worker/src/network_cmd_impl.rs
@@ -264,25 +264,6 @@ pub async fn on_block_not_found_cmd(worker: &mut NetworkWorker, node: NodeId, bl
         .await;
 }
 
-pub async fn on_send_operation_cmd(
-    worker: &mut NetworkWorker,
-    node: NodeId,
-    operations: Operations,
-) {
-    massa_trace!(
-        "network_worker.manage_network_command receive NetworkCommand::SendOperations",
-        { "node": node, "operations": operations }
-    );
-    worker
-        .event
-        .forward(
-            node,
-            worker.active_nodes.get(&node),
-            NodeCommand::SendOperations(operations),
-        )
-        .await;
-}
-
 pub async fn on_send_endorsements_cmd(
     worker: &mut NetworkWorker,
     node: NodeId,
@@ -421,9 +402,12 @@ pub async fn on_ask_for_operations_cmd(
         "network_worker.manage_network_command receive NetworkCommand::SendOperationBatch",
         { "wishlist": wishlist }
     );
-    let fut = worker.event.forward(
-        to_node,
-        worker.active_nodes.get(&to_node),
-        NodeCommand::AskForOperations(wishlist),
-    );
+    worker
+        .event
+        .forward(
+            to_node,
+            worker.active_nodes.get(&to_node),
+            NodeCommand::AskForOperations(wishlist),
+        )
+        .await;
 }

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -14,4 +14,10 @@ pub struct ProtocolSettings {
     pub max_simultaneous_ask_blocks_per_node: usize,
     /// Max wait time for sending a Network or Node event.
     pub max_send_wait: MassaTime,
+    pub operation_batch_buffer_capacity: usize,
+    /// Start processing batches in the buffer each `operation_batch_proc_period` in millisecond
+    pub operation_batch_proc_period: u64,
+    /// All operations asked are prune each `operation_asked_pruning_period` millisecond
+    /// todo: link algorithm documentation
+    pub operation_asked_pruning_period: u64,
 }

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -231,6 +231,9 @@ pub fn create_protocol_settings() -> ProtocolSettings {
         max_send_wait: MassaTime::from(100),
         max_known_ops_size: 1000,
         max_known_endorsements_size: 1000,
+        operation_batch_buffer_capacity: 1000,
+        operation_batch_proc_period: 200,
+        operation_asked_pruning_period: 500,
     }
 }
 

--- a/massa-protocol-worker/src/node_info.rs
+++ b/massa-protocol-worker/src/node_info.rs
@@ -27,8 +27,6 @@ pub(crate) struct NodeInfo {
     pub known_blocks: Map<BlockId, (bool, Instant)>,
     /// The blocks the node asked for.
     pub wanted_blocks: Map<BlockId, Instant>,
-    /// The blocks the node asked for.
-    pub operation_wishlist: OperationIds,
     /// Blocks we asked that node for
     pub asked_blocks: Map<BlockId, Instant>,
     /// Instant when the node was added
@@ -69,7 +67,6 @@ impl NodeInfo {
             known_endorsements_queue: VecDeque::with_capacity(
                 pool_settings.max_known_endorsements_size,
             ),
-            operation_wishlist: Set::default(),
         }
     }
 


### PR DESCRIPTION
Use the protocol settings to handle `operation_batch_buffer_capacity`, `operation_batch_proc_period` and `operation_asked_pruning_period`