### PR TITLE
Reduce operation id length in the inter-nodes communications 2/2 (v2)

### DIFF
--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -70,9 +70,19 @@ impl OperationIdAdapter {
         self.0.get(prefix)
     }
 
-    /// Prune the adapter
-    pub fn prune(&mut self) {
-        todo!()
+    /// Clear the content of the adapter
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    /// Returns the number of prefix keys in the adapter.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns `true` if the adapter contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -14,6 +14,7 @@ use crate::{
 };
 use massa_hash::Hash;
 use massa_signature::{PublicKey, PUBLIC_KEY_SIZE_BYTES};
+use nom::AsBytes;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -61,6 +62,36 @@ impl std::fmt::Debug for OperationId {
             )
         } else {
             write!(f, "{}", self.0.to_bs58_check())
+        }
+    }
+}
+
+impl std::fmt::Display for OperationPrefixId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if cfg!(feature = "hash-prefix") {
+            write!(
+                f,
+                "{}-{}",
+                OPERATION_ID_STRING_PREFIX,
+                bs58::encode(self.0.as_bytes()).into_string()
+            )
+        } else {
+            write!(f, "{}", bs58::encode(self.0.as_bytes()).into_string())
+        }
+    }
+}
+
+impl std::fmt::Debug for OperationPrefixId {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if cfg!(feature = "hash-prefix") {
+            write!(
+                f,
+                "{}-{}",
+                OPERATION_ID_STRING_PREFIX,
+                bs58::encode(self.0.as_bytes()).into_string()
+            )
+        } else {
+            write!(f, "{}", bs58::encode(self.0.as_bytes()).into_string())
         }
     }
 }

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -3,7 +3,7 @@
 use crate::constants::{ADDRESS_SIZE_BYTES, OPERATION_ID_SIZE_BYTES};
 use crate::error::ModelsResult;
 use crate::node_configuration::OPERATION_ID_PREFIX_SIZE_BYTES;
