### PR TITLE
increase cursor delay

### DIFF
--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -21,7 +21,7 @@
     readonly_queue_length = 10
     # by how many milliseconds shoud the execution lag behind real time
     # higher values increase speculative execution lag but improve performance
-    cursor_delay = 0
+    cursor_delay = 2000
 
 [ledger]
     # path to the initial smart contract balance ledger


### PR DESCRIPTION
Increase execution cursor delay from 0 to 2000 milliseconds to reduce CPU usage