### PR TITLE
Include a speed limit in network module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-speed-limit"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "481ce9cb6a828f4679495f7376cb6779978d925dd9790b99b48d1bbde6d0f00b"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-timer",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +927,12 @@ name = "futures-task"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1826,6 +1844,7 @@ dependencies = [
 name = "massa_network_worker"
 version = "0.1.0"
 dependencies = [
+ "async-speed-limit",
  "enum-map",
  "futures 0.3.21",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,13 +83,13 @@ dependencies = [
 [[package]]
 name = "async-speed-limit"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481ce9cb6a828f4679495f7376cb6779978d925dd9790b99b48d1bbde6d0f00b"
+source = "git+https://github.com/adrien-zinger/async-speed-limit?rev=36d79e0#36d79e063144cf0cdfc258c9e127c84f10a53b57"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-timer",
  "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1587,6 +1587,7 @@ dependencies = [
 name = "massa_bootstrap"
 version = "0.1.0"
 dependencies = [
+ "async-speed-limit",
  "bitvec",
  "displaydoc",
  "futures 0.3.21",

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-speed-limit = { git = "https://github.com/adrien-zinger/async-speed-limit", rev = "36d79e0", features = ["default", "tokio"] }
 displaydoc = "0.2"
 futures = "0.3"
 num_enum = "0.5"
@@ -62,3 +63,4 @@ testing = [
     "massa_async_pool/testing",
 ]
 sandbox = ["massa_async_pool/sandbox", "massa_final_state/sandbox"]
+

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -1,5 +1,6 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
+use async_speed_limit::Limiter;
 use massa_final_state::FinalState;
 use massa_ledger_exports::get_address_from_key;
 use massa_logging::massa_trace;
@@ -329,7 +330,8 @@ async fn connect_to_server(
     let mut connector = establisher
         .get_connector(bootstrap_settings.connect_timeout)
         .await?; // cancellable
-    let socket = connector.connect(*addr).await?; // cancellable
+    let socket = <Limiter>::new(bootstrap_settings.max_bit_read_write.into())
+        .limit(connector.connect(*addr).await?); // cancellable
     Ok(BootstrapClientBinder::new(socket, *pub_key))
 }
 

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -1,6 +1,5 @@
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
-use async_speed_limit::Limiter;
 use massa_final_state::FinalState;
 use massa_ledger_exports::get_address_from_key;
 use massa_logging::massa_trace;
@@ -330,9 +329,12 @@ async fn connect_to_server(
     let mut connector = establisher
         .get_connector(bootstrap_settings.connect_timeout)
         .await?; // cancellable
-    let socket = <Limiter>::new(bootstrap_settings.max_bit_read_write.into())
-        .limit(connector.connect(*addr).await?); // cancellable
-    Ok(BootstrapClientBinder::new(socket, *pub_key))
+    let socket = connector.connect(*addr).await?; // cancellable
+    Ok(BootstrapClientBinder::new(
+        socket,
+        *pub_key,
+        bootstrap_settings.max_bytes_read_write,
+    ))
 }
 
 /// Gets the state from a bootstrap server

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -35,7 +35,8 @@ impl BootstrapClientBinder {
     ///
     /// # Argument
     /// * duplex: duplex stream.
-    pub fn new(duplex: Duplex, remote_pubkey: PublicKey, max_bytes_read_write: u32) -> Self {
+    /// * limit: limit max bytes per second (up and down)
+    pub fn new(duplex: Duplex, remote_pubkey: PublicKey, limit: f64) -> Self {
         let max_bootstrap_message_size =
             with_serialization_context(|context| context.max_bootstrap_message_size);
         let size_field_len = u32::be_bytes_min_length(max_bootstrap_message_size);
@@ -43,7 +44,7 @@ impl BootstrapClientBinder {
             max_bootstrap_message_size,
             size_field_len,
             remote_pubkey,
-            duplex: <Limiter>::new(max_bytes_read_write.into()).limit(duplex),
+            duplex: <Limiter>::new(limit).limit(duplex),
             prev_message: None,
             version_serializer: VersionSerializer::new(),
         }

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -6,6 +6,8 @@ use crate::messages::{
     BootstrapClientMessage, BootstrapClientMessageSerializer, BootstrapServerMessage,
     BootstrapServerMessageDeserializer,
 };
+use async_speed_limit::clock::StandardClock;
+use async_speed_limit::Resource;
 use massa_hash::{Hash, HASH_SIZE_BYTES};
 use massa_models::Version;
 use massa_models::{
@@ -23,7 +25,7 @@ pub struct BootstrapClientBinder {
     max_bootstrap_message_size: u32,
     size_field_len: usize,
     remote_pubkey: PublicKey,
-    duplex: Duplex,
+    duplex: Resource<Duplex, StandardClock>,
     prev_message: Option<Hash>,
     version_serializer: VersionSerializer,
 }
@@ -33,7 +35,7 @@ impl BootstrapClientBinder {
     ///
     /// # Argument
     /// * duplex: duplex stream.
-    pub fn new(duplex: Duplex, remote_pubkey: PublicKey) -> Self {
+    pub fn new(duplex: Resource<Duplex, StandardClock>, remote_pubkey: PublicKey) -> Self {
         let max_bootstrap_message_size =
             with_serialization_context(|context| context.max_bootstrap_message_size);
         let size_field_len = u32::be_bytes_min_length(max_bootstrap_message_size);

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -5,7 +5,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use async_speed_limit::Limiter;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use massa_async_pool::AsyncMessageId;
@@ -155,8 +154,6 @@ impl BootstrapServer {
                 Ok((dplx, remote_addr)) = listener.accept() => {
 
                     // limit communication bandwidth
-                    let dplx = <Limiter>::new(self.bootstrap_settings.max_bit_read_write.into()).limit(dplx);
-
                     if bootstrap_sessions.len() < self.bootstrap_settings.max_simultaneous_bootstraps.try_into().map_err(|_| BootstrapError::GeneralError("Fail to convert u32 to usize".to_string()))? {
                         massa_trace!("bootstrap.lib.run.select.accept", {"remote_addr": remote_addr});
                         let now = Instant::now();
@@ -175,7 +172,7 @@ impl BootstrapServer {
                         match self.ip_hist_map.entry(remote_addr.ip()) {
                             hash_map::Entry::Occupied(mut occ) => {
                                 if now.duration_since(*occ.get()) <= per_ip_min_interval {
-                                    let mut server = BootstrapServerBinder::new(dplx, self.private_key);
+                                    let mut server = BootstrapServerBinder::new(dplx, self.private_key, self.bootstrap_settings.max_bit_read_write);
                                     let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
                                         error:
                                         format!("Your last bootstrap on this server was {:#?} ago and you have to wait {:#?} before retrying.", occ.get().elapsed(), per_ip_min_interval.saturating_sub(occ.get().elapsed()))
@@ -220,7 +217,7 @@ impl BootstrapServer {
                         bootstrap_sessions.push(async move {
                             //Socket lifetime
                             {
-                                let mut server = BootstrapServerBinder::new(dplx, private_key);
+                                let mut server = BootstrapServerBinder::new(dplx, private_key, self.bootstrap_settings.max_bit_read_write);
                                 match manage_bootstrap(self.bootstrap_settings, &mut server, data_pos, data_graph, data_peers, data_execution, compensation_millis, version).await {
                                     Ok(_) => info!("bootstrapped peer {}", remote_addr),
                                     Err(BootstrapError::ReceivedError(error)) => debug!("bootstrap serving error received from peer {}: {}", remote_addr, error),
@@ -234,7 +231,7 @@ impl BootstrapServer {
                         });
                         massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});
                     } else {
-                        let mut server = BootstrapServerBinder::new(dplx, self.private_key);
+                        let mut server = BootstrapServerBinder::new(dplx, self.private_key, self.bootstrap_settings.max_bit_read_write);
                         let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
                             error: "Bootstrap failed because the bootstrap server currently has no slots available.".to_string()
                         })).await {

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -5,6 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use async_speed_limit::Limiter;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use massa_async_pool::AsyncMessageId;
@@ -151,92 +152,98 @@ impl BootstrapServer {
                 }
 
                 // listener
-                Ok((dplx, remote_addr)) = listener.accept() => if bootstrap_sessions.len() < self.bootstrap_settings.max_simultaneous_bootstraps.try_into().map_err(|_| BootstrapError::GeneralError("Fail to convert u32 to usize".to_string()))? {
-                    massa_trace!("bootstrap.lib.run.select.accept", {"remote_addr": remote_addr});
-                    let now = Instant::now();
+                Ok((dplx, remote_addr)) = listener.accept() => {
 
-                    // clear IP history if necessary
-                    if self.ip_hist_map.len() > self.bootstrap_settings.ip_list_max_size {
-                        self.ip_hist_map.retain(|_k, v| now.duration_since(*v) <= per_ip_min_interval);
+                    // limit communication bandwidth
+                    let dplx = <Limiter>::new(self.bootstrap_settings.max_bit_read_write.into()).limit(dplx);
+
+                    if bootstrap_sessions.len() < self.bootstrap_settings.max_simultaneous_bootstraps.try_into().map_err(|_| BootstrapError::GeneralError("Fail to convert u32 to usize".to_string()))? {
+                        massa_trace!("bootstrap.lib.run.select.accept", {"remote_addr": remote_addr});
+                        let now = Instant::now();
+
+                        // clear IP history if necessary
                         if self.ip_hist_map.len() > self.bootstrap_settings.ip_list_max_size {
-                            // too many IPs are spamming us: clear cache
-                            warn!("high bootstrap load: at least {} different IPs attempted bootstrap in the last {}ms", self.ip_hist_map.len(), self.bootstrap_settings.per_ip_min_interval);
-                            self.ip_hist_map.clear();
-                        }
-                    }
-
-                    // check IP's bootstrap attempt history
-                    match self.ip_hist_map.entry(remote_addr.ip()) {
-                        hash_map::Entry::Occupied(mut occ) => {
-                            if now.duration_since(*occ.get()) <= per_ip_min_interval {
-                                let mut server = BootstrapServerBinder::new(dplx, self.private_key);
-                                let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
-                                    error:
-                                    format!("Your last bootstrap on this server was {:#?} ago and you have to wait {:#?} before retrying.", occ.get().elapsed(), per_ip_min_interval.saturating_sub(occ.get().elapsed()))
-                                })).await {
-                                    Err(_) => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "bootstrap error no available slots send timed out").into()),
-                                    Ok(Err(e)) => Err(e),
-                                    Ok(Ok(_)) => Ok(()),
-                                };
-                                // in list, non-expired => refuse
-                                massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {"remote_addr": remote_addr});
-                                continue;
-                            } else {
-                                // in list, expired
-                                occ.insert(now);
-                            }
-                        },
-                        hash_map::Entry::Vacant(vac) => {
-                            vac.insert(now);
-                        }
-                    }
-
-                    // load cache if absent
-                    if bootstrap_data.is_none() {
-                        massa_trace!("bootstrap.lib.run.select.accept.cache_load.start", {});
-
-                        // Note that all requests are done simultaneously except for the consensus graph that is done after the others.
-                        // This is done to ensure that the execution bootstrap state is older than the consensus state.
-                        // If the consensus state snapshot is older than the execution state snapshot,
-                        //   the execution final ledger will be in the future after bootstrap, which causes an inconsistency.
-                        let peer_boot = self.network_command_sender.get_bootstrap_peers().await?;
-                        let (pos_boot, graph_boot) = self.consensus_command_sender.get_bootstrap_state().await?;
-                        bootstrap_data = Some((pos_boot, graph_boot, peer_boot, self.final_state.clone()));
-                        cache_timer.set(sleep(cache_timeout));
-                    }
-                    massa_trace!("bootstrap.lib.run.select.accept.cache_available", {});
-
-                    // launch bootstrap
-                    let private_key = self.private_key;
-                    let compensation_millis = self.compensation_millis;
-                    let version = self.version;
-                    let (data_pos, data_graph, data_peers, data_execution) = bootstrap_data.clone().unwrap(); // will not panic (checked above)
-                    bootstrap_sessions.push(async move {
-                        //Socket lifetime
-                        {
-                            let mut server = BootstrapServerBinder::new(dplx, private_key);
-                            match manage_bootstrap(self.bootstrap_settings, &mut server, data_pos, data_graph, data_peers, data_execution, compensation_millis, version).await {
-                                Ok(_) => info!("bootstrapped peer {}", remote_addr),
-                                Err(BootstrapError::ReceivedError(error)) => debug!("bootstrap serving error received from peer {}: {}", remote_addr, error),
-                                Err(err) => {
-                                    debug!("bootstrap serving error for peer {}: {}", remote_addr, err);
-                                    // We allow unused result because we don't care if an error is thrown when sending the error message to the server we will close the socket anyway.
-                                    let _ = tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError { error: err.to_string() })).await;
-                                },
+                            self.ip_hist_map.retain(|_k, v| now.duration_since(*v) <= per_ip_min_interval);
+                            if self.ip_hist_map.len() > self.bootstrap_settings.ip_list_max_size {
+                                // too many IPs are spamming us: clear cache
+                                warn!("high bootstrap load: at least {} different IPs attempted bootstrap in the last {}ms", self.ip_hist_map.len(), self.bootstrap_settings.per_ip_min_interval);
+                                self.ip_hist_map.clear();
                             }
                         }
-                    });
-                    massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});
-                } else {
-                    let mut server = BootstrapServerBinder::new(dplx, self.private_key);
-                    let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
-                        error: "Bootstrap failed because the bootstrap server currently has no slots available.".to_string()
-                    })).await {
-                        Err(_) => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "bootstrap error no available slots send timed out").into()),
-                        Ok(Err(e)) => Err(e),
-                        Ok(Ok(_)) => Ok(()),
-                    };
-                    debug!("did not bootstrap {}: no available slots", remote_addr);
+
+                        // check IP's bootstrap attempt history
+                        match self.ip_hist_map.entry(remote_addr.ip()) {
+                            hash_map::Entry::Occupied(mut occ) => {
+                                if now.duration_since(*occ.get()) <= per_ip_min_interval {
+                                    let mut server = BootstrapServerBinder::new(dplx, self.private_key);
+                                    let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
+                                        error:
+                                        format!("Your last bootstrap on this server was {:#?} ago and you have to wait {:#?} before retrying.", occ.get().elapsed(), per_ip_min_interval.saturating_sub(occ.get().elapsed()))
+                                    })).await {
+                                        Err(_) => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "bootstrap error no available slots send timed out").into()),
+                                        Ok(Err(e)) => Err(e),
+                                        Ok(Ok(_)) => Ok(()),
+                                    };
+                                    // in list, non-expired => refuse
+                                    massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {"remote_addr": remote_addr});
+                                    continue;
+                                } else {
+                                    // in list, expired
+                                    occ.insert(now);
+                                }
+                            },
+                            hash_map::Entry::Vacant(vac) => {
+                                vac.insert(now);
+                            }
+                        }
+
+                        // load cache if absent
+                        if bootstrap_data.is_none() {
+                            massa_trace!("bootstrap.lib.run.select.accept.cache_load.start", {});
+
+                            // Note that all requests are done simultaneously except for the consensus graph that is done after the others.
+                            // This is done to ensure that the execution bootstrap state is older than the consensus state.
+                            // If the consensus state snapshot is older than the execution state snapshot,
+                            //   the execution final ledger will be in the future after bootstrap, which causes an inconsistency.
+                            let peer_boot = self.network_command_sender.get_bootstrap_peers().await?;
+                            let (pos_boot, graph_boot) = self.consensus_command_sender.get_bootstrap_state().await?;
+                            bootstrap_data = Some((pos_boot, graph_boot, peer_boot, self.final_state.clone()));
+                            cache_timer.set(sleep(cache_timeout));
+                        }
+                        massa_trace!("bootstrap.lib.run.select.accept.cache_available", {});
+
+                        // launch bootstrap
+                        let private_key = self.private_key;
+                        let compensation_millis = self.compensation_millis;
+                        let version = self.version;
+                        let (data_pos, data_graph, data_peers, data_execution) = bootstrap_data.clone().unwrap(); // will not panic (checked above)
+                        bootstrap_sessions.push(async move {
+                            //Socket lifetime
+                            {
+                                let mut server = BootstrapServerBinder::new(dplx, private_key);
+                                match manage_bootstrap(self.bootstrap_settings, &mut server, data_pos, data_graph, data_peers, data_execution, compensation_millis, version).await {
+                                    Ok(_) => info!("bootstrapped peer {}", remote_addr),
+                                    Err(BootstrapError::ReceivedError(error)) => debug!("bootstrap serving error received from peer {}: {}", remote_addr, error),
+                                    Err(err) => {
+                                        debug!("bootstrap serving error for peer {}: {}", remote_addr, err);
+                                        // We allow unused result because we don't care if an error is thrown when sending the error message to the server we will close the socket anyway.
+                                        let _ = tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError { error: err.to_string() })).await;
+                                    },
+                                }
+                            }
+                        });
+                        massa_trace!("bootstrap.session.started", {"active_count": bootstrap_sessions.len()});
+                    } else {
+                        let mut server = BootstrapServerBinder::new(dplx, self.private_key);
+                        let _ = match tokio::time::timeout(self.bootstrap_settings.write_error_timeout.into(), server.send(BootstrapServerMessage::BootstrapError {
+                            error: "Bootstrap failed because the bootstrap server currently has no slots available.".to_string()
+                        })).await {
+                            Err(_) => Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "bootstrap error no available slots send timed out").into()),
+                            Ok(Err(e)) => Err(e),
+                            Ok(Ok(_)) => Ok(()),
+                        };
+                        debug!("did not bootstrap {}: no available slots", remote_addr);
+                    }
                 }
             }
         }

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -6,6 +6,8 @@ use crate::messages::{
     BootstrapClientMessage, BootstrapClientMessageDeserializer, BootstrapServerMessage,
     BootstrapServerMessageSerializer,
 };
