### PR TITLE
skip_serializing_phantom

### DIFF
--- a/massa-models/src/signed.rs
+++ b/massa-models/src/signed.rs
@@ -18,7 +18,7 @@ where
     pub content: T,
     /// signature
     pub signature: Signature,
-    #[serde(skip_deserializing)]
+    #[serde(skip)]
     phantom: PhantomData<U>,
 }
 


### PR DESCRIPTION
Phantom deserialization was already corrected but we still see things like:

```
{
    id: 'oTRiD2cVbkDWQExktpom6WX7vGaG2Tjwea4vedAsnchnE1uRK',
    in_blocks: [ '5iDiPG367t63dyNi3Ltp3ouzDKLaZ8j1sCsg4kE9cP28VTNaA' ],
    in_pool: true,
    is_final: false,
    operation: {
      content: [Object],
      phantom: null,
      signature: '2oDdgwAdRtwBKoyAycd23QQeGknhhJVUTEt2iALQrS7vFRLW7SoPRPbX8dXhCyEPtwBdF9HaqnnFArfqGYBnqDFdXg12k'
    }
  }
```

=> completely skip that field