### PR TITLE
Improve operations batching

### DIFF
--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -213,13 +213,16 @@ impl NetworkCommandSender {
     /// # Returns
     /// Can return a [NetworkError::ChannelError] that must be managed by the direct caller of the
     /// function.
-    pub async fn send_ask_for_operations(
+    pub fn send_ask_for_operations(
         &self,
         to_node: NodeId,
         wishlist: OperationIds,
     ) -> Result<(), NetworkError> {
         match self.0.try_reserve() {
-            Ok(permit) => Ok(permit.send(NetworkCommand::AskForOperations { to_node, wishlist })),
+            Ok(permit) => {
+                permit.send(NetworkCommand::AskForOperations { to_node, wishlist });
+                Ok(())
+            }
             Err(_) => Err(NetworkError::ChannelError(
                 "Failed to acquire permit to send AskForOperations command".into(),
             )),

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -63,14 +63,15 @@ impl ProtocolWorker {
         operations_ids: OperationIds,
         node_id: NodeId,
     ) -> Result<(), ProtocolError> {
-        // Add to the buffer, if capacity remains.
-        if self.op_batch_buffer.len() < self.protocol_settings.operation_batch_buffer_capacity {
-            self.op_batch_buffer.push_back(OperationBatchItem {
-                instant: Instant::now(),
-                node_id,
-                operations_ids,
-            });
+        // Add to the buffer, dropping the oldest one if no capacity remains.
+        if self.op_batch_buffer.len() >= self.protocol_settings.operation_batch_buffer_capacity {
+            self.op_batch_buffer.pop_front();
         }
+        self.op_batch_buffer.push_back(OperationBatchItem {
+            instant: Instant::now(),
+            node_id,
+            operations_ids,
+        });
         Ok(())
     }
 
@@ -123,24 +124,24 @@ impl ProtocolWorker {
         operation_batch_proc_period_timer: &mut std::pin::Pin<&mut Sleep>,
     ) -> Result<(), ProtocolError> {
         let now = Instant::now();
-        
+
         // Reset timer to the next tick.
         let next_tick = now
             .checked_add(self.protocol_settings.operation_batch_proc_period.into())
             .ok_or(TimeError::TimeOverflowError)?;
         operation_batch_proc_period_timer.set(sleep_until(next_tick));
-        
-        while !self.op_batch_buffer.is_empty()
-        // This unwrap is ok because we checked that it's not empty just before.
-            && now >= self.op_batch_buffer.front().unwrap().instant
-        {
-            let batch_item = self.op_batch_buffer.pop_front().unwrap();
+
+        while let Some(batch_item) = self.op_batch_buffer.front() {
+            if now < batch_item.instant {
+                break;
+            }
+
             let mut ask_set = OperationIds::default();
-            for op_id in batch_item.operations_ids.into_iter() {
-                if self.checked_operations.contains(&op_id) {
+            for op_id in batch_item.operations_ids.iter() {
+                if self.checked_operations.contains(op_id) {
                     continue;
                 }
-                let wish = match self.asked_operations.get_mut(&op_id) {
+                let wish = match self.asked_operations.get_mut(op_id) {
                     Some(wish) => {
                         if wish.1.contains(&batch_item.node_id) {
                             continue; // already asked to the `node_id`
@@ -162,24 +163,26 @@ impl ProtocolWorker {
                             op_id,
                             wish.0.elapsed().as_millis()
                         );
-                        ask_set.insert(op_id);
+                        ask_set.insert(*op_id);
                         wish.0 = now;
                         wish.1.push(batch_item.node_id);
                     }
                 } else {
-                    ask_set.insert(op_id);
+                    ask_set.insert(*op_id);
                     self.asked_operations
-                        .insert(op_id, (now, vec![batch_item.node_id]));
+                        .insert(*op_id, (now, vec![batch_item.node_id]));
                 }
             } // EndOf for op_id in op_batch:
 
             if !ask_set.is_empty() {
                 self.network_command_sender
-                    .send_ask_for_operations(batch_item.node_id, ask_set)
-                    .await?;
+                    .send_ask_for_operations(batch_item.node_id, ask_set)?;
+
+                // Remove the item from the buffer if sending was successful.
+                let _ = self.op_batch_buffer.pop_front().unwrap();
             }
         }
-        
+
         Ok(())
     }
 

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -189,15 +189,13 @@ impl ProtocolWorker {
             )
             .await?;
         }
-        // reset timer
-        if let Some(item) = self.op_batch_buffer.front() {
-            operation_batch_proc_period_timer.set(sleep_until(item.instant));
-        } else {
-            let next_tick = now
-                .checked_add(self.protocol_settings.operation_batch_proc_period.into())
-                .ok_or(TimeError::TimeOverflowError)?;
-            operation_batch_proc_period_timer.set(sleep_until(next_tick));
-        }
+        
+        // Reset timer to the next tick.
+        let next_tick = now
+            .checked_add(self.protocol_settings.operation_batch_proc_period.into())
+            .ok_or(TimeError::TimeOverflowError)?;
+        operation_batch_proc_period_timer.set(sleep_until(next_tick));
+        
         Ok(())
     }
 

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -14,7 +14,6 @@ use crate::protocol_worker::ProtocolWorker;
 use massa_models::{
     node::NodeId,
     operation::{OperationIds, Operations},
-    prehash::BuildMap,
     signed::Signable,
 };
 use massa_network_exports::NetworkError;
@@ -61,72 +60,18 @@ impl ProtocolWorker {
     ///```
     pub(crate) async fn on_operations_announcements_received(
         &mut self,
-        op_batch: OperationIds,
+        operations_ids: OperationIds,
         node_id: NodeId,
     ) -> Result<(), ProtocolError> {
-        let mut ask_set =
-            OperationIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
-        let mut future_set =
-            OperationIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
-        // exactitude isn't important, we want to have a now for that function call
-        let now = Instant::now();
-        for op_id in op_batch {
-            if self.checked_operations.contains(&op_id) {
-                continue;
-            }
-            let wish = match self.asked_operations.get_mut(&op_id) {
-                Some(wish) => {
-                    if wish.1.contains(&node_id) {
-                        continue; // already asked to the `node_id`
-                    } else {
-                        Some(wish) // already asked but at someone else
-                    }
-                }
-                None => None,
-            };
-            if let Some(wish) = wish {
-                // Ask now if latest ask instant < now - operation_batch_proc_period
-                // otherwise add in future_set
-                if wish.0
-                    < now
-                        .checked_sub(self.protocol_settings.operation_batch_proc_period.into())
-                        .ok_or(TimeError::TimeOverflowError)?
-                {
-                    debug!(
-                        "re-ask operation {:?} asked for the first time {:?} millis ago.",
-                        op_id,
-                        wish.0.elapsed().as_millis()
-                    );
-                    ask_set.insert(op_id);
-                    wish.0 = now;
-                    wish.1.push(node_id);
-                } else {
-                    future_set.insert(op_id);
-                }
-            } else {
-                ask_set.insert(op_id);
-                self.asked_operations.insert(op_id, (now, vec![node_id]));
-            }
-        } // EndOf for op_id in op_batch:
-        if self.op_batch_buffer.len() < self.protocol_settings.operation_batch_buffer_capacity
-            && !future_set.is_empty()
-        {
+        // Add to the buffer, if capacity remains.
+        if self.op_batch_buffer.len() < self.protocol_settings.operation_batch_buffer_capacity {
             self.op_batch_buffer.push_back(OperationBatchItem {
-                instant: now
-                    .checked_add(self.protocol_settings.operation_batch_proc_period.into())
-                    .ok_or(TimeError::TimeOverflowError)?,
+                instant: Instant::now(),
                 node_id,
-                operations_ids: future_set,
+                operations_ids,
             });
         }
-        if !ask_set.is_empty() {
-            self.network_command_sender
-                .send_ask_for_operations(node_id, ask_set)
-                .await
-                .map_err(|_| ProtocolError::ChannelError("send ask for operations failed".into()))
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 
     /// On full operations are received from the network,
@@ -178,23 +123,62 @@ impl ProtocolWorker {
         operation_batch_proc_period_timer: &mut std::pin::Pin<&mut Sleep>,
     ) -> Result<(), ProtocolError> {
         let now = Instant::now();
-        while !self.op_batch_buffer.is_empty()
-        // This unwrap is ok because we checked that it's not empty just before.
-            && now >= self.op_batch_buffer.front().unwrap().instant
-        {
-            let op_batch_item = self.op_batch_buffer.pop_front().unwrap();
-            self.on_operations_announcements_received(
-                op_batch_item.operations_ids,
-                op_batch_item.node_id,
-            )
-            .await?;
-        }
         
         // Reset timer to the next tick.
         let next_tick = now
             .checked_add(self.protocol_settings.operation_batch_proc_period.into())
             .ok_or(TimeError::TimeOverflowError)?;
         operation_batch_proc_period_timer.set(sleep_until(next_tick));
+        
+        while !self.op_batch_buffer.is_empty()
+        // This unwrap is ok because we checked that it's not empty just before.
+            && now >= self.op_batch_buffer.front().unwrap().instant
+        {
+            let batch_item = self.op_batch_buffer.pop_front().unwrap();
+            let mut ask_set = OperationIds::default();
+            for op_id in batch_item.operations_ids.into_iter() {
+                if self.checked_operations.contains(&op_id) {
+                    continue;
+                }
+                let wish = match self.asked_operations.get_mut(&op_id) {
+                    Some(wish) => {
+                        if wish.1.contains(&batch_item.node_id) {
+                            continue; // already asked to the `node_id`
+                        } else {
+                            Some(wish) // already asked but at someone else
+                        }
+                    }
+                    None => None,
+                };
+                if let Some(wish) = wish {
+                    // Ask now if latest ask instant < now - operation_batch_proc_period.
+                    if wish.0
+                        < now
+                            .checked_sub(self.protocol_settings.operation_batch_proc_period.into())
+                            .ok_or(TimeError::TimeOverflowError)?
+                    {
+                        debug!(
+                            "re-ask operation {:?} asked for the first time {:?} millis ago.",
+                            op_id,
+                            wish.0.elapsed().as_millis()
+                        );
+                        ask_set.insert(op_id);
+                        wish.0 = now;
+                        wish.1.push(batch_item.node_id);
+                    }
+                } else {
+                    ask_set.insert(op_id);
+                    self.asked_operations
+                        .insert(op_id, (now, vec![batch_item.node_id]));
+                }
+            } // EndOf for op_id in op_batch:
+
+            if !ask_set.is_empty() {
+                self.network_command_sender
+                    .send_ask_for_operations(batch_item.node_id, ask_set)
+                    .await?;
+            }
+        }
         
         Ok(())
     }


### PR DESCRIPTION
Possible fix for https://github.com/massalabs/massa/issues/2522

Changes:

1. `on_operations_announcements_received` now only adds to the buffer.
2. buffer is processed at each timer interval.
3. A command is only send to network if a permit can be acquired.
4. An item in the buffer is only removed if sending the message at 3 was successful.
5. If the buffer is full when receiving an announcement is received, we drop the oldest one.