### PR TITLE
Add static limit logs

### DIFF
--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -13,7 +13,7 @@ parking_lot = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.15", features = ["full"] }
-tracing = "0.1"
+tracing = { version = "0.1", features = ["max_level_debug", "release_max_level_debug"] }
 tracing-subscriber = "0.3"
 # custom modules
 massa_api = { path = "../massa-api" }


### PR DESCRIPTION
While https://github.com/massalabs/massa/issues/2465 is not fix we need to avoid compiling with trace to avoir mass CPU comsuption.