+use async_speed_limit::clock::StandardClock;
+use async_speed_limit::Resource;
 use massa_hash::Hash;
 use massa_hash::HASH_SIZE_BYTES;
 use massa_models::Version;
@@ -25,7 +27,7 @@ pub struct BootstrapServerBinder {
     max_bootstrap_message_size: u32,
     size_field_len: usize,
     local_privkey: PrivateKey,
-    duplex: Duplex,
+    duplex: Resource<Duplex, StandardClock>,
     prev_message: Option<Hash>,
     version_serializer: VersionSerializer,
     version_deserializer: VersionDeserializer,
@@ -36,7 +38,7 @@ impl BootstrapServerBinder {
     ///
     /// # Argument
     /// * duplex: duplex stream.
-    pub fn new(duplex: Duplex, local_privkey: PrivateKey) -> Self {
+    pub fn new(duplex: Resource<Duplex, StandardClock>, local_privkey: PrivateKey) -> Self {
         let max_bootstrap_message_size =
             with_serialization_context(|context| context.max_bootstrap_message_size);
         let size_field_len = u32::be_bytes_min_length(max_bootstrap_message_size);

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -38,7 +38,9 @@ impl BootstrapServerBinder {
     ///
     /// # Argument
     /// * duplex: duplex stream.
-    pub fn new(duplex: Duplex, local_privkey: PrivateKey, limit: u32) -> Self {
+    /// * local_privkey: local node user private key
+    /// * limit: limit max bytes per second (up and down)
+    pub fn new(duplex: Duplex, local_privkey: PrivateKey, limit: f64) -> Self {
         let max_bootstrap_message_size =
             with_serialization_context(|context| context.max_bootstrap_message_size);
         let size_field_len = u32::be_bytes_min_length(max_bootstrap_message_size);
@@ -46,7 +48,7 @@ impl BootstrapServerBinder {
             max_bootstrap_message_size,
             size_field_len,
             local_privkey,
-            duplex: <Limiter>::new(limit.into()).limit(duplex),
+            duplex: <Limiter>::new(limit).limit(duplex),
             prev_message: None,
             version_serializer: VersionSerializer::new(),
             version_deserializer: VersionDeserializer::new(),

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -38,5 +38,5 @@ pub struct BootstrapSettings {
     /// Max size of the IP list
     pub ip_list_max_size: usize,
     /// Read-Write limitation for a connection in bytes per seconds
-    pub max_bit_read_write: u32,
+    pub max_bytes_read_write: u32,
 }

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -38,5 +38,5 @@ pub struct BootstrapSettings {
     /// Max size of the IP list
     pub ip_list_max_size: usize,
     /// Read-Write limitation for a connection in bytes per seconds
-    pub max_bytes_read_write: u32,
+    pub max_bytes_read_write: f64,
 }

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -37,4 +37,6 @@ pub struct BootstrapSettings {
     pub per_ip_min_interval: MassaTime,
     /// Max size of the IP list
     pub ip_list_max_size: usize,
+    /// Read-Write limitation for a connection in bit by 0.100 milliseconds
+    pub max_bit_read_write: u32,
 }

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -37,6 +37,6 @@ pub struct BootstrapSettings {
     pub per_ip_min_interval: MassaTime,
     /// Max size of the IP list
     pub ip_list_max_size: usize,
-    /// Read-Write limitation for a connection in bit by 0.100 milliseconds
+    /// Read-Write limitation for a connection in bytes per seconds
     pub max_bit_read_write: u32,
 }

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -7,16 +7,32 @@ use crate::{
     client_binder::BootstrapClientBinder, server_binder::BootstrapServerBinder,
     tests::tools::get_bootstrap_config, BootstrapPeers,
 };
+use async_speed_limit::clock::StandardClock;
+use async_speed_limit::{Limiter, Resource};
 use massa_models::Version;
 use massa_signature::PrivateKey;
 use serial_test::serial;
-use tokio::io::duplex;
+use tokio::io::DuplexStream;
 
 lazy_static::lazy_static! {
     pub static ref BOOTSTRAP_SETTINGS_PRIVATE_KEY: (BootstrapSettings, PrivateKey) = {
         let (private_key, public_key) = get_keys();
         (get_bootstrap_config(public_key), private_key)
     };
+}
+
+// Wrap tokio io duplex around a async-speed-limit's `Resource`
+fn duplex(
+    max_buf_size: usize,
+) -> (
+    Resource<DuplexStream, StandardClock>,
+    Resource<DuplexStream, StandardClock>,
+) {
+    let (client, server) = tokio::io::duplex(max_buf_size);
+    (
+        <Limiter>::new(std::f64::INFINITY).limit(client),
+        <Limiter>::new(std::f64::INFINITY).limit(server),
+    )
 }
 
 /// The server and the client will handshake and then send message in both ways in order

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -26,9 +26,12 @@ async fn test_binders() {
     let (bootstrap_settings, server_private_key): &(BootstrapSettings, PrivateKey) =
         &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
     let (client, server) = duplex(1000000);
-    let mut server = BootstrapServerBinder::new(server, *server_private_key, u32::MAX);
-    let mut client =
-        BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1, u32::MAX);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key, f64::INFINITY);
+    let mut client = BootstrapClientBinder::new(
+        client,
+        bootstrap_settings.bootstrap_list[0].1,
+        f64::INFINITY,
+    );
 
     let server_thread = tokio::spawn(async move {
         // Test message 1
@@ -112,9 +115,12 @@ async fn test_binders_double_send_server_works() {
         &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
 
     let (client, server) = duplex(1000000);
-    let mut server = BootstrapServerBinder::new(server, *server_private_key, u32::MAX);
-    let mut client =
-        BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1, u32::MAX);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key, f64::INFINITY);
+    let mut client = BootstrapClientBinder::new(
+        client,
+        bootstrap_settings.bootstrap_list[0].1,
+        f64::INFINITY,
+    );
 
     let server_thread = tokio::spawn(async move {
         // Test message 1
@@ -183,9 +189,12 @@ async fn test_binders_try_double_send_client_works() {
         &BOOTSTRAP_SETTINGS_PRIVATE_KEY;
 
     let (client, server) = duplex(1000000);
-    let mut server = BootstrapServerBinder::new(server, *server_private_key, u32::MAX);
-    let mut client =
-        BootstrapClientBinder::new(client, bootstrap_settings.bootstrap_list[0].1, u32::MAX);
+    let mut server = BootstrapServerBinder::new(server, *server_private_key, f64::INFINITY);
+    let mut client = BootstrapClientBinder::new(
+        client,
+        bootstrap_settings.bootstrap_list[0].1,
+        f64::INFINITY,
+    );
 
     let server_thread = tokio::spawn(async move {
         // Test message 1

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -154,7 +154,7 @@ pub fn get_bootstrap_config(bootstrap_public_key: PublicKey) -> BootstrapSetting
         max_simultaneous_bootstraps: 2,
         ip_list_max_size: 10,
         per_ip_min_interval: 10000.into(),
-        max_bit_read_write: std::u32::MAX,
+        max_bytes_read_write: std::u32::MAX,
     }
 }
 

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -154,7 +154,7 @@ pub fn get_bootstrap_config(bootstrap_public_key: PublicKey) -> BootstrapSetting
         max_simultaneous_bootstraps: 2,
         ip_list_max_size: 10,
         per_ip_min_interval: 10000.into(),
-        max_bytes_read_write: std::u32::MAX,
+        max_bytes_read_write: std::f64::INFINITY,
     }
 }
 

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -154,6 +154,7 @@ pub fn get_bootstrap_config(bootstrap_public_key: PublicKey) -> BootstrapSetting
         max_simultaneous_bootstraps: 2,
         ip_list_max_size: 10,
         per_ip_min_interval: 10000.into(),
+        max_bit_read_write: std::u32::MAX,
     }
 }
 

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -52,6 +52,10 @@ pub struct NetworkSettings {
     pub max_in_connection_overflow: usize,
     /// Max operations per message in the network to avoid sending to big data packet.
     pub max_operations_per_message: u32,
+    /// Read limitation for a connection in bit by 0.100 milliseconds
+    pub max_bit_read: u32,
+    /// Write limitation for a connection in bit by 0.100 milliseconds
+    pub max_bit_write: u32,
 }
 
 /// Connection configuration for a peer type
@@ -118,6 +122,8 @@ pub mod tests {
                 max_in_connection_overflow: 2,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
+                max_bit_read: std::u32::MAX,
+                max_bit_write: std::u32::MAX,
             }
         }
     }
@@ -175,6 +181,8 @@ pub mod tests {
                 max_in_connection_overflow: 10,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
+                max_bit_read: std::u32::MAX,
+                max_bit_write: std::u32::MAX,
             }
         }
     }

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -53,9 +53,9 @@ pub struct NetworkSettings {
     /// Max operations per message in the network to avoid sending to big data packet.
     pub max_operations_per_message: u32,
     /// Read limitation for a connection in bytes per seconds
-    pub max_bytes_read: u32,
+    pub max_bytes_read: f64,
     /// Write limitation for a connection in bytes per seconds
-    pub max_bytes_write: u32,
+    pub max_bytes_write: f64,
 }
 
 /// Connection configuration for a peer type
@@ -122,8 +122,8 @@ pub mod tests {
                 max_in_connection_overflow: 2,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bytes_read: std::u32::MAX,
-                max_bytes_write: std::u32::MAX,
+                max_bytes_read: std::f64::INFINITY,
+                max_bytes_write: std::f64::INFINITY,
             }
         }
     }
@@ -181,8 +181,8 @@ pub mod tests {
                 max_in_connection_overflow: 10,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bytes_read: std::u32::MAX,
-                max_bytes_write: std::u32::MAX,
+                max_bytes_read: std::f64::INFINITY,
+                max_bytes_write: std::f64::INFINITY,
             }
         }
     }

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -122,8 +122,8 @@ pub mod tests {
                 max_in_connection_overflow: 2,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bit_read: std::u32::MAX,
-                max_bit_write: std::u32::MAX,
+                max_bit_read: std::u64::MAX,
+                max_bit_write: std::u64::MAX,
             }
         }
     }
