### PR TITLE
Improve get operations

### DIFF
--- a/massa-consensus-worker/src/consensus_worker.rs
+++ b/massa-consensus-worker/src/consensus_worker.rs
@@ -819,7 +819,7 @@ impl ConsensusWorker {
                     { "operation_ids": operation_ids }
                 );
                 if response_tx
-                    .send(self.block_db.get_operations(&operation_ids)?)
+                    .send(self.block_db.get_operations(operation_ids)?)
                     .is_err()
                 {
                     warn!("consensus: could not send get operations response");


### PR DESCRIPTION
Depends on https://github.com/massalabs/massa/pull/2504

Caught my attention as part of https://github.com/massalabs/massa/pull/2504

This makes `get_operation` take the ids by value, and improve the search algorithm(less cloning of operations and just taking the operation ids). 