### PR TITLE
Batch limitation feature

### DIFF
--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -98,7 +98,11 @@
     operation_batch_proc_period = 200
     # All operations asked are prune each `operation_asked_pruning_period` millisecond
     asked_operations_pruning_period = 100
-
+    # Max number of operation per message, same as network param but can be smaller
+    max_operations_per_message = 1024
+    # Max number of operation ids batches a node is allowed to send in a second
+    max_op_batch_per_sec_per_node = 6
+    
 [network]
     # port on which to listen for protocol communication
     bind = "[::]:31244"

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -102,6 +102,8 @@
     max_operations_per_message = 1024
     # Max number of operation ids batches a node is allowed to send in a second
     max_op_batch_per_sec_per_node = 6
+    # Pruning asked op timer in millisecond
+    asked_ops_lifetime = 100000
     
 [network]
     # port on which to listen for protocol communication

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -19,7 +19,7 @@ pub struct ProtocolSettings {
     /// Dismiss the new batches if overflow
     pub operation_batch_buffer_capacity: usize,
     /// Start processing batches in the buffer each `operation_batch_proc_period` in millisecond
-    pub operation_batch_proc_period: u64,
+    pub operation_batch_proc_period: MassaTime,
     /// All operations asked are prune each `operation_asked_pruning_period` millisecond
     pub asked_operations_pruning_period: u64,
     /// Maximum number of batch we accept from a node by second before bannish it

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -2,6 +2,7 @@
 
 use massa_time::MassaTime;
 use serde::Deserialize;
+use std::time::Duration;
 
 /// Protocol Configuration
 #[derive(Debug, Deserialize, Clone, Copy)]
@@ -21,6 +22,19 @@ pub struct ProtocolSettings {
     pub operation_batch_proc_period: u64,
     /// All operations asked are prune each `operation_asked_pruning_period` millisecond
     pub asked_operations_pruning_period: u64,
-    /// Maximum number of batch we accept from a node by second before bannish it.
+    /// Maximum number of batch we accept from a node by second before bannish it
     pub max_op_batch_per_sec_per_node: usize,
+    /// All operations asked are prune each `operation_asked_pruning_period` millisecond
+    pub max_operations_per_message: u64,
+}
+
+impl ProtocolSettings {
+    pub fn get_batch_send_period(&self) -> Duration {
+        if self.max_op_batch_per_sec_per_node == 0 {
+            // panic or what
+            Duration::from_secs(1)
+        } else {
+            Duration::from_millis(1000 / self.max_op_batch_per_sec_per_node as u64)
+        }
+    }
 }

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -21,4 +21,6 @@ pub struct ProtocolSettings {
     pub operation_batch_proc_period: u64,
     /// All operations asked are prune each `operation_asked_pruning_period` millisecond
     pub asked_operations_pruning_period: u64,
+    /// Maximum number of batch we accept from a node by second before bannish it.
+    pub max_op_batch_per_sec_per_node: usize,
 }

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -26,6 +26,8 @@ pub struct ProtocolSettings {
     pub max_op_batch_per_sec_per_node: usize,
     /// All operations asked are prune each `operation_asked_pruning_period` millisecond
     pub max_operations_per_message: u64,
+    /// Pruning asked op timer
+    pub asked_ops_lifetime: MassaTime,
 }
 
 impl ProtocolSettings {

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -236,6 +236,7 @@ pub fn create_protocol_settings() -> ProtocolSettings {
         asked_operations_pruning_period: 500,
         max_op_batch_per_sec_per_node: 6,
         max_operations_per_message: 1024,
+        asked_ops_lifetime: 100000.into(),
     }
 }
 

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -235,6 +235,7 @@ pub fn create_protocol_settings() -> ProtocolSettings {
         operation_batch_proc_period: 200,
         asked_operations_pruning_period: 500,
         max_op_batch_per_sec_per_node: 6,
+        max_operations_per_message: 1024,
     }
 }
 

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -232,7 +232,7 @@ pub fn create_protocol_settings() -> ProtocolSettings {
         max_known_ops_size: 1000,
         max_known_endorsements_size: 1000,
         operation_batch_buffer_capacity: 1000,
-        operation_batch_proc_period: 200,
+        operation_batch_proc_period: 200.into(),
         asked_operations_pruning_period: 500,
         max_op_batch_per_sec_per_node: 6,
         max_operations_per_message: 1024,

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -234,6 +234,7 @@ pub fn create_protocol_settings() -> ProtocolSettings {
         operation_batch_buffer_capacity: 1000,
         operation_batch_proc_period: 200,
         asked_operations_pruning_period: 500,
+        max_op_batch_per_sec_per_node: 6,
     }
 }
 