-use crate::prehash::{BuildMap, Map, PreHashed, Set};
+use crate::prehash::{BuildMap, PreHashed, Set};
 use crate::signed::{Id, Signable, Signed};
 use crate::with_serialization_context;
 use crate::{
@@ -17,7 +17,6 @@ use massa_signature::{PublicKey, PUBLIC_KEY_SIZE_BYTES};
 use nom::AsBytes;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::Entry;
 use std::convert::TryInto;
 use std::fmt::Formatter;
 use std::mem::transmute_copy;
@@ -36,55 +35,6 @@ pub struct OperationPrefixId(Vec<u8>);
 /// Right part of the operation id hash, contains the remains of `OperationId - OperationPrefixId`
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct OperationSuffixId(Vec<u8>);
-
-/// Manage the relation between [OperationPrefixId] and [OperationId]
-///
-/// note: we could think about replace `Vec<OperationId>` with `Vec<OperationSuffixId>`
-///       if the execution time CPU is equivalent
-#[derive(Default)]
-pub struct OperationIdAdapter(Map<OperationPrefixId, OperationIds>);
-
-impl OperationIdAdapter {
-    /// Insert in the adapter an operation id
-    pub fn insert(&mut self, id: &OperationId) {
-        let prefix = id.split().0;
-        match self.0.entry(prefix) {
-            Entry::Occupied(mut e) => {
-                e.get_mut().insert(*id);
-            }
-            Entry::Vacant(e) => {
-                let mut ids = OperationIds::default();
-                ids.insert(*id);
-                e.insert(ids);
-            }
-        }
-    }
-
-    /// Check if prefix id is in the adapter
-    pub fn contains(&self, prefix: &OperationPrefixId) -> bool {
-        self.0.contains_key(prefix)
-    }
-
-    /// Get a set of [OperationIds] matching with the givec `prefix`
-    pub fn get(&self, prefix: &OperationPrefixId) -> Option<&OperationIds> {
-        self.0.get(prefix)
-    }
-
-    /// Clear the content of the adapter
-    pub fn clear(&mut self) {
-        self.0.clear()
-    }
-
-    /// Returns the number of prefix keys in the adapter.
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    /// Returns `true` if the adapter contains no elements.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
 
 impl std::fmt::Display for OperationId {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/massa-network-exports/src/commands.rs
+++ b/massa-network-exports/src/commands.rs
@@ -73,7 +73,7 @@ use crate::{BootstrapPeers, ConnectionClosureReason, Peers};
 use massa_models::{
     composite::PubkeySig,
     node::NodeId,
-    operation::{OperationIds, Operations},
+    operation::{OperationIds, OperationPrefixIds, Operations},
     stats::NetworkStats,
     Block, BlockId, SignedEndorsement, SignedHeader,
 };
@@ -98,9 +98,9 @@ pub enum NodeCommand {
     /// Send full Operations (send to a node that previously asked for)
     SendOperations(OperationIds),
     /// Send a batch of operation ids
-    SendOperationAnnouncements(OperationIds),
+    SendOperationAnnouncements(OperationPrefixIds),
     /// Ask for a set of operations
-    AskForOperations(OperationIds),
+    AskForOperations(OperationPrefixIds),
     /// Endorsements
     SendEndorsements(Vec<SignedEndorsement>),
 }
@@ -125,9 +125,9 @@ pub enum NodeEventType {
     /// Received full operations.
     ReceivedOperations(Operations, Vec<Vec<u8>>),
     /// Received an operation id batch announcing new operations
-    ReceivedOperationAnnouncements(OperationIds),
+    ReceivedOperationAnnouncements(OperationPrefixIds),
     /// Receive a list of wanted operations
-    ReceivedAskForOperations(OperationIds),
+    ReceivedAskForOperations(OperationPrefixIds),
     /// Receive a set of endorsement
     ReceivedEndorsements(Vec<SignedEndorsement>),
 }
@@ -210,14 +210,14 @@ pub enum NetworkCommand {
         /// to node id
         to_node: NodeId,
         /// batch of operation ids
-        batch: OperationIds,
+        batch: OperationPrefixIds,
     },
     /// Ask for operation
     AskForOperations {
         /// to node id
         to_node: NodeId,
         /// operation ids in the wish list
-        wishlist: OperationIds,
+        wishlist: OperationPrefixIds,
     },
     /// Whitelist a list of `IpAddr`
     Whitelist(Vec<IpAddr>),
@@ -275,15 +275,15 @@ pub enum NetworkEvent {
     ReceivedOperationAnnouncements {
         /// from node id
         node: NodeId,
-        /// operation ids
-        operation_ids: OperationIds,
+        /// operation prefix ids
+        operation_prefix_ids: OperationPrefixIds,
     },
     /// Receive a list of asked operations from `node`
     ReceiveAskForOperations {
         /// from node id
         node: NodeId,
-        /// operation ids
-        operation_ids: OperationIds,
+        /// operation prefix ids
+        operation_prefix_ids: OperationPrefixIds,
     },
     /// received endorsements from node
     ReceivedEndorsements {

--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -5,8 +5,11 @@ use crate::{
     NetworkEvent, Peers,
 };
 use massa_models::{
-    composite::PubkeySig, node::NodeId, operation::OperationIds, stats::NetworkStats, BlockId,
-    SignedEndorsement,
+    composite::PubkeySig,
+    node::NodeId,
+    operation::{OperationIds, OperationPrefixIds},
+    stats::NetworkStats,
+    BlockId, SignedEndorsement,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -200,7 +203,7 @@ impl NetworkCommandSender {
     pub async fn send_operations_batch(
         &self,
         to_node: NodeId,
-        batch: OperationIds,
+        batch: OperationPrefixIds,
     ) -> Result<(), NetworkError> {
         self.0
             .send(NetworkCommand::SendOperationAnnouncements { to_node, batch })
@@ -222,7 +225,7 @@ impl NetworkCommandSender {
     pub async fn send_ask_for_operations(
         &self,
         to_node: NodeId,
-        wishlist: OperationIds,
+        wishlist: OperationPrefixIds,
     ) -> Result<(), NetworkError> {
         self.0
             .send(NetworkCommand::AskForOperations { to_node, wishlist })

--- a/massa-network-worker/src/messages.rs
+++ b/massa-network-worker/src/messages.rs
@@ -3,7 +3,7 @@
 use massa_models::{
     array_from_slice,
     constants::{BLOCK_ID_SIZE_BYTES, HANDSHAKE_RANDOMNESS_SIZE_BYTES},
-    operation::{OperationIds, Operations},
+    operation::{OperationPrefixIds, Operations},
     signed::Signed,
     with_serialization_context, Block, BlockHeader, BlockId, DeserializeCompact, DeserializeVarInt,
     Endorsement, EndorsementId, IpAddrDeserializer, IpAddrSerializer, ModelsError,
@@ -50,9 +50,9 @@ pub enum Message {
     /// Block not found
     BlockNotFound(BlockId),
     /// Batch of operation ids
-    OperationsAnnouncement(OperationIds),
+    OperationsAnnouncement(OperationPrefixIds),
     /// Someone ask for operations.
-    AskForOperations(OperationIds),
+    AskForOperations(OperationPrefixIds),
     /// A list of operations
     Operations(Operations),
     /// Endorsements
@@ -322,14 +322,16 @@ impl DeserializeCompact for Message {
                 Message::Operations(operations)
             }
             MessageTypeId::AskForOperations => {
-                let (operation_ids, delta) = OperationIds::from_bytes_compact(&buffer[cursor..])?;
+                let (operation_prefix_ids, delta) =
+                    OperationPrefixIds::from_bytes_compact(&buffer[cursor..])?;
                 cursor += delta;
-                Message::AskForOperations(operation_ids)
+                Message::AskForOperations(operation_prefix_ids)
             }
             MessageTypeId::OperationsAnnouncement => {
-                let (operation_ids, delta) = OperationIds::from_bytes_compact(&buffer[cursor..])?;
+                let (operation_prefix_ids, delta) =
+                    OperationPrefixIds::from_bytes_compact(&buffer[cursor..])?;
                 cursor += delta;
-                Message::OperationsAnnouncement(operation_ids)
+                Message::OperationsAnnouncement(operation_prefix_ids)
             }
             MessageTypeId::Endorsements => {
                 // length

--- a/massa-network-worker/src/network_cmd_impl.rs
+++ b/massa-network-worker/src/network_cmd_impl.rs
@@ -24,8 +24,11 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use massa_hash::Hash;
 use massa_logging::massa_trace;
 use massa_models::{
-    composite::PubkeySig, node::NodeId, operation::OperationIds, stats::NetworkStats, BlockId,
-    SignedEndorsement,
+    composite::PubkeySig,
+    node::NodeId,
+    operation::{OperationIds, OperationPrefixIds},
+    stats::NetworkStats,
+    BlockId, SignedEndorsement,
 };
 use massa_network_exports::{
     BootstrapPeers, ConnectionClosureReason, ConnectionId, NetworkError, NodeCommand, Peer, Peers,
@@ -385,7 +388,7 @@ pub async fn on_send_operations_cmd(
 pub async fn on_send_operation_batches_cmd(
     worker: &mut NetworkWorker,
     to_node: NodeId,
-    batch: OperationIds,
+    batch: OperationPrefixIds,
 ) {
     massa_trace!(
         "network_worker.manage_network_command receive NetworkCommand::SendOperationAnnouncements",
@@ -416,7 +419,7 @@ pub async fn on_send_operation_batches_cmd(
 pub async fn on_ask_for_operations_cmd(
     worker: &mut NetworkWorker,
     to_node: NodeId,
-    wishlist: OperationIds,
+    wishlist: OperationPrefixIds,
 ) {
     massa_trace!(
         "network_worker.manage_network_command receive NetworkCommand::SendOperationAnnouncements",

--- a/massa-network-worker/src/network_event.rs
+++ b/massa-network-worker/src/network_event.rs
@@ -79,11 +79,10 @@ impl EventSender {
 pub mod event_impl {
     use crate::network_worker::NetworkWorker;
     use massa_logging::massa_trace;
+    use massa_models::operation::OperationPrefixIds;
     use massa_models::signed::Signable;
     use massa_models::{
-        node::NodeId,
-        operation::{OperationIds, Operations},
-        Block, BlockId, SignedEndorsement, SignedHeader,
+        node::NodeId, operation::Operations, Block, BlockId, SignedEndorsement, SignedHeader,
     };
     use massa_network_exports::NodeCommand;
     use massa_network_exports::{NetworkError, NetworkEvent};
@@ -245,17 +244,17 @@ pub mod event_impl {
     pub async fn on_received_operations_annoncement(
         worker: &mut NetworkWorker,
         from: NodeId,
-        operation_ids: OperationIds,
+        operation_prefix_ids: OperationPrefixIds,
     ) {
         massa_trace!(
             "network_worker.on_node_event receive NetworkEvent::ReceivedOperationAnnouncements",
-            { "operations": operation_ids }
+            { "operations": operation_prefix_ids }
         );
         if let Err(err) = worker
             .event
             .send(NetworkEvent::ReceivedOperationAnnouncements {
                 node: from,
-                operation_ids,
+                operation_prefix_ids,
             })
             .await
         {
@@ -268,17 +267,17 @@ pub mod event_impl {
     pub async fn on_received_ask_for_operations(
         worker: &mut NetworkWorker,
         from: NodeId,
-        operation_ids: OperationIds,
+        operation_prefix_ids: OperationPrefixIds,
     ) {
         massa_trace!(
             "network_worker.on_node_event receive NetworkEvent::ReceiveAskForOperations",
-            { "operations": operation_ids }
+            { "operations": operation_prefix_ids }
         );
         if let Err(err) = worker
             .event
             .send(NetworkEvent::ReceiveAskForOperations {
                 node: from,
-                operation_ids,
+                operation_prefix_ids,
             })
             .await
         {

--- a/massa-network-worker/src/node_worker.rs
+++ b/massa-network-worker/src/node_worker.rs
@@ -337,17 +337,17 @@ impl NodeWorker {
                                 };
                                 self.send_node_event(NodeEvent(self.node_id, NodeEventType::ReceivedOperations(operations, serialized))).await;
                             }
-                            Message::AskForOperations(operation_ids) => {
+                            Message::AskForOperations(operation_prefix_ids) => {
                                 massa_trace!(
                                     "node_worker.run_loop. receive Message::AskForOperations: ",
-                                    {"node": self.node_id, "operation_ids": operation_ids}
+                                    {"node": self.node_id, "operation_ids": operation_prefix_ids}
                                 );
                                 //massa_trace!("node_worker.run_loop. receive Message::AskForOperations", {"node": self.node_id, "operations": operation_ids});
-                                self.send_node_event(NodeEvent(self.node_id, NodeEventType::ReceivedAskForOperations(operation_ids))).await;
+                                self.send_node_event(NodeEvent(self.node_id, NodeEventType::ReceivedAskForOperations(operation_prefix_ids))).await;
                             }
-                            Message::OperationsAnnouncement(operation_ids) => {
-                                massa_trace!("node_worker.run_loop. receive Message::OperationsBatch", {"node": self.node_id, "operation_ids": operation_ids});
-                                self.send_node_event(NodeEvent(self.node_id, NodeEventType::ReceivedOperationAnnouncements(operation_ids))).await;
+                            Message::OperationsAnnouncement(operation_prefix_ids) => {
+                                massa_trace!("node_worker.run_loop. receive Message::OperationsBatch", {"node": self.node_id, "operation_prefix_ids": operation_prefix_ids});
+                                self.send_node_event(NodeEvent(self.node_id, NodeEventType::ReceivedOperationAnnouncements(operation_prefix_ids))).await;
                             }
                             Message::Endorsements(endorsements) => {
                                 massa_trace!("node_worker.run_loop. receive Message::Endorsement", {"node": self.node_id, "endorsements": endorsements});
@@ -420,9 +420,9 @@ impl NodeWorker {
                                 }
                             }
                         },
-                        Some(NodeCommand::SendOperationAnnouncements(operation_ids)) => {
-                            massa_trace!("node_worker.run_loop. send Message::OperationsAnnouncement", {"node": self.node_id, "operation_ids": operation_ids});
-                            for chunk in operation_ids
+                        Some(NodeCommand::SendOperationAnnouncements(operation_prefix_ids)) => {
+                            massa_trace!("node_worker.run_loop. send Message::OperationsAnnouncement", {"node": self.node_id, "operation_ids": operation_prefix_ids});
+                            for chunk in operation_prefix_ids
                             .into_iter()
                             .chunks(self.cfg.max_operations_per_message as usize)
                             .into_iter()
@@ -432,13 +432,13 @@ impl NodeWorker {
                                 }
                             }
                         }
-                        Some(NodeCommand::AskForOperations(operation_ids)) => {
+                        Some(NodeCommand::AskForOperations(operation_prefix_ids)) => {
                             //massa_trace!("node_worker.run_loop. send Message::AskForOperations", {"node": self.node_id, "operation_ids": operation_ids});
                             massa_trace!(
                                 "node_worker.run_loop. send Message::AskForOperations",
-                                {"node": self.node_id, "operation_ids": operation_ids}
+                                {"node": self.node_id, "operation_ids": operation_prefix_ids}
                             );
-                            for chunk in operation_ids
+                            for chunk in operation_prefix_ids
                             .into_iter()
                             .chunks(self.cfg.max_operations_per_message as usize)
                             .into_iter()

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -102,7 +102,7 @@ pub enum ProtocolCommand {
     GetBlocksResults(BlocksResults),
     /// The response to a `[ProtocolEvent::GetOperations]`.
     GetOperationsResults((NodeId, OperationIds)),
-    /// Propagate operations ids (send batches)
+    /// Propagate operations prefix ids (send batches)
     PropagateOperations(OperationIds),
     /// Propagate endorsements
     PropagateEndorsements(Map<EndorsementId, SignedEndorsement>),
@@ -201,7 +201,9 @@ impl ProtocolCommandSender {
             })
     }
 
-    /// Propagate a batch of operation ids from pool.
+    /// Propagate a batch of operation ids (from pool).
+    ///
+    /// note: Full `OperationId` is replaced by a `OperationPrefixId` later by the worker.
     pub async fn propagate_operations(
         &mut self,
         operation_ids: OperationIds,

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -102,7 +102,9 @@ pub enum ProtocolCommand {
     GetBlocksResults(BlocksResults),
     /// The response to a `[ProtocolEvent::GetOperations]`.
     GetOperationsResults((NodeId, OperationIds)),
-    /// Propagate operations prefix ids (send batches)
+    /// Propagate operations (send batches)
+    /// note: OperationIds are replaced with OperationPrefixIds
+    ///       by the controller
     PropagateOperations(OperationIds),
     /// Propagate endorsements
     PropagateEndorsements(Map<EndorsementId, SignedEndorsement>),

--- a/massa-protocol-exports/src/tests/mock_network_controller.rs
+++ b/massa-protocol-exports/src/tests/mock_network_controller.rs
@@ -117,7 +117,7 @@ impl MockNetworkController {
         self.network_event_tx
             .send(NetworkEvent::ReceivedOperationAnnouncements {
                 node: source_node_id,
-                operation_ids,
+                operation_prefix_ids: operation_ids.iter().map(|id| id.split().0).collect(),
             })
             .await
             .expect("Couldn't send operations to protocol.");
@@ -133,7 +133,7 @@ impl MockNetworkController {
         self.network_event_tx
             .send(NetworkEvent::ReceiveAskForOperations {
                 node: source_node_id,
-                operation_ids,
+                operation_prefix_ids: operation_ids.iter().map(|id| id.split().0).collect(),
             })
             .await
             .expect("Couldn't send operations to protocol.");

--- a/massa-protocol-worker/src/checked_operations.rs
+++ b/massa-protocol-worker/src/checked_operations.rs
@@ -5,14 +5,14 @@ use massa_models::{
     prehash::Map,
 };
 
+/// The structure store the previously checked operations.
 /// Manage the relation between [OperationPrefixId] and [OperationId]
-///
 /// note: we could think about replace `Vec<OperationId>` with `Vec<OperationSuffixId>`
 ///       if the execution time CPU is equivalent
 #[derive(Default)]
-pub(crate) struct OperationIdAdapter(Map<OperationPrefixId, OperationIds>);
+pub(crate) struct CheckedOperations(Map<OperationPrefixId, OperationIds>);
 
-impl OperationIdAdapter {
+impl CheckedOperations {
     /// Insert in the adapter an operation `id`.
     ///
     /// If the set did not have this value present, `true` is returned.
@@ -51,14 +51,14 @@ pub(crate) trait Contains<T> {
     fn contains(&self, e: &T) -> bool;
 }
 
-impl Contains<OperationPrefixId> for OperationIdAdapter {
+impl Contains<OperationPrefixId> for CheckedOperations {
     /// Check if prefix id is in the adapter
     fn contains(&self, prefix: &OperationPrefixId) -> bool {
         self.0.contains_key(prefix)
     }
 }
 
-impl Contains<OperationId> for OperationIdAdapter {
+impl Contains<OperationId> for CheckedOperations {
     /// Check if operation id is in the adapter
     fn contains(&self, id: &OperationId) -> bool {
         let prefix = id.split().0;

--- a/massa-protocol-worker/src/lib.rs
+++ b/massa-protocol-worker/src/lib.rs
@@ -12,8 +12,8 @@
 pub mod protocol_worker;
 pub mod worker_operations_impl;
 pub use protocol_worker::start_protocol_controller;
+mod checked_operations;
 mod node_info;
-mod operation_id_adapter;
 
 #[cfg(test)]
 pub mod tests;

--- a/massa-protocol-worker/src/lib.rs
+++ b/massa-protocol-worker/src/lib.rs
@@ -13,6 +13,7 @@ pub mod protocol_worker;
 pub mod worker_operations_impl;
 pub use protocol_worker::start_protocol_controller;
 mod node_info;
+mod operation_id_adapter;
 
 #[cfg(test)]
 pub mod tests;

--- a/massa-protocol-worker/src/operation_id_adapter.rs
+++ b/massa-protocol-worker/src/operation_id_adapter.rs
@@ -1,0 +1,70 @@
+use std::collections::hash_map::Entry;
+
+use massa_models::{
+    operation::{OperationId, OperationIds, OperationPrefixId},
+    prehash::Map,
+};
+
+/// Manage the relation between [OperationPrefixId] and [OperationId]
+///
+/// note: we could think about replace `Vec<OperationId>` with `Vec<OperationSuffixId>`
+///       if the execution time CPU is equivalent
+#[derive(Default)]
+pub(crate) struct OperationIdAdapter(Map<OperationPrefixId, OperationIds>);
+
+impl OperationIdAdapter {
+    /// Insert in the adapter an operation `id`.
+    ///
+    /// If the set did not have this value present, `true` is returned.
+    ///
+    /// If the set did have this value present, `false` is returned.
+    pub fn insert(&mut self, id: &OperationId) -> bool {
+        let prefix = id.split().0;
+        match self.0.entry(prefix) {
+            Entry::Occupied(mut e) => e.get_mut().insert(*id),
+            Entry::Vacant(e) => {
+                let mut ids = OperationIds::default();
+                ids.insert(*id);
+                e.insert(ids);
+                true
+            }
+        }
+    }
+
+    /// Get a set of [OperationIds] matching with the givec `prefix`.
+    pub fn get(&self, prefix: &OperationPrefixId) -> Option<&OperationIds> {
+        self.0.get(prefix)
+    }
+
+    /// Clear the content of the adapter.
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    /// Returns the number of prefix keys in the adapter.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+pub(crate) trait Contains<T> {
+    fn contains(&self, e: &T) -> bool;
+}
+
+impl Contains<OperationPrefixId> for OperationIdAdapter {
+    /// Check if prefix id is in the adapter
+    fn contains(&self, prefix: &OperationPrefixId) -> bool {
+        self.0.contains_key(prefix)
+    }
+}
+
+impl Contains<OperationId> for OperationIdAdapter {
+    /// Check if operation id is in the adapter
+    fn contains(&self, id: &OperationId) -> bool {
+        let prefix = id.split().0;
+        match self.0.get(&prefix) {
+            Some(ids) => ids.contains(id),
+            _ => false,
+        }
+    }
+}

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use crate::operation_id_adapter::OperationIdAdapter;
+use crate::checked_operations::CheckedOperations;
 use crate::{node_info::NodeInfo, worker_operations_impl::OperationBatchBuffer};
 use itertools::Itertools;
 use massa_hash::Hash;
@@ -145,7 +145,7 @@ pub struct ProtocolWorker {
     /// List of processed endorsements
     checked_endorsements: Set<EndorsementId>,
     /// List of processed operations
-    pub(crate) checked_operations: OperationIdAdapter,
+    pub(crate) checked_operations: CheckedOperations,
     /// List of processed headers
     checked_headers: Map<BlockId, BlockInfo>,
     /// List of ids of operations that we asked to the nodes

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -960,6 +960,13 @@ impl ProtocolWorker {
         }
     }
 
+    /// Prune `op_prefix_adapter` if it has grown too large.
+    fn prune_operation_ids_adapter(&mut self) {
+        if self.op_prefix_adapter.len() > self.protocol_settings.max_known_ops_size {
+            self.op_prefix_adapter.clear();
+        }
+    }
+
     /// Prune `checked_headers` if it is too large
     fn prune_checked_headers(&mut self) {
         if self.checked_headers.len() > self.protocol_settings.max_known_blocks_size {
@@ -1156,6 +1163,7 @@ impl ProtocolWorker {
 
             // prune checked operations cache
             self.prune_checked_operations();
+            self.prune_operation_ids_adapter();
         }
 
         Ok((seen_ops, received_ids, has_duplicate_operations, total_gas))

--- a/massa-protocol-worker/src/tests/operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/operations_scenarios.rs
@@ -178,7 +178,7 @@ async fn test_protocol_propagates_operations_to_active_nodes() {
                 {
                     Some(NetworkCommand::SendOperationAnnouncements { to_node, batch }) => {
                         assert_eq!(batch.len(), 1);
-                        assert!(batch.contains(&expected_operation_id));
+                        assert!(batch.contains(&expected_operation_id.split().0));
                         assert_eq!(nodes[1].id, to_node);
                         break;
                     }
@@ -260,7 +260,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
                 {
                     Some(NetworkCommand::SendOperationAnnouncements { to_node, batch }) => {
                         assert_eq!(batch.len(), 1);
-                        assert!(batch.contains(&expected_operation_id));
+                        assert!(batch.contains(&expected_operation_id.split().0));
                         assert_eq!(new_nodes[0].id, to_node);
                         break;
                     }
@@ -669,7 +669,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             {
                 Some(NetworkCommand::SendOperationAnnouncements { to_node, batch }) => {
                     assert_eq!(batch.len(), 1);
-                    assert!(batch.contains(&operation_id_2));
+                    assert!(batch.contains(&operation_id_2.split().0));
                     assert_eq!(nodes[0].id, to_node);
                 }
                 None => panic!("Operation not propagated."),
@@ -798,7 +798,7 @@ async fn test_protocol_ask_operations_on_batch_received() {
             {
                 Some(NetworkCommand::AskForOperations { to_node, wishlist }) => {
                     assert_eq!(wishlist.len(), 1);
-                    assert!(wishlist.contains(&expected_operation_id));
+                    assert!(wishlist.contains(&expected_operation_id.split().0));
                     assert_eq!(to_node, creator_node.id);
                 }
                 _ => panic!("Unexpected or no network command."),

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -10,7 +10,7 @@
 
 use std::collections::VecDeque;
 
-use crate::protocol_worker::ProtocolWorker;
+use crate::{operation_id_adapter::Contains, protocol_worker::ProtocolWorker};
 use massa_logging::massa_trace;
 use massa_models::{
     node::NodeId,
@@ -72,7 +72,7 @@ impl ProtocolWorker {
         let now = Instant::now();
         let mut count_reask = 0;
         for op_id in op_batch {
-            if self.op_prefix_adapter.contains(&op_id) {
+            if self.checked_operations.contains(&op_id) {
                 continue;
             }
             let wish = match self.asked_operations.get_mut(&op_id) {
@@ -209,9 +209,9 @@ impl ProtocolWorker {
     ) -> Result<(), ProtocolError> {
         let mut req_operation_ids = OperationIds::default();
         for prefix in op_pre_ids {
-            if let Some(op_ids) = self.op_prefix_adapter.get(&prefix) {
+            if let Some(op_ids) = self.checked_operations.get(&prefix) {
                 for op_id in op_ids {
-                    if self.checked_operations.get(op_id).is_some() {
+                    if self.checked_operations.contains(op_id) {
                         req_operation_ids.insert(*op_id);
                     }
                 }

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -210,11 +210,7 @@ impl ProtocolWorker {
         let mut req_operation_ids = OperationIds::default();
         for prefix in op_pre_ids {
             if let Some(op_ids) = self.checked_operations.get(&prefix) {
-                for op_id in op_ids {
-                    if self.checked_operations.contains(op_id) {
-                        req_operation_ids.insert(*op_id);
-                    }
-                }
+                req_operation_ids.extend(op_ids);
             }
         }
         self.send_protocol_pool_event(ProtocolPoolEvent::GetOperations((

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -72,7 +72,7 @@ impl ProtocolWorker {
         let now = Instant::now();
         let mut count_reask = 0;
         for op_id in op_batch {
-            if self.op_prefix_adapter.contains_key(&op_id) {
+            if self.op_prefix_adapter.contains(&op_id) {
                 continue;
             }
             let wish = match self.asked_operations.get_mut(&op_id) {

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -10,7 +10,7 @@
 
 use std::collections::VecDeque;
 
-use crate::{operation_id_adapter::Contains, protocol_worker::ProtocolWorker};
+use crate::{checked_operations::Contains, protocol_worker::ProtocolWorker};
 use massa_logging::massa_trace;
 use massa_models::{
     node::NodeId,

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -14,7 +14,7 @@ use crate::protocol_worker::ProtocolWorker;
 use massa_logging::massa_trace;
 use massa_models::{
     node::NodeId,
-    operation::{OperationIds, Operations},
+    operation::{OperationIds, OperationPrefixIds, Operations},
     prehash::BuildMap,
 };
 use massa_network_exports::NetworkError;
@@ -25,14 +25,14 @@ use tracing::warn;
 
 /// Structure containing a Batch of `operation_ids` we would like to ask
 /// to a `node_id` now or later. Mainly used in protocol and translated into
-/// simple combination of a `node_id` and `operations_ids`
+/// simple combination of a `node_id` and `operations_prefix_ids`
 pub struct OperationBatchItem {
     /// last updated at instant
     pub instant: Instant,
     /// node id
     pub node_id: NodeId,
-    /// operation ids
-    pub operations_ids: OperationIds,
+    /// operation prefix ids
+    pub operations_prefix_ids: OperationPrefixIds,
 }
 
 /// Queue containing every `[OperationsBatchItem]` we want to ask now or later.
@@ -61,18 +61,18 @@ impl ProtocolWorker {
     ///```
     pub(crate) async fn on_operations_announcements_received(
         &mut self,
-        op_batch: OperationIds,
+        op_batch: OperationPrefixIds,
         node_id: NodeId,
     ) -> Result<(), ProtocolError> {
         let mut ask_set =
-            OperationIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
+            OperationPrefixIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
         let mut future_set =
-            OperationIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
+            OperationPrefixIds::with_capacity_and_hasher(op_batch.len(), BuildMap::default());
         // exactitude isn't important, we want to have a now for that function call
         let now = Instant::now();
         let mut count_reask = 0;
         for op_id in op_batch {
-            if self.checked_operations.contains(&op_id) {
+            if self.op_prefix_adapter.contains_key(&op_id) {
                 continue;
             }
             let wish = match self.asked_operations.get_mut(&op_id) {
@@ -101,7 +101,7 @@ impl ProtocolWorker {
                     future_set.insert(op_id);
                 }
             } else {
-                ask_set.insert(op_id);
+                ask_set.insert(op_id.clone());
                 self.asked_operations.insert(op_id, (now, vec![node_id]));
             }
         } // EndOf for op_id in op_batch:
@@ -116,7 +116,7 @@ impl ProtocolWorker {
                     .checked_add(self.protocol_settings.operation_batch_proc_period.into())
                     .ok_or(TimeError::TimeOverflowError)?,
                 node_id,
-                operations_ids: future_set,
+                operations_prefix_ids: future_set,
             });
         }
         if !ask_set.is_empty() {
@@ -179,7 +179,7 @@ impl ProtocolWorker {
         {
             let op_batch_item = self.op_batch_buffer.pop_front().unwrap();
             self.on_operations_announcements_received(
-                op_batch_item.operations_ids,
+                op_batch_item.operations_prefix_ids,
                 op_batch_item.node_id,
             )
             .await?;
@@ -198,23 +198,30 @@ impl ProtocolWorker {
     }
 
     /// Process the reception of a batch of asked operations, that means that
-    /// we sent already a batch of ids in the network notifying that we already
+    /// we have already sent a batch of ids in the network, notifying that we already
     /// have those operations. Ask pool for the operations.
     ///
     /// See also `on_operation_results_from_pool`
     pub(crate) async fn on_asked_operations_received(
         &mut self,
         node_id: NodeId,
-        op_ids: OperationIds,
+        op_pre_ids: OperationPrefixIds,
     ) -> Result<(), ProtocolError> {
-        let mut operation_ids = OperationIds::default();
-        for op_id in op_ids.iter() {
-            if self.checked_operations.get(op_id).is_some() {
-                operation_ids.insert(*op_id);
+        let mut req_operation_ids = OperationIds::default();
+        for prefix in op_pre_ids {
+            if let Some(op_ids) = self.op_prefix_adapter.get(&prefix) {
+                for op_id in op_ids {
+                    if self.checked_operations.get(op_id).is_some() {
+                        req_operation_ids.insert(*op_id);
+                    }
+                }
             }
         }
-        self.send_protocol_pool_event(ProtocolPoolEvent::GetOperations((node_id, operation_ids)))
-            .await;
+        self.send_protocol_pool_event(ProtocolPoolEvent::GetOperations((
+            node_id,
+            req_operation_ids,
+        )))
+        .await;
         Ok(())
     }
 


### PR DESCRIPTION
Implement in the network module the usage of the `OperationPrefixIds` for the announcement process.

Linked issues: https://github.com/massalabs/massa/issues/2584, #2647
WARNING: note the comment https://github.com/massalabs/massa/issues/2584#issuecomment-1159640929

