### PR TITLE
Add CI check for warning handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
+  RUSTFLAGS: "--deny warnings"
 
 jobs:
   # Quick tests on each commit/PR

--- a/massa-consensus-worker/src/tests/inter_cycle_batch_finalization.rs
+++ b/massa-consensus-worker/src/tests/inter_cycle_batch_finalization.rs
@@ -67,7 +67,7 @@ async fn test_inter_cycle_batch_finalization() {
         roll_price,
         t0,
         genesis_timestamp: MassaTime::now().unwrap().saturating_add(warmup_time),
-        ..ConsensusConfig::default_with_staking_keys_and_ledger(&vec![staking_key], &initial_ledger)
+        ..ConsensusConfig::default_with_staking_keys_and_ledger(&[staking_key], &initial_ledger)
     };
 
     consensus_without_pool_test(


### PR DESCRIPTION
As it has been said, the main branch shouldn't accept any warnings, and then we need to ensure that.

![image](https://acegif.com/wp-content/uploads/snow-white-61.gif)
