### PR TITLE
Add more size in the API bodies

### DIFF
--- a/massa-api/src/lib.rs
+++ b/massa-api/src/lib.rs
@@ -92,6 +92,7 @@ fn serve(api: impl Endpoints, url: &SocketAddr) -> StopHandle {
 
     let server = ServerBuilder::new(io)
         .event_loop_executor(tokio::runtime::Handle::current())
+        .max_request_body_size(50 * 1024 * 1024)
         .start_http(url)
         .expect("Unable to start RPC server");
 


### PR DESCRIPTION
Currently the API accept bodies of maximum size of 5 MiB (default value of `jsonrpc_http_server` : https://docs.rs/jsonrpc-http-server/latest/jsonrpc_http_server/struct.ServerBuilder.html#method.max_request_body_size)

In order to upload bigger SC we need to allow bigger body size in the construction of the RPC API.