### PR TITLE
Add send on client binders and receive on server binders of bootstrap

### DIFF
--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -41,3 +41,4 @@ lazy_static = "1.4.0"
 # for more information on what are the following features used for, see the cargo.toml at workspace level
 [features]
 instrument = ["tokio/tracing", "massa_consensus_exports/instrument", "massa_graph/instrument", "massa_models/instrument", "massa_network_exports/instrument", "massa_proof_of_stake_exports/instrument", "massa_time/instrument"]
+testing = ["massa_final_state/testing", "massa_ledger/testing"]

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -13,6 +13,7 @@ use massa_signature::{verify_signature, PublicKey, Signature, SIGNATURE_SIZE_BYT
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
+use tracing::debug;
 
 /// Bootstrap client binder
 pub struct BootstrapClientBinder {
@@ -101,6 +102,8 @@ impl BootstrapClientBinder {
             }
         };
 
+        debug!("Received = {:#?}", message);
+
         // save prev sig
         self.prev_message = Some(Hash::compute_from(&sig.to_bytes()));
 
@@ -114,6 +117,8 @@ impl BootstrapClientBinder {
         let msg_len: u32 = msg_bytes.len().try_into().map_err(|e| {
             BootstrapError::GeneralError(format!("bootstrap message too large to encode: {}", e))
         })?;
+
+        debug!("Sent = {:#?}", msg);
 
         if let Some(prev_message) = self.prev_message {
             self.duplex.write_all(&prev_message.to_bytes()).await?;

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -96,7 +96,7 @@ impl BootstrapClientBinder {
                     self.duplex.read_exact(&mut sig_bytes).await?;
                     Signature::from_bytes(&sig_bytes)?
                 };
-                // Check if old signature match
+                // Check if old signature matches
                 {
                     let old_message = &sended_message.to_bytes_compact()?;
                     let mut old_sig_msg_bytes =

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -71,6 +71,8 @@ impl BootstrapClientBinder {
             Signature::from_bytes(&sig_bytes)?
         };
 
+        self.prev_message = Some(Hash::compute_from(&sig.to_bytes()));
+
         // read message length
         let msg_len = {
             let mut meg_len_bytes = vec![0u8; self.size_field_len];
@@ -100,9 +102,6 @@ impl BootstrapClientBinder {
                 msg
             }
         };
-
-        // save prev sig
-        self.prev_message = Some(Hash::compute_from(&sig.to_bytes()));
 
         Ok(message)
     }

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -103,7 +103,7 @@ impl BootstrapClientBinder {
                         vec![0u8; SIGNATURE_SIZE_BYTES + (old_message.len())];
                     old_sig_msg_bytes[..SIGNATURE_SIZE_BYTES]
                         .clone_from_slice(&self.prev_sig.unwrap().to_bytes());
-                    old_sig_msg_bytes[SIGNATURE_SIZE_BYTES..].clone_from_slice(&old_message);
+                    old_sig_msg_bytes[SIGNATURE_SIZE_BYTES..].clone_from_slice(old_message);
                     let old_msg_hash = Hash::compute_from(&old_sig_msg_bytes);
                     verify_signature(
                         &old_msg_hash,

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -134,6 +134,7 @@ impl BootstrapClientBinder {
         Ok(message)
     }
 
+    #[allow(dead_code)]
     /// Send a message to the bootstrap server
     pub async fn send(&mut self, msg: BootstrapMessage) -> Result<(), BootstrapError> {
         let msg_bytes = msg.to_bytes_compact()?;

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -96,8 +96,7 @@ impl BootstrapClientBinder {
                 self.duplex.read_exact(&mut sig_msg_bytes[..]).await?;
                 let msg_hash = Hash::compute_from(&sig_msg_bytes);
                 verify_signature(&msg_hash, &sig, &self.remote_pubkey)?;
-                let (msg, _len) =
-                    BootstrapMessage::from_bytes_compact(&sig_msg_bytes[..])?;
+                let (msg, _len) = BootstrapMessage::from_bytes_compact(&sig_msg_bytes[..])?;
                 msg
             }
         };

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -115,9 +115,9 @@ impl BootstrapClientBinder {
             BootstrapError::GeneralError(format!("bootstrap message too large to encode: {}", e))
         })?;
 
-        self.duplex
-            .write_all(&self.prev_message.unwrap().to_bytes())
-            .await?;
+        if let Some(prev_message) = self.prev_message {
+            self.duplex.write_all(&prev_message.to_bytes()).await?;
+        }
 
         // send message length
         {

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -97,7 +97,7 @@ impl BootstrapClientBinder {
                 let msg_hash = Hash::compute_from(&sig_msg_bytes);
                 verify_signature(&msg_hash, &sig, &self.remote_pubkey)?;
                 let (msg, _len) =
-                    BootstrapMessage::from_bytes_compact(&sig_msg_bytes[HASH_SIZE_BYTES..])?;
+                    BootstrapMessage::from_bytes_compact(&sig_msg_bytes[..])?;
                 msg
             }
         };

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -13,7 +13,6 @@ use massa_signature::{verify_signature, PublicKey, Signature, SIGNATURE_SIZE_BYT
 use rand::{rngs::StdRng, RngCore, SeedableRng};
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
-use tracing::debug;
 
 /// Bootstrap client binder
 pub struct BootstrapClientBinder {
@@ -102,8 +101,6 @@ impl BootstrapClientBinder {
             }
         };
 
-        debug!("Received = {:#?}", message);
-
         // save prev sig
         self.prev_message = Some(Hash::compute_from(&sig.to_bytes()));
 
@@ -117,8 +114,6 @@ impl BootstrapClientBinder {
         let msg_len: u32 = msg_bytes.len().try_into().map_err(|e| {
             BootstrapError::GeneralError(format!("bootstrap message too large to encode: {}", e))
         })?;
-
-        debug!("Sent = {:#?}", msg);
 
         if let Some(prev_message) = self.prev_message {
             self.duplex.write_all(&prev_message.to_bytes()).await?;

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -78,7 +78,7 @@ impl BootstrapClientBinder {
             u32::from_be_bytes_min(&meg_len_bytes, self.max_bootstrap_message_size)?.0
         };
 
-        // read message, check signature and optionally check signature of the message sent just before then deserialize it
+        // read message, check signature and check signature of the message sent just before then deserialize it
         let message = {
             if let Some(prev_message) = self.prev_message {
                 let mut sig_msg_bytes = vec![0u8; HASH_SIZE_BYTES + (msg_len as usize)];

--- a/massa-bootstrap/src/error.rs
+++ b/massa-bootstrap/src/error.rs
@@ -38,4 +38,6 @@ pub enum BootstrapError {
     MissingKeyError,
     /// incompatible version: {0}
     IncompatibleVersionError(String),
+    /// Received error: {0}
+    ReceivedError(String),
 }

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -381,8 +381,6 @@ struct BootstrapServer {
 }
 
 impl BootstrapServer {
-    // We don't want to leave on a fail of sending error to a bootstrap client.
-    #[allow(unused_must_use)]
     pub async fn run(mut self) -> Result<(), BootstrapError> {
         debug!("starting bootstrap server");
         massa_trace!("bootstrap.lib.run", {});
@@ -447,7 +445,7 @@ impl BootstrapServer {
                         hash_map::Entry::Occupied(mut occ) => {
                             if now.duration_since(*occ.get()) <= per_ip_min_interval {
                                 let mut server = BootstrapServerBinder::new(dplx, self.private_key);
-                                send_state_timeout_with_error_check(
+                                let _ = send_state_timeout_with_error_check(
                                     self.bootstrap_settings.write_error_timeout.into(),
                                     self.bootstrap_settings.read_error_timeout.into(),
                                     &mut server,
@@ -512,7 +510,7 @@ impl BootstrapServer {
                     massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});
                 } else {
                     let mut server = BootstrapServerBinder::new(dplx, self.private_key);
-                    send_state_timeout_with_error_check(
+                    let _ = send_state_timeout_with_error_check(
                         self.bootstrap_settings.write_error_timeout.into(),
                         self.bootstrap_settings.read_error_timeout.into(),
                         &mut server,

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -298,6 +298,7 @@ pub async fn get_state(
                     }
                 }
             }
+            info!("The bootstrap on the server {} has failed. Your node will try to bootstrap to another node in {} ms", addr, bootstrap_settings.retry_delay);
             sleep(bootstrap_settings.retry_delay.into()).await;
         }
     }

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -454,7 +454,7 @@ impl BootstrapServer {
                 } else {
                     let mut server = BootstrapServerBinder::new(dplx, self.private_key);
                     send_state_timeout(
-                        std::time::Duration::new(1, 0),
+                        std::time::Duration::new(0, 200000000),
                         server.send(BootstrapMessage::BootstrapError {
                             error: "no available slots to bootstrap".to_string()
                         }),

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -88,7 +88,7 @@ async fn get_state_internal(
     // handshake
     let send_time_uncompensated = MassaTime::now()?;
     // client.handshake() is not cancel-safe but we drop the whole client object if cancelled => it's OK
-    match tokio::time::timeout(cfg.write_timeout.into(), client.handshake()).await {
+    match tokio::time::timeout(cfg.write_timeout.into(), client.handshake(our_version)).await {
         Err(_) => {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::TimedOut,
@@ -452,7 +452,7 @@ impl BootstrapServer {
                     massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});
                 } else {
                     debug!("did not bootstrap {}: no available slots", remote_addr);
-                },
+                }
             }
         }
 
@@ -481,7 +481,7 @@ async fn manage_bootstrap(
     // Handshake
     send_state_timeout(
         bootstrap_settings.read_timeout.into(),
-        server.handshake(),
+        server.handshake(version),
         "bootstrap handshake send timed out",
     )
     .await?;

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -98,7 +98,7 @@ async fn get_state_internal(
             ))
         }
         Ok(Ok(msg)) => return Err(BootstrapError::UnexpectedMessage(msg))
-    }
+    };
 
     // handshake
     let send_time_uncompensated = MassaTime::now()?;

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -381,6 +381,8 @@ struct BootstrapServer {
 }
 
 impl BootstrapServer {
+    // We don't want to leave on a fail of sending error to a bootstrap client.
+    #[allow(unused_must_use)]
     pub async fn run(mut self) -> Result<(), BootstrapError> {
         debug!("starting bootstrap server");
         massa_trace!("bootstrap.lib.run", {});
@@ -455,7 +457,7 @@ impl BootstrapServer {
                                     },
                                     "bootstrap error no available slots send timed out",
                                 )
-                                .await?;
+                                .await;
                                 // in list, non-expired => refuse
                                 massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {"remote_addr": remote_addr});
                                 continue;
@@ -519,7 +521,7 @@ impl BootstrapServer {
                         },
                         "bootstrap error no available slots send timed out",
                     )
-                    .await?;
+                    .await;
                     debug!("did not bootstrap {}: no available slots", remote_addr);
                 }
             }

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -449,6 +449,7 @@ impl BootstrapServer {
                     match self.ip_hist_map.entry(remote_addr.ip()) {
                         hash_map::Entry::Occupied(mut occ) => {
                             if now.duration_since(*occ.get()) <= per_ip_min_interval {
+                                debug!("Should not happens here");
                                 let mut server = BootstrapServerBinder::new(dplx, self.private_key);
                                 send_state_timeout_with_error_check(
                                     self.bootstrap_settings.write_error_timeout.into(),
@@ -497,7 +498,6 @@ impl BootstrapServer {
                     let (data_pos, data_graph, data_peers, data_execution) = bootstrap_data.clone().unwrap(); // will not panic (checked above)
                     bootstrap_sessions.push(async move {
                         //TODO: Remove debug
-                        sleep(std::time::Duration::new(3, 0)).await;
                         //Socket lifetime
                         {
                             let mut server = BootstrapServerBinder::new(dplx, private_key);
@@ -513,6 +513,7 @@ impl BootstrapServer {
                                     sleep(self.bootstrap_settings.write_error_timeout.into()).await;
                                 },
                             }
+                            sleep(std::time::Duration::new(3, 0)).await;
                         }
                     });
                     massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});

--- a/massa-bootstrap/src/messages.rs
+++ b/massa-bootstrap/src/messages.rs
@@ -135,7 +135,15 @@ impl DeserializeCompact for BootstrapMessage {
                 let (error_len, delta) = u32::from_varint_bytes(&buffer[cursor..])?;
                 cursor += delta;
 
-                let error = String::from_utf8_lossy(&buffer[cursor..cursor + error_len as usize]);
+                let error = String::from_utf8_lossy(
+                    buffer
+                        .get(cursor..cursor + error_len as usize)
+                        .ok_or_else(|| {
+                            ModelsError::DeserializeError(
+                                "Error message content too short.".to_string(),
+                            )
+                        })?,
+                );
                 cursor += error_len as usize;
 
                 BootstrapMessage::BootstrapError {

--- a/massa-bootstrap/src/messages.rs
+++ b/massa-bootstrap/src/messages.rs
@@ -10,6 +10,7 @@ use massa_proof_of_stake_exports::ExportProofOfStake;
 use massa_time::MassaTime;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 use std::convert::TryInto;
 
 /// Messages used during bootstrap
@@ -79,7 +80,7 @@ impl SerializeCompact for BootstrapMessage {
             }
             BootstrapMessage::BootstrapError { error } => {
                 res.extend(u32::from(MessageTypeId::BootstrapError).to_varint_bytes());
-                res.extend(u64::to_varint_bytes(error.len() as u64));
+                res.extend(u32::to_varint_bytes(error.len() as u32));
                 res.extend(error.as_bytes())
             }
         }
@@ -93,6 +94,8 @@ impl DeserializeCompact for BootstrapMessage {
 
         let (type_id_raw, delta) = u32::from_varint_bytes(&buffer[cursor..])?;
         cursor += delta;
+
+        debug!("type_id = {}", type_id_raw);
 
         let type_id: MessageTypeId = type_id_raw
             .try_into()
@@ -132,7 +135,7 @@ impl DeserializeCompact for BootstrapMessage {
                 BootstrapMessage::FinalState { final_state }
             }
             MessageTypeId::BootstrapError => {
-                let (error_len, delta) = u64::from_varint_bytes(&buffer[cursor..])?;
+                let (error_len, delta) = u32::from_varint_bytes(&buffer[cursor..])?;
                 cursor += delta;
 
                 let error = String::from_utf8_lossy(&buffer[cursor..cursor + error_len as usize]);

--- a/massa-bootstrap/src/messages.rs
+++ b/massa-bootstrap/src/messages.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 
 /// Messages used during bootstrap
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum BootstrapMessage {
     /// Sync clocks
     BootstrapTime {

--- a/massa-bootstrap/src/messages.rs
+++ b/massa-bootstrap/src/messages.rs
@@ -10,8 +10,8 @@ use massa_proof_of_stake_exports::ExportProofOfStake;
 use massa_time::MassaTime;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
 use std::convert::TryInto;
+use tracing::debug;
 
 /// Messages used during bootstrap
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/massa-bootstrap/src/messages.rs
+++ b/massa-bootstrap/src/messages.rs
@@ -11,7 +11,6 @@ use massa_time::MassaTime;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
-use tracing::debug;
 
 /// Messages used during bootstrap
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -94,8 +93,6 @@ impl DeserializeCompact for BootstrapMessage {
 
         let (type_id_raw, delta) = u32::from_varint_bytes(&buffer[cursor..])?;
         cursor += delta;
-
-        debug!("type_id = {}", type_id_raw);
 
         let type_id: MessageTypeId = type_id_raw
             .try_into()

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -11,7 +11,6 @@ use massa_models::{
     DeserializeMinBEInt, SerializeCompact, SerializeMinBEInt,
 };
 use massa_signature::{sign, PrivateKey};
-use tracing::debug;
 use std::convert::TryInto;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -90,7 +89,6 @@ impl BootstrapServerBinder {
                 sign(&Hash::compute_from(&signed_data), &self.local_privkey)?
             }
         };
-        debug!("Sent = {:#?}", msg);
 
         // send signature
         self.duplex.write_all(&sig.to_bytes()).await?;
@@ -146,7 +144,7 @@ impl BootstrapServerBinder {
             let (msg, _len) = BootstrapMessage::from_bytes_compact(&msg_bytes)?;
             msg
         };
-        debug!("Received = {:#?}", message);
+
         self.prev_message = Some(Hash::compute_from(&msg_bytes));
         Ok(message)
     }

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -107,6 +107,7 @@ impl BootstrapServerBinder {
         Ok(())
     }
 
+    #[allow(dead_code)]
     /// Read a message sent from the client (not signed). NOT cancel-safe
     pub async fn next(&mut self) -> Result<BootstrapMessage, BootstrapError> {
         // read prev signature

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -134,6 +134,7 @@ impl BootstrapServerBinder {
         let mut msg_bytes = vec![0u8; msg_len as usize];
         let message = {
             self.duplex.read_exact(&mut msg_bytes).await?;
+            self.prev_message = Some(Hash::compute_from(&msg_bytes));
             if let Some(prev_message) = self.prev_message {
                 if prev_message != hash.unwrap() {
                     return Err(BootstrapError::GeneralError(
@@ -145,7 +146,6 @@ impl BootstrapServerBinder {
             msg
         };
 
-        self.prev_message = Some(Hash::compute_from(&msg_bytes));
         Ok(message)
     }
 }

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -120,7 +120,7 @@ impl BootstrapServerBinder {
         if let Some(prev_sig) = self.prev_sig {
             if sig != prev_sig || self.received_client_message_sig.is_some() {
                 return Err(BootstrapError::GeneralError(
-                    "The prev signature sent by the client doesn't match our.".to_string(),
+                    "The prev signature sent by the client doesn't match ours.".to_string(),
                 ));
             }
         }

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -17,6 +17,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 /// Bootstrap server binder
 pub struct BootstrapServerBinder {
     max_bootstrap_message_size: u32,
+    size_field_len: usize,
     local_privkey: PrivateKey,
     duplex: Duplex,
     prev_message: Option<Hash>,
@@ -30,8 +31,10 @@ impl BootstrapServerBinder {
     pub fn new(duplex: Duplex, local_privkey: PrivateKey) -> Self {
         let max_bootstrap_message_size =
             with_serialization_context(|context| context.max_bootstrap_message_size);
+        let size_field_len = u32::be_bytes_min_length(max_bootstrap_message_size);
         BootstrapServerBinder {
             max_bootstrap_message_size,
+            size_field_len,
             local_privkey,
             duplex,
             prev_message: None,
@@ -42,28 +45,20 @@ impl BootstrapServerBinder {
     /// NOT cancel-safe
     /// MUST always be followed by a send of the BootstrapMessage::BootstrapTime
     pub async fn handshake(&mut self, version: Version) -> Result<(), BootstrapError> {
-        // read randomness, check hash
-        let rand_hash = {
+        // read version and random bytes, send signature
+        let msg_hash = {
             let version_bytes = version.to_bytes_compact()?;
-            let mut random_bytes =
-                vec![0u8; (version_bytes.len() as usize) + BOOTSTRAP_RANDOMNESS_SIZE_BYTES];
-            self.duplex.read_exact(&mut random_bytes).await?;
-            let receive_version =
-                Version::from_bytes_compact(&random_bytes[..version_bytes.len()])?;
-            if !receive_version.0.is_compatible(&version) {
-                return Err(BootstrapError::IncompatibleVersionError(format!("Received a bad incompatible version in handshake. (excepted: {}, received: {})", version, receive_version.0)));
+            let mut msg_bytes = vec![0u8; version_bytes.len() + BOOTSTRAP_RANDOMNESS_SIZE_BYTES];
+            self.duplex.read_exact(&mut msg_bytes).await?;
+            let received_version = Version::from_bytes_compact(&msg_bytes[..version_bytes.len()])?;
+            if !received_version.0.is_compatible(&version) {
+                return Err(BootstrapError::IncompatibleVersionError(format!("Received a bad incompatible version in handshake. (excepted: {}, received: {})", version, received_version.0)));
             }
-            let expected_hash = Hash::compute_from(&random_bytes);
-            let mut hash_bytes = [0u8; HASH_SIZE_BYTES];
-            self.duplex.read_exact(&mut hash_bytes).await?;
-            if Hash::from_bytes(&hash_bytes)? != expected_hash {
-                return Err(BootstrapError::GeneralError("wrong handshake hash".into()));
-            }
-            expected_hash
+            Hash::compute_from(&msg_bytes)
         };
 
         // save prev sig
-        self.prev_message = Some(rand_hash);
+        self.prev_message = Some(msg_hash);
 
         Ok(())
     }
@@ -79,14 +74,15 @@ impl BootstrapServerBinder {
         // compute signature
         let sig = {
             if let Some(prev_message) = self.prev_message {
-                let mut signed_data = vec![0u8; HASH_SIZE_BYTES + (msg_len as usize)];
-                signed_data[..HASH_SIZE_BYTES].clone_from_slice(&prev_message.to_bytes());
-                signed_data[HASH_SIZE_BYTES..].clone_from_slice(&msg_bytes);
+                // there was a previous message: sign(prev_msg_hash + msg)
+                let mut signed_data =
+                    Vec::with_capacity(HASH_SIZE_BYTES.saturating_add(msg_len as usize));
+                signed_data.extend(prev_message.to_bytes());
+                signed_data.extend(&msg_bytes);
                 sign(&Hash::compute_from(&signed_data), &self.local_privkey)?
             } else {
-                let mut signed_data = vec![0u8; msg_len as usize];
-                signed_data[..].clone_from_slice(&msg_bytes);
-                sign(&Hash::compute_from(&signed_data), &self.local_privkey)?
+                // there was no previous message: sign(msg)
+                sign(&Hash::compute_from(&msg_bytes), &self.local_privkey)?
             }
         };
 
@@ -112,7 +108,7 @@ impl BootstrapServerBinder {
     /// Read a message sent from the client (not signed). NOT cancel-safe
     pub async fn next(&mut self) -> Result<BootstrapMessage, BootstrapError> {
         // read prev hash
-        let hash = {
+        let received_prev_hash = {
             if self.prev_message.is_some() {
                 let mut hash_bytes = [0u8; HASH_SIZE_BYTES];
                 self.duplex.read_exact(&mut hash_bytes).await?;
@@ -122,30 +118,40 @@ impl BootstrapServerBinder {
             }
         };
 
-        let size_field_len = u32::be_bytes_min_length(self.max_bootstrap_message_size);
-
         // read message length
         let msg_len = {
-            let mut meg_len_bytes = vec![0u8; size_field_len];
-            self.duplex.read_exact(&mut meg_len_bytes[..]).await?;
-            u32::from_be_bytes_min(&meg_len_bytes, self.max_bootstrap_message_size)?.0
-        };
-        // read message and deserialize
-        let mut msg_bytes = vec![0u8; msg_len as usize];
-        let message = {
-            self.duplex.read_exact(&mut msg_bytes).await?;
-            if let Some(prev_message) = self.prev_message {
-                if prev_message != hash.unwrap() {
-                    return Err(BootstrapError::GeneralError(
-                        "Message sequencing has been broken".to_string(),
-                    ));
-                }
-            }
-            self.prev_message = Some(Hash::compute_from(&msg_bytes));
-            let (msg, _len) = BootstrapMessage::from_bytes_compact(&msg_bytes)?;
-            msg
+            let mut msg_len_bytes = vec![0u8; self.size_field_len];
+            self.duplex.read_exact(&mut msg_len_bytes[..]).await?;
+            u32::from_be_bytes_min(&msg_len_bytes, self.max_bootstrap_message_size)?.0
         };
 
-        Ok(message)
+        // read message
+        let mut msg_bytes = vec![0u8; msg_len as usize];
+        self.duplex.read_exact(&mut msg_bytes).await?;
+
+        // check previous hash
+        if received_prev_hash != self.prev_message {
+            return Err(BootstrapError::GeneralError(
+                "Message sequencing has been broken".to_string(),
+            ));
+        }
+
+        // update previous hash
+        if let Some(prev_hash) = received_prev_hash {
+            // there was a previous message: hash(prev_hash + message)
+            let mut hashed_bytes =
+                Vec::with_capacity(HASH_SIZE_BYTES.saturating_add(msg_bytes.len()));
+            hashed_bytes.extend(prev_hash.to_bytes());
+            hashed_bytes.extend(&msg_bytes);
+            self.prev_message = Some(Hash::compute_from(&hashed_bytes));
+        } else {
+            // no previous message: hash message only
+            self.prev_message = Some(Hash::compute_from(&msg_bytes));
+        }
+
+        // deserialize message
+        let (msg, _len) = BootstrapMessage::from_bytes_compact(&msg_bytes)?;
+
+        Ok(msg)
     }
 }

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -134,7 +134,6 @@ impl BootstrapServerBinder {
         let mut msg_bytes = vec![0u8; msg_len as usize];
         let message = {
             self.duplex.read_exact(&mut msg_bytes).await?;
-            self.prev_message = Some(Hash::compute_from(&msg_bytes));
             if let Some(prev_message) = self.prev_message {
                 if prev_message != hash.unwrap() {
                     return Err(BootstrapError::GeneralError(
@@ -142,6 +141,7 @@ impl BootstrapServerBinder {
                     ));
                 }
             }
+            self.prev_message = Some(Hash::compute_from(&msg_bytes));
             let (msg, _len) = BootstrapMessage::from_bytes_compact(&msg_bytes)?;
             msg
         };

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -19,6 +19,10 @@ pub struct BootstrapSettings {
     pub read_timeout: MassaTime,
     /// write timeout
     pub write_timeout: MassaTime,
+    /// readout error timeout
+    pub read_error_timeout: MassaTime,
+    /// write error timeout
+    pub write_error_timeout: MassaTime,
     /// Time we wait before retrying a bootstrap
     pub retry_delay: MassaTime,
     /// Max ping delay.

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -105,6 +105,72 @@ async fn test_binders() {
     client_thread.await.unwrap();
 }
 
+/// The server and the client will handshake and then send message only from server to client
+#[tokio::test]
+#[serial]
+async fn test_binders_double_send_server_works() {
+    let (bootstrap_settings, server_private_key): &(BootstrapSettings, PrivateKey) =
+        &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
+
+    let (client, server) = duplex(1000000);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key);
+    let mut client = BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1);
+
+    let server_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+
+        server.handshake().await.unwrap();
+        server.send(test_peers_message.clone()).await.unwrap();
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+
+        server.send(test_peers_message.clone()).await.unwrap();
+    });
+
+    let client_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+
+        client.handshake().await.unwrap();
+        let message = client.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let message = client.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+    });
+
+    server_thread.await.unwrap();
+    client_thread.await.unwrap();
+}
+
 /// The server and the client will handshake and then send message in both ways but the client will try to send two messages without answer and it should fail
 #[tokio::test]
 #[serial]

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -15,6 +15,7 @@ lazy_static::lazy_static! {
     };
 }
 
+/// The server and the client will handshake and then send message in both ways in order
 #[tokio::test]
 #[serial]
 async fn test_binders() {
@@ -98,6 +99,77 @@ async fn test_binders() {
             }
             _ => panic!("Bad message receive: Expected a peers list message"),
         }
+    });
+
+    server_thread.await.unwrap();
+    client_thread.await.unwrap();
+}
+
+/// The server and the client will handshake and then send message in both ways but the client will try to send two messages without answer and it should fail
+#[tokio::test]
+#[serial]
+async fn test_binders_try_double_send_client() {
+    let (bootstrap_settings, server_private_key): &(BootstrapSettings, PrivateKey) =
+        &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
+
+    let (client, server) = duplex(1000000);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key);
+    let mut client = BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1);
+
+    let server_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+
+        server.handshake().await.unwrap();
+        server.send(test_peers_message.clone()).await.unwrap();
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+
+        let message = server.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+
+        server.next().await.expect_err(
+            "Must error because the client sent two times a message without waiting for our answer",
+        );
+    });
+
+    let client_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+
+        client.handshake().await.unwrap();
+        let message = client.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+        client.send(test_peers_message.clone()).await.unwrap();
+
+        // Test message 3
+        client.send(test_peers_message.clone()).await.unwrap();
     });
 
     server_thread.await.unwrap();

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -1,0 +1,105 @@
+use super::tools::get_keys;
+use crate::BootstrapSettings;
+use crate::{
+    tests::tools::get_bootstrap_config, BootstrapClientBinder, BootstrapMessage, BootstrapPeers,
+    BootstrapServerBinder,
+};
+use massa_signature::PrivateKey;
+use serial_test::serial;
+use tokio::io::duplex;
+
+lazy_static::lazy_static! {
+    pub static ref BOOTSTRAP_SETTINGS_PRIVATE_KEY: (BootstrapSettings, PrivateKey) = {
+        let (private_key, public_key) = get_keys();
+        (get_bootstrap_config(public_key), private_key)
+    };
+}
+
+#[tokio::test]
+#[serial]
+async fn test_binders() {
+    let (bootstrap_settings, server_private_key): &(BootstrapSettings, PrivateKey) =
+        &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
+
+    let (client, server) = duplex(1000000);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key);
+    let mut client = BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1);
+
+    let server_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+
+        server.handshake().await.unwrap();
+        server.send(test_peers_message.clone()).await.unwrap();
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+
+        let message = server.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+
+        // Test message 3
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+
+        server.send(test_peers_message.clone()).await.unwrap();
+    });
+
+    let client_thread = tokio::spawn(async move {
+        // Test message 1
+        let vector_peers = vec![bootstrap_settings.bootstrap_list[0].0.ip()];
+
+        client.handshake().await.unwrap();
+        let message = client.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+
+        // Test message 2
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let test_peers_message = BootstrapMessage::BootstrapPeers {
+            peers: BootstrapPeers(vector_peers.clone()),
+        };
+        client.send(test_peers_message.clone()).await.unwrap();
+
+        // Test message 3
+        let vector_peers = vec![
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+            bootstrap_settings.bootstrap_list[0].0.ip(),
+        ];
+        let message = client.next().await.unwrap();
+        match message {
+            BootstrapMessage::BootstrapPeers { peers } => {
+                assert_eq!(vector_peers, peers.0);
+            }
+            _ => panic!("Bad message receive: Expected a peers list message"),
+        }
+    });
+
+    server_thread.await.unwrap();
+    client_thread.await.unwrap();
+}

--- a/massa-bootstrap/src/tests/mod.rs
+++ b/massa-bootstrap/src/tests/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
+mod binders;
 pub mod mock_establisher;
 mod scenarios;
 pub mod tools;

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -132,6 +132,8 @@ pub fn get_bootstrap_config(bootstrap_public_key: PublicKey) -> BootstrapSetting
         max_ping: MassaTime::from(500),
         read_timeout: 1000.into(),
         write_timeout: 1000.into(),
+        read_error_timeout: 200.into(),
+        write_error_timeout: 200.into(),
         bootstrap_list: vec![(SocketAddr::new(BASE_BOOTSTRAP_IP, 16), bootstrap_public_key)],
         enable_clock_synchronization: true,
         cache_duration: 10000.into(),

--- a/massa-final-state/Cargo.toml
+++ b/massa-final-state/Cargo.toml
@@ -19,4 +19,4 @@ massa_async_pool = { path = "../massa-async-pool", features=["testing"] }
 
 # for more information on what are the following features used for, see the cargo.toml at workspace level
 [features]
-testing = []
+testing = ["massa_ledger/testing", "massa_async_pool/testing"]

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -174,6 +174,10 @@
     read_timeout = 10000
     # timeout for message sending
     write_timeout = 10000
+    # timeout for incoming error message readout
+    read_error_timeout = 200
+    # timeout for message error sending
+    write_error_timeout = 200
     # when enabled, apply a correction to the local computer clock to match bootstrap server time
     enable_clock_synchronization = false
     # [server] data is cached for cache duration milliseconds


### PR DESCRIPTION
Part of #2577 

The goal of this PR is to be able to send data through the client and receive in the server.

The client do not have a private key so he can't sign his messages but he need to send the signature of the previous message he received.

The server need to make a signature of the message he received and save it to put it has the previous signature of his new message.

Multiple tests has been added.