--- a/massa-protocol-worker/src/node_info.rs
+++ b/massa-protocol-worker/src/node_info.rs
@@ -39,6 +39,8 @@ pub(crate) struct NodeInfo {
     pub known_endorsements: Set<EndorsementId>,
     /// Same as `known_endorsements` but sorted for a premature optimization :-)
     pub known_endorsements_queue: VecDeque<EndorsementId>,
+    /// History of when node sent batches
+    pub batches_sent_history: VecDeque<Instant>,
 }
 
 impl NodeInfo {
@@ -67,6 +69,7 @@ impl NodeInfo {
             known_endorsements_queue: VecDeque::with_capacity(
                 pool_settings.max_known_endorsements_size,
             ),
+            batches_sent_history: VecDeque::new(),
         }
     }
 

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -270,7 +270,9 @@ impl ProtocolWorker {
         tokio::pin!(operation_prune_timer);
         let block_ask_timer = sleep(self.protocol_settings.ask_block_timeout.into());
         tokio::pin!(block_ask_timer);
-        let operation_ask_timer = sleep(self.protocol_settings.ask_block_timeout.into());
+        let operation_ask_timer = sleep(Duration::from_millis(
+            self.protocol_settings.operation_batch_proc_period,
+        ));
         tokio::pin!(operation_ask_timer);
         let propagate_operations_timer = sleep(self.protocol_settings.get_batch_send_period());
         tokio::pin!(propagate_operations_timer);

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -270,10 +270,9 @@ impl ProtocolWorker {
         tokio::pin!(operation_prune_timer);
         let block_ask_timer = sleep(self.protocol_settings.ask_block_timeout.into());
         tokio::pin!(block_ask_timer);
-        let operation_ask_timer = sleep(Duration::from_millis(
-            self.protocol_settings.operation_batch_proc_period,
-        ));
-        tokio::pin!(operation_ask_timer);
+        let operation_batch_proc_period_timer =
+            sleep(self.protocol_settings.operation_batch_proc_period.into());
+        tokio::pin!(operation_batch_proc_period_timer);
         let propagate_operations_timer = sleep(self.protocol_settings.get_batch_send_period());
         tokio::pin!(propagate_operations_timer);
         loop {
@@ -316,9 +315,9 @@ impl ProtocolWorker {
                 }
 
                 // operation ask timer
-                _ = &mut operation_ask_timer => {
+                _ = &mut operation_batch_proc_period_timer => {
                     massa_trace!("protocol.protocol_worker.run_loop.operation_ask_timer", { });
-                    self.update_ask_operation(&mut operation_ask_timer).await?;
+                    self.update_ask_operation(&mut operation_batch_proc_period_timer).await?;
                 }
 
                 // operation prune timer

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -268,7 +268,7 @@ impl ProtocolWorker {
             self.protocol_settings.asked_operations_pruning_period,
         ));
         tokio::pin!(operation_prune_timer);
-        let block_ask_timer = sleep(self.protocol_settings.ask_block_timeout.into());
+        let block_ask_timer = sleep(self.protocol_settings.asked_ops_lifetime.into());
         tokio::pin!(block_ask_timer);
         let operation_batch_proc_period_timer =
             sleep(self.protocol_settings.operation_batch_proc_period.into());

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -113,9 +113,7 @@ impl ProtocolWorker {
                 // otherwise add in future_set
                 if wish.0
                     < now
-                        .checked_sub(Duration::from_millis(
-                            self.protocol_settings.operation_batch_proc_period,
-                        ))
+                        .checked_sub(self.protocol_settings.operation_batch_proc_period.into())
                         .ok_or(TimeError::TimeOverflowError)?
                 {
                     ask_set.insert(op_id);
@@ -132,9 +130,7 @@ impl ProtocolWorker {
         if self.op_batch_buffer.len() < self.protocol_settings.operation_batch_buffer_capacity {
             self.op_batch_buffer.push_back(OperationBatchItem {
                 instant: now
-                    .checked_add(Duration::from_millis(
-                        self.protocol_settings.operation_batch_proc_period,
-                    ))
+                    .checked_add(self.protocol_settings.operation_batch_proc_period.into())
                     .ok_or(TimeError::TimeOverflowError)?,
                 node_id,
                 operations_ids: future_set,
@@ -196,9 +192,12 @@ impl ProtocolWorker {
         &mut self,
         operation_batch_proc_period_timer: &mut std::pin::Pin<&mut Sleep>,
     ) -> Result<(), ProtocolError> {
-        // init timer
-
-        if let Some(op_batch_item) = self.op_batch_buffer.pop_front() {
+        let now = Instant::now();
+        while !self.op_batch_buffer.is_empty()
+        // This unwrap is ok because we checked that it's not empty just before.
+            && now > self.op_batch_buffer.front().unwrap().instant
+        {
+            let op_batch_item = self.op_batch_buffer.pop_front().unwrap();
             self.on_batch_operations_received(op_batch_item.operations_ids, op_batch_item.node_id)
                 .await?;
         }
@@ -206,7 +205,7 @@ impl ProtocolWorker {
         if let Some(item) = self.op_batch_buffer.front() {
             operation_batch_proc_period_timer.set(sleep_until(item.instant));
         } else {
-            let next_tick = Instant::now()
+            let next_tick = now
                 .checked_add(self.protocol_settings.operation_batch_proc_period.into())
                 .ok_or(TimeError::TimeOverflowError)?;
             operation_batch_proc_period_timer.set(sleep_until(next_tick));

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -28,7 +28,7 @@ impl ProtocolWorker {
     ///
     /// Call that function each time we receive a batch from a `node_id`
     ///
-    /// Return true if node has been considered as bannished, false otherwise.
+    /// Return true if node has been considered as banned, false otherwise.
     async fn limitation_batches_by_node(&mut self, node_id: NodeId) -> bool {
         let now = Instant::now();
         let max = self.protocol_settings.max_op_batch_per_sec_per_node;

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -23,6 +23,14 @@ use tokio::time::{sleep_until, Instant, Sleep};
 use tracing::warn;
 
 impl ProtocolWorker {
+    /// Limit the number of batch an external node can send in a second. Ban
+    /// it if it exceed self.settings.max_op_batch_per_sec_per_node
+    ///
+    /// Call that function each time we receive a batch from a `node_id`
+    async fn limitation_batches_by_node(&mut self, node_id: NodeId) -> bool {
+        todo!("Impl limitation")
+    }
+
     /// On receive a batch of operation ids `op_batch` from another `node_id`
     /// Execute the following algorithm: [redirect to github](https://github.com/massalabs/massa/issues/2283#issuecomment-1040872779)
     ///
@@ -48,6 +56,9 @@ impl ProtocolWorker {
         op_batch: OperationIds,
         node_id: NodeId,
     ) -> Result<(), ProtocolError> {
+        if self.limitation_batches_by_node(node_id) {
+            return Ok(());
+        }
         let mut ask_set =
             OperationIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
         let mut future_set =


### PR DESCRIPTION
Add the batch limitation logic from https://github.com/massalabs/massa/issues/2283#issuecomment-1040872779.

We should limit the number of batch we receive by second from node. If exceeded, ban the node.