@@ -181,8 +181,8 @@ pub mod tests {
                 max_in_connection_overflow: 10,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bit_read: std::u32::MAX,
-                max_bit_write: std::u32::MAX,
+                max_bit_read: std::u64::MAX,
+                max_bit_write: std::u64::MAX,
             }
         }
     }

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -53,9 +53,9 @@ pub struct NetworkSettings {
     /// Max operations per message in the network to avoid sending to big data packet.
     pub max_operations_per_message: u32,
     /// Read limitation for a connection in bytes per seconds
-    pub max_bit_read: u32,
+    pub max_bytes_read: u32,
     /// Write limitation for a connection in bytes per seconds
-    pub max_bit_write: u32,
+    pub max_bytes_write: u32,
 }
 
 /// Connection configuration for a peer type
@@ -122,8 +122,8 @@ pub mod tests {
                 max_in_connection_overflow: 2,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bit_read: std::u64::MAX,
-                max_bit_write: std::u64::MAX,
+                max_bytes_read: std::u32::MAX,
+                max_bytes_write: std::u32::MAX,
             }
         }
     }
@@ -181,8 +181,8 @@ pub mod tests {
                 max_in_connection_overflow: 10,
                 peer_types_config,
                 max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
-                max_bit_read: std::u64::MAX,
-                max_bit_write: std::u64::MAX,
+                max_bytes_read: std::u32::MAX,
+                max_bytes_write: std::u32::MAX,
             }
         }
     }

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -52,9 +52,9 @@ pub struct NetworkSettings {
     pub max_in_connection_overflow: usize,
     /// Max operations per message in the network to avoid sending to big data packet.
     pub max_operations_per_message: u32,
-    /// Read limitation for a connection in bit by 0.100 milliseconds
+    /// Read limitation for a connection in bytes per seconds
     pub max_bit_read: u32,
-    /// Write limitation for a connection in bit by 0.100 milliseconds
+    /// Write limitation for a connection in bytes per seconds
     pub max_bit_write: u32,
 }
 

