### PR TITLE
Display connected node in a more usable format

### DIFF
--- a/massa-models/src/api.rs
+++ b/massa-models/src/api.rs
@@ -76,7 +76,7 @@ impl std::fmt::Display for NodeStatus {
 
         writeln!(f, "Connected nodes:")?;
         for (node_id, ip_addr) in &self.connected_nodes {
-            writeln!(f, "\tNode's ID: {} / IP address: {}", node_id, ip_addr)?;
+            writeln!(f, "\t[\"{}:31245\", \"{}\"],", ip_addr, node_id)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This format enables simple copy/paste addition of bootstrap nodes.

Adding bootstrap mode is a recurrent task for testers.
Having to add handcrafted lines based on 'get_status' output is error prone, and confusing (port added, places switched...)
Using this format we have a consistent format.
The information lost (about what is the IP and what is a node_id) does not worth the current burden and could be easily added to the 'Connected nodes' display (IMHO).