### PR TITLE
Reduce operation id length in the inter-nodes communications 1/2

### DIFF
--- a/massa-models/src/error.rs
+++ b/massa-models/src/error.rs
@@ -48,6 +48,8 @@ pub enum ModelsError {
     AmountOverflowError,
     /// Wrong prefix for hash: expected {0}, got {1}
     WrongPrefix(String, String),
+    /// Wrong operation id size deduced on join
+    OperationPrefixJoinError,
 }
 
 impl From<nom::Err<nom::error::Error<&[u8]>>> for ModelsError {

--- a/massa-models/src/node_configuration/default.rs
+++ b/massa-models/src/node_configuration/default.rs
@@ -174,6 +174,8 @@ pub const BLOCK_ID_SIZE_BYTES: usize = massa_hash::HASH_SIZE_BYTES;
 pub const ENDORSEMENT_ID_SIZE_BYTES: usize = massa_hash::HASH_SIZE_BYTES;
 /// operation id size
 pub const OPERATION_ID_SIZE_BYTES: usize = massa_hash::HASH_SIZE_BYTES;
+/// operation id prefix size
+pub const OPERATION_ID_PREFIX_SIZE_BYTES: usize = 20;
 /// slot as a key size
 pub const SLOT_KEY_SIZE: usize = 9;
 

--- a/massa-models/src/node_configuration/default_testing.rs
+++ b/massa-models/src/node_configuration/default_testing.rs
@@ -125,6 +125,8 @@ pub const MAX_OPERATIONS_PER_MESSAGE: u32 = 1024;
 pub const NODE_SEND_CHANNEL_SIZE: usize = 1024;
 /// operation id size
 pub const OPERATION_ID_SIZE_BYTES: usize = massa_hash::HASH_SIZE_BYTES;
+/// operation id prefix size
+pub const OPERATION_ID_PREFIX_SIZE_BYTES: usize = 20;
 /// operation validity periods
 pub const OPERATION_VALIDITY_PERIODS: u64 = 1;
 /// periods per cycle

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -27,7 +27,7 @@ const OPERATION_ID_STRING_PREFIX: &str = "OPE";
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct OperationId(Hash);
 
-/// left part of the operation id hash stored in a vector of size [OPERATION_ID_PREFIX_SIZE_BYTES]
+/// Left part of the operation id hash stored in a vector of size [OPERATION_ID_PREFIX_SIZE_BYTES]
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct OperationPrefixId(Vec<u8>);
 
@@ -153,8 +153,7 @@ impl OperationId {
         ))
     }
 
-    /// split into a tuple of [OperationPrefixId] and [OperationSuffixId]
-    ///
+    /// Split into a tuple of [OperationPrefixId] and [OperationSuffixId]
     pub fn split(&self) -> (OperationPrefixId, OperationSuffixId) {
         (
             OperationPrefixId(self.0.to_bytes()[..OPERATION_ID_PREFIX_SIZE_BYTES].to_vec()),
@@ -162,7 +161,7 @@ impl OperationId {
         )
     }
 
-    /// split into a tuple of [OperationPrefixId] and [OperationSuffixId]
+    /// Split into a tuple of [OperationPrefixId] and [OperationSuffixId]
     pub fn into_split(self) -> (OperationPrefixId, OperationSuffixId) {
         self.split()
     }
@@ -182,7 +181,7 @@ impl OperationPrefixId {
         }
         let mut id = self.0.clone();
         id.extend(&suffix.0);
-        // the following code is safe until we correctly check the size in the if
+        // the following code is safe because we correctly check the size in the if
         // guard and return early an error if the transmutation would fail.
         let data: &[u8; OPERATION_ID_SIZE_BYTES] = unsafe { transmute_copy(&id) };
         Ok(OperationId::from_bytes(data))


### PR DESCRIPTION
That PR proposes a first step in order to send only a part of the operation's ids when we declare and ask them in our network.

The modules impacted from that proposal are only `massa-storage` and `massa-models`. It adds a _prefix_ and _suffix_ logic in both.

The `operations` structure is modified as followed in order to retrieve operations from the _operation id truncated hash_. The motivation is mainly to not store the relation `id-trucatedId` in a foreign structure that would have the same time-overhead but a bigger space-overhead. Another good solution to avoid the waste of space would be to use a `BTreeMap` instead in order to iterate through the hashes (theorically :rofl:), but it would probably be slower... I don't know.

```rust
operations: Arc<RwLock<Map<OperationPrefixId, Map<OperationSuffixId, StoredOperation>>>>,
```

Next step: modify protocol and network to apply the solution.

After a little calculation, I found that a foreign relation table to manage in protocol would have another time overhead to regularly prune it and `1.6byte` / entry as space overhead.