--- a/massa-network-worker/Cargo.toml
+++ b/massa-network-worker/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-speed-limit = "0.4.0"
 enum-map = { version = "2.0.3", features = ["serde"] }
 futures = "0.3"
 itertools = "0.10"

--- a/massa-network-worker/Cargo.toml
+++ b/massa-network-worker/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-speed-limit = "0.4.0"
+async-speed-limit = { git = "https://github.com/adrien-zinger/async-speed-limit", rev = "36d79e0", features = ["default", "tokio"] }
 enum-map = { version = "2.0.3", features = ["serde"] }
 futures = "0.3"
 itertools = "0.10"

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -21,9 +21,10 @@ impl WriteBinder {
     ///
     /// # Argument
     /// * `write_half`: writer half.
-    pub fn new(write_half: WriteHalf, limit: u32) -> Self {
+    /// * `limit`: limit max bytes per second write
+    pub fn new(write_half: WriteHalf, limit: f64) -> Self {
         WriteBinder {
-            write_half: <Limiter>::new(limit.into()).limit(write_half),
+            write_half: <Limiter>::new(limit).limit(write_half),
             message_index: 0,
         }
     }
@@ -70,9 +71,10 @@ impl ReadBinder {
     ///
     /// # Argument
     /// * `read_half`: reader half.
-    pub fn new(read_half: ReadHalf, limit: u32) -> Self {
+    /// * `limit`: limit max bytes per second read.
+    pub fn new(read_half: ReadHalf, limit: f64) -> Self {
         ReadBinder {
-            read_half: <Limiter>::new(limit.into()).limit(read_half),
+            read_half: <Limiter>::new(limit).limit(read_half),
             message_index: 0,
             buf: Vec::new(),
             cursor: 0,

--- a/massa-network-worker/src/handshake_worker.rs
+++ b/massa-network-worker/src/handshake_worker.rs
@@ -66,8 +66,8 @@ impl HandshakeWorker {
         timeout_duration: MassaTime,
         version: Version,
         connection_id: ConnectionId,
-        max_bit_read: u32,
-        max_bit_write: u32,
+        max_bytes_read: u32,
+        max_bytes_write: u32,
     ) -> JoinHandle<(ConnectionId, HandshakeReturnType)> {
         debug!("starting handshake with connection_id={}", connection_id);
         massa_trace!("network_worker.new_connection", {
@@ -79,8 +79,8 @@ impl HandshakeWorker {
             (
                 connection_id_copy,
                 HandshakeWorker {
-                    reader: ReadBinder::new(socket_reader, max_bit_read),
-                    writer: WriteBinder::new(socket_writer, max_bit_write),
+                    reader: ReadBinder::new(socket_reader, max_bytes_read),
+                    writer: WriteBinder::new(socket_writer, max_bytes_write),
                     self_node_id,
                     private_key,
                     timeout_duration,

--- a/massa-network-worker/src/handshake_worker.rs
+++ b/massa-network-worker/src/handshake_worker.rs
@@ -66,8 +66,8 @@ impl HandshakeWorker {
         timeout_duration: MassaTime,
         version: Version,
         connection_id: ConnectionId,
-        max_bytes_read: u32,
-        max_bytes_write: u32,
+        max_bytes_read: f64,
+        max_bytes_write: f64,
     ) -> JoinHandle<(ConnectionId, HandshakeReturnType)> {
         debug!("starting handshake with connection_id={}", connection_id);
         massa_trace!("network_worker.new_connection", {

--- a/massa-network-worker/src/handshake_worker.rs
+++ b/massa-network-worker/src/handshake_worker.rs
@@ -6,6 +6,7 @@ use super::{
     binders::{ReadBinder, WriteBinder},
     messages::Message,
 };
+use async_speed_limit::{clock::StandardClock, Resource};
 use futures::future::try_join;
 use massa_hash::Hash;
 use massa_logging::massa_trace;
@@ -58,8 +59,8 @@ impl HandshakeWorker {
     /// * `connection_id`: Node we are trying to connect for debugging
     /// * `version`: Node version used in handshake initialization (check peers compatibility)
     pub fn spawn(
-        socket_reader: ReadHalf,
-        socket_writer: WriteHalf,
+        socket_reader: Resource<ReadHalf, StandardClock>,
+        socket_writer: Resource<WriteHalf, StandardClock>,
         self_node_id: NodeId,
         private_key: PrivateKey,
         timeout_duration: MassaTime,

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -577,9 +577,8 @@ impl NetworkWorker {
                     .peer_info_db
                     .try_out_connection_attempt_success(&ip_addr)?
                 {
-                    let limiter = <Limiter>::new(1024.0);
-                    let reader = limiter.clone().limit(reader);
-                    let writer = limiter.limit(writer);
+                    let reader = <Limiter>::new(self.cfg.max_bit_read.into()).limit(reader);
+                    let writer = <Limiter>::new(self.cfg.max_bit_write.into()).limit(writer);
                     // outgoing connection established
                     let connection_id = *cur_connection_id;
                     debug!(
@@ -634,9 +633,8 @@ impl NetworkWorker {
     ) -> Result<(), NetworkError> {
         match res {
             Ok((reader, writer, remote_addr)) => {
-                let limiter = <Limiter>::new(1024.0);
-                let reader = limiter.clone().limit(reader);
-                let writer = limiter.limit(writer);
+                let reader = <Limiter>::new(self.cfg.max_bit_read.into()).limit(reader);
+                let writer = <Limiter>::new(self.cfg.max_bit_write.into()).limit(writer);
                 match self.peer_info_db.try_new_in_connection(&remote_addr.ip()) {
                     Ok(_) => {
                         let connection_id = *cur_connection_id;

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -702,12 +702,12 @@ impl NetworkWorker {
         if self.cfg.max_in_connection_overflow > self.handshake_peer_list_futures.len() {
             let msg = Message::PeerList(self.peer_info_db.get_advertisable_peer_ips());
             let timeout = self.cfg.peer_list_send_timeout.to_duration();
-            let max_bit_read = self.cfg.max_bit_read;
-            let max_bit_write = self.cfg.max_bit_write;
+            let max_bytes_read = self.cfg.max_bytes_read;
+            let max_bytes_write = self.cfg.max_bytes_write;
             self.handshake_peer_list_futures
                 .push(tokio::spawn(async move {
-                    let mut writer = WriteBinder::new(writer, max_bit_read);
-                    let mut reader = ReadBinder::new(reader, max_bit_write);
+                    let mut writer = WriteBinder::new(writer, max_bytes_read);
+                    let mut reader = ReadBinder::new(reader, max_bytes_write);
                     match tokio::time::timeout(
                         timeout,
                         futures::future::try_join(
@@ -754,8 +754,8 @@ impl NetworkWorker {
             self.cfg.connect_timeout,
             self.version,
             connection_id,
-            self.cfg.max_bit_read,
-            self.cfg.max_bit_write,
+            self.cfg.max_bytes_read,
+            self.cfg.max_bytes_write,
         ));
         Ok(())
     }

--- a/massa-network-worker/src/tests/scenarios.rs
+++ b/massa-network-worker/src/tests/scenarios.rs
@@ -67,8 +67,8 @@ async fn test_node_worker_shutdown() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
-    let reader = ReadBinder::new(duplex_mock_read, u32::MAX);
-    let writer = WriteBinder::new(duplex_mock_write, u32::MAX);
+    let reader = ReadBinder::new(duplex_mock_read, f64::INFINITY);
+    let writer = WriteBinder::new(duplex_mock_write, f64::INFINITY);
 
     // Note: both channels have size 1.
     let (node_command_tx, node_command_rx) = mpsc::channel::<NodeCommand>(1);
@@ -123,8 +123,8 @@ async fn test_node_worker_operations_message() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
-    let reader = ReadBinder::new(duplex_mock_read, u32::MAX);
-    let writer = WriteBinder::new(duplex_mock_write, u32::MAX);
+    let reader = ReadBinder::new(duplex_mock_read, f64::INFINITY);
+    let writer = WriteBinder::new(duplex_mock_write, f64::INFINITY);
 
     // Note: both channels have size 1.
     let (node_command_tx, node_command_rx) = mpsc::channel::<NodeCommand>(1);

--- a/massa-network-worker/src/tests/scenarios.rs
+++ b/massa-network-worker/src/tests/scenarios.rs
@@ -68,9 +68,8 @@ async fn test_node_worker_shutdown() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
-    let limiter = <Limiter>::new(1024.0);
-    let duplex_mock_read = limiter.clone().limit(duplex_mock_read);
-    let duplex_mock_write = limiter.limit(duplex_mock_write);
+    let duplex_mock_read = <Limiter>::new(std::f64::INFINITY).limit(duplex_mock_read);
+    let duplex_mock_write = <Limiter>::new(std::f64::INFINITY).limit(duplex_mock_write);
     let reader = ReadBinder::new(duplex_mock_read);
     let writer = WriteBinder::new(duplex_mock_write);
 

--- a/massa-network-worker/src/tests/scenarios.rs
+++ b/massa-network-worker/src/tests/scenarios.rs
@@ -11,6 +11,7 @@ use crate::{
     binders::{ReadBinder, WriteBinder},
     NetworkSettings,
 };
+use async_speed_limit::Limiter;
 use enum_map::enum_map;
 use enum_map::EnumMap;
 use massa_hash::Hash;
@@ -67,6 +68,9 @@ async fn test_node_worker_shutdown() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
+    let limiter = <Limiter>::new(1024.0);
+    let duplex_mock_read = limiter.clone().limit(duplex_mock_read);
+    let duplex_mock_write = limiter.limit(duplex_mock_write);
     let reader = ReadBinder::new(duplex_mock_read);
     let writer = WriteBinder::new(duplex_mock_write);
 

--- a/massa-network-worker/src/tests/scenarios.rs
+++ b/massa-network-worker/src/tests/scenarios.rs
@@ -11,7 +11,6 @@ use crate::{
     binders::{ReadBinder, WriteBinder},
     NetworkSettings,
 };
-use async_speed_limit::Limiter;
 use enum_map::enum_map;
 use enum_map::EnumMap;
 use massa_hash::Hash;
@@ -68,10 +67,8 @@ async fn test_node_worker_shutdown() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
-    let duplex_mock_read = <Limiter>::new(std::f64::INFINITY).limit(duplex_mock_read);
-    let duplex_mock_write = <Limiter>::new(std::f64::INFINITY).limit(duplex_mock_write);
-    let reader = ReadBinder::new(duplex_mock_read);
-    let writer = WriteBinder::new(duplex_mock_write);
+    let reader = ReadBinder::new(duplex_mock_read, u32::MAX);
+    let writer = WriteBinder::new(duplex_mock_write, u32::MAX);
 
     // Note: both channels have size 1.
     let (node_command_tx, node_command_rx) = mpsc::channel::<NodeCommand>(1);
@@ -126,8 +123,8 @@ async fn test_node_worker_operations_message() {
     let network_conf = NetworkSettings::scenarios_default(bind_port, temp_peers_file.path());
     let (duplex_controller, _duplex_mock) = tokio::io::duplex(1);
     let (duplex_mock_read, duplex_mock_write) = tokio::io::split(duplex_controller);
-    let reader = ReadBinder::new(duplex_mock_read);
-    let writer = WriteBinder::new(duplex_mock_write);
+    let reader = ReadBinder::new(duplex_mock_read, u32::MAX);
+    let writer = WriteBinder::new(duplex_mock_write, u32::MAX);
 
     // Note: both channels have size 1.
     let (node_command_tx, node_command_rx) = mpsc::channel::<NodeCommand>(1);

--- a/massa-network-worker/src/tests/tools.rs
+++ b/massa-network-worker/src/tests/tools.rs
@@ -83,9 +83,8 @@ pub async fn full_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let limiter = <Limiter>::new(1024.0);
-    let mock_read_half = limiter.clone().limit(mock_read_half);
-    let mock_write_half = limiter.limit(mock_write_half);
+    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
+    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -144,10 +143,8 @@ pub async fn rejected_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let limiter = <Limiter>::new(1024.0);
-    let mock_read_half = limiter.clone().limit(mock_read_half);
-    let mock_write_half = limiter.limit(mock_write_half);
-
+    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
+    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let result = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -232,10 +229,8 @@ pub async fn full_connection_from_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let limiter = <Limiter>::new(1024.0);
-    let mock_read_half = limiter.clone().limit(mock_read_half);
-    let mock_write_half = limiter.limit(mock_write_half);
-
+    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
+    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,

--- a/massa-network-worker/src/tests/tools.rs
+++ b/massa-network-worker/src/tests/tools.rs
@@ -9,7 +9,6 @@ use crate::NetworkError;
 use crate::NetworkEvent;
 use crate::NetworkSettings;
 
-use async_speed_limit::Limiter;
 use massa_hash::Hash;
 use massa_models::node::NodeId;
 use massa_models::signed::Signed;
@@ -83,8 +82,6 @@ pub async fn full_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
-    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -93,6 +90,8 @@ pub async fn full_connection_to_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
+        u32::MAX,
+        u32::MAX,
     )
     .await
     .expect("handshake creation failed")
@@ -143,8 +142,6 @@ pub async fn rejected_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
-    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let result = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -153,6 +150,8 @@ pub async fn rejected_connection_to_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
+        u32::MAX,
+        u32::MAX,
     )
     .await
     .expect("handshake creation failed")
@@ -229,8 +228,6 @@ pub async fn full_connection_from_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
-    let mock_read_half = <Limiter>::new(std::f64::INFINITY).limit(mock_read_half);
-    let mock_write_half = <Limiter>::new(std::f64::INFINITY).limit(mock_write_half);
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -239,6 +236,8 @@ pub async fn full_connection_from_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
+        u32::MAX,
+        u32::MAX,
     )
     .await
     .expect("handshake creation failed")

--- a/massa-network-worker/src/tests/tools.rs
+++ b/massa-network-worker/src/tests/tools.rs
@@ -90,8 +90,8 @@ pub async fn full_connection_to_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
-        u32::MAX,
-        u32::MAX,
+        f64::INFINITY,
+        f64::INFINITY,
     )
     .await
     .expect("handshake creation failed")
@@ -150,8 +150,8 @@ pub async fn rejected_connection_to_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
-        u32::MAX,
-        u32::MAX,
+        f64::INFINITY,
+        f64::INFINITY,
     )
     .await
     .expect("handshake creation failed")
@@ -236,8 +236,8 @@ pub async fn full_connection_from_controller(
         rw_timeout_ms.into(),
         Version::from_str("TEST.1.2").unwrap(),
         connection_id,
-        u32::MAX,
-        u32::MAX,
+        f64::INFINITY,
+        f64::INFINITY,
     )
     .await
     .expect("handshake creation failed")

--- a/massa-network-worker/src/tests/tools.rs
+++ b/massa-network-worker/src/tests/tools.rs
@@ -9,6 +9,7 @@ use crate::NetworkError;
 use crate::NetworkEvent;
 use crate::NetworkSettings;
 
+use async_speed_limit::Limiter;
 use massa_hash::Hash;
 use massa_models::node::NodeId;
 use massa_models::signed::Signed;
@@ -82,6 +83,9 @@ pub async fn full_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
+    let limiter = <Limiter>::new(1024.0);
+    let mock_read_half = limiter.clone().limit(mock_read_half);
+    let mock_write_half = limiter.limit(mock_write_half);
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,
@@ -140,6 +144,9 @@ pub async fn rejected_connection_to_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
+    let limiter = <Limiter>::new(1024.0);
+    let mock_read_half = limiter.clone().limit(mock_read_half);
+    let mock_write_half = limiter.limit(mock_write_half);
 
     let result = HandshakeWorker::spawn(
         mock_read_half,
@@ -225,6 +232,10 @@ pub async fn full_connection_from_controller(
     let private_key = generate_random_private_key();
     let public_key = derive_public_key(&private_key);
     let mock_node_id = NodeId(public_key);
+    let limiter = <Limiter>::new(1024.0);
+    let mock_read_half = limiter.clone().limit(mock_read_half);
+    let mock_write_half = limiter.limit(mock_write_half);
+
     let res = HandshakeWorker::spawn(
         mock_read_half,
         mock_write_half,

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -157,9 +157,9 @@
     # that send a list of peers
     max_in_connection_overflow = 100
     # Read limitation for a connection in bytes per seconds
-    max_bit_read = 5_000_000
+    max_bytes_read = 5_000_000
     # Write limitation for a connection in bytes per seconds
-    max_bit_write = 5_000_000
+    max_bytes_write = 5_000_000
 
     [network.peer_types_config]
     Standard = { target_out_connections = 10, max_out_attempts = 10, max_in_connections = 15}
@@ -205,7 +205,7 @@
     # refuse consecutive bootstrap attempts from a given IP when the interval between them is lower than per_ip_min_interval milliseconds
     per_ip_min_interval = 180000
     # Read-Write limitation for a connection in bytes per seconds (about the bootstrap specifically)
-    max_bit_read_write = 5_000_000
+    max_bytes_read_write = 5_000_000
 
 [pool]
     # max number of operations kept per thread

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -157,9 +157,9 @@
     # that send a list of peers
     max_in_connection_overflow = 100
     # Read limitation for a connection in bit by 0.100 milliseconds
-    max_bit_read = 1_000_000_000
+    max_bit_read = 40_000_000
     # Write limitation for a connection in bit by 0.100 milliseconds
-    max_bit_write = 1_000_000_000
+    max_bit_write = 72_000_000
 
     [network.peer_types_config]
     Standard = { target_out_connections = 10, max_out_attempts = 10, max_in_connections = 15}
@@ -205,7 +205,7 @@
     # refuse consecutive bootstrap attempts from a given IP when the interval between them is lower than per_ip_min_interval milliseconds
     per_ip_min_interval = 180000
     # Read-Write limitation for a connection in bit by 0.100 milliseconds (about the bootstrap specifically)
-    max_bit_read_write = 1_000_000_000
+    max_bit_read_write = 1_600_000
 
 [pool]
     # max number of operations kept per thread

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -157,9 +157,9 @@
     # that send a list of peers
     max_in_connection_overflow = 100
     # Read limitation for a connection in bytes per seconds
-    max_bytes_read = 5_000_000
+    max_bytes_read = 20_000_000.0
     # Write limitation for a connection in bytes per seconds
-    max_bytes_write = 5_000_000
+    max_bytes_write = 20_000_000.0
 
     [network.peer_types_config]
     Standard = { target_out_connections = 10, max_out_attempts = 10, max_in_connections = 15}
@@ -205,7 +205,7 @@
     # refuse consecutive bootstrap attempts from a given IP when the interval between them is lower than per_ip_min_interval milliseconds
     per_ip_min_interval = 180000
     # Read-Write limitation for a connection in bytes per seconds (about the bootstrap specifically)
-    max_bytes_read_write = 5_000_000
+    max_bytes_read_write = 20_000_000.0
 
 [pool]
     # max number of operations kept per thread

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -156,10 +156,10 @@
     # Max number of in connection overflowed managed by the handshake
     # that send a list of peers
     max_in_connection_overflow = 100
-    # Read limitation for a connection in bit by 0.100 milliseconds
-    max_bit_read = 40_000_000
-    # Write limitation for a connection in bit by 0.100 milliseconds
-    max_bit_write = 72_000_000
+    # Read limitation for a connection in bytes per seconds
+    max_bit_read = 5_000_000
+    # Write limitation for a connection in bytes per seconds
+    max_bit_write = 5_000_000
 
     [network.peer_types_config]
     Standard = { target_out_connections = 10, max_out_attempts = 10, max_in_connections = 15}
@@ -204,8 +204,8 @@
     ip_list_max_size = 10000
     # refuse consecutive bootstrap attempts from a given IP when the interval between them is lower than per_ip_min_interval milliseconds
     per_ip_min_interval = 180000
-    # Read-Write limitation for a connection in bit by 0.100 milliseconds (about the bootstrap specifically)
-    max_bit_read_write = 1_600_000
+    # Read-Write limitation for a connection in bytes per seconds (about the bootstrap specifically)
+    max_bit_read_write = 5_000_000
 
 [pool]
     # max number of operations kept per thread

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -101,7 +101,7 @@
     max_node_known_endorsements_size = 1024
     # Maximum number of batches in the memory buffer.
     # Dismiss the new batches if overflow
-    operation_batch_buffer_capacity = 10024 
+    operation_batch_buffer_capacity = 10024
     # Start processing batches in the buffer each `operation_batch_proc_period` in millisecond
     operation_batch_proc_period = 500
     # All operations asked are prune each `operation_asked_pruning_period` millisecond
@@ -156,6 +156,10 @@
     # Max number of in connection overflowed managed by the handshake
     # that send a list of peers
     max_in_connection_overflow = 100
+    # Read limitation for a connection in bit by 0.100 milliseconds
+    max_bit_read = 1_000_000_000
+    # Write limitation for a connection in bit by 0.100 milliseconds
+    max_bit_write = 1_000_000_000
 
     [network.peer_types_config]
     Standard = { target_out_connections = 10, max_out_attempts = 10, max_in_connections = 15}
@@ -200,6 +204,8 @@
     ip_list_max_size = 10000
     # refuse consecutive bootstrap attempts from a given IP when the interval between them is lower than per_ip_min_interval milliseconds
     per_ip_min_interval = 180000
+    # Read-Write limitation for a connection in bit by 0.100 milliseconds (about the bootstrap specifically)
+    max_bit_read_write = 1_000_000_000
 
 [pool]
     # max number of operations kept per thread


### PR DESCRIPTION
This PR is just an example we can apply a QoS strategy in massa (in the network module) with a crate without a big refacto.

The crate I use is [async-speed-limit](https://crates.io/crates/async-speed-limit). This project is interesting and surprisingly small. We can look at how they just wrap tokio [here](https://github.com/tikv/async-speed-limit/blob/36d79e063144cf0cdfc258c9e127c84f10a53b57/src/io.rs#L72-L113) and call the [poll_limited_function](https://github.com/tikv/async-speed-limit/blob/36d79e063144cf0cdfc258c9e127c84f10a53b57/src/limiter.rs#L506-L540).

My first impression is that the crate is an implementation of the Nagle's algorithm. We can easily fork the project and implement our version with another algorithm after a discussion!

TODO:
- [x] use a config or a const parameter for the limitation value
- [x] test in a subproject
- [ ] list other possible algorithms implementation