### PR TITLE
Move endorsements from block header to block.

### DIFF
--- a/massa-graph/src/block_graph.rs
+++ b/massa-graph/src/block_graph.rs
@@ -2489,7 +2489,7 @@ impl BlockGraph {
         }
 
         // initialize block state accumulator
-        let mut state_accu = match self.block_state_accumulator_init(&block_to_check, pos) {
+        let mut state_accu = match self.block_state_accumulator_init(block_to_check, pos) {
             Ok(accu) => accu,
             Err(err) => {
                 warn!(

--- a/massa-graph/src/export_active_block.rs
+++ b/massa-graph/src/export_active_block.rs
@@ -50,8 +50,6 @@ impl TryFrom<ExportActiveBlock> for ActiveBlock {
 
         let endorsement_ids = a_block
             .block
-            .header
-            .content
             .endorsements
             .iter()
             .map(|endo| Ok((endo.content.compute_id()?, endo.content.index)))

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -5,9 +5,8 @@ use crate::prehash::{Map, PreHashed, Set};
 use crate::signed::{Id, Signable, Signed};
 use crate::{
     array_from_slice, u8_from_slice, with_serialization_context, Address, DeserializeCompact,
-    DeserializeMinBEInt, DeserializeVarInt, Endorsement, EndorsementId, ModelsError, Operation,
-    OperationId, SerializeCompact, SerializeMinBEInt, SerializeVarInt, SignedEndorsement,
-    SignedOperation, Slot,
+    DeserializeMinBEInt, Endorsement, EndorsementId, ModelsError, Operation, OperationId,
+    SerializeCompact, SerializeMinBEInt, SignedEndorsement, SignedOperation, Slot,
 };
 use massa_hash::Hash;
 use massa_hash::HASH_SIZE_BYTES;

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -64,7 +64,7 @@ pub fn create_block(private_key: &PrivateKey, public_key: &PublicKey) -> Block {
                 BlockId(Hash::compute_from("Genesis 1".as_bytes())),
             ],
             operation_merkle_root: Hash::compute_from(&Vec::new()),
-            endorsements: Vec::new(),
+            endorsement_merkle_root: Hash::compute_from(&Vec::new()),
         },
         private_key,
     )
@@ -73,6 +73,7 @@ pub fn create_block(private_key: &PrivateKey, public_key: &PublicKey) -> Block {
     Block {
         header,
         operations: Vec::new(),
+        endorsements: Vec::new(),
     }
 }
 
@@ -102,13 +103,17 @@ pub fn create_block_with_operations(
                 BlockId(Hash::compute_from("Genesis 1".as_bytes())),
             ],
             operation_merkle_root,
-            endorsements: Vec::new(),
+            endorsement_merkle_root: Hash::compute_from(&Vec::new()),
         },
         private_key,
     )
     .unwrap();
 
-    Block { header, operations }
+    Block {
+        header,
+        operations,
+        endorsements: Vec::new(),
+    }
 }
 
 /// create a block with no operation
@@ -123,6 +128,11 @@ pub fn create_block_with_endorsements(
     slot: Slot,
     endorsements: Vec<SignedEndorsement>,
 ) -> Block {
+    let endorsement_merkle_root = Hash::compute_from(
+        &endorsements.iter().fold(Vec::new(), |acc, v| {
+            [acc, v.content.compute_id().unwrap().to_bytes().to_vec()].concat()
+        })[..],
+    );
     let (_, header) = Signed::new_signed(
         BlockHeader {
             creator: *public_key,
@@ -132,7 +142,7 @@ pub fn create_block_with_endorsements(
                 BlockId(Hash::compute_from("Genesis 1".as_bytes())),
             ],
             operation_merkle_root: Hash::compute_from(&Vec::new()),
-            endorsements,
+            endorsement_merkle_root,
         },
         private_key,
     )
@@ -141,6 +151,7 @@ pub fn create_block_with_endorsements(
     Block {
         header,
         operations: Default::default(),
+        endorsements,
     }
 }
 

--- a/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
@@ -118,6 +118,7 @@ async fn test_protocol_sends_blocks_with_operations_to_consensus() {
 
                 let block = {
                     let operation_merkle_root = Hash::compute_from("merkle root".as_bytes());
+                    let endorsement_merkle_root = Hash::compute_from("merkle root".as_bytes());
 
                     let (_, header) = Signed::new_signed(
                         BlockHeader {
@@ -125,7 +126,7 @@ async fn test_protocol_sends_blocks_with_operations_to_consensus() {
                             slot: slot_a,
                             parents: Vec::new(),
                             operation_merkle_root,
-                            endorsements: Vec::new(),
+                            endorsement_merkle_root,
                         },
                         &creator_node.private_key,
                     )
@@ -134,6 +135,7 @@ async fn test_protocol_sends_blocks_with_operations_to_consensus() {
                     Block {
                         header,
                         operations: vec![op.clone()],
+                        endorsements: Vec::new(),
                     }
                 };
 


### PR DESCRIPTION
Endorsement are now managed like operations and have a merkle root in the header.
The content is in the body of the block.