### PR TITLE
Change format input operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "bs58",
  "console",
  "dialoguer",
  "erased-serde",
@@ -1598,6 +1599,7 @@ dependencies = [
 name = "massa_api"
 version = "0.1.0"
 dependencies = [
+ "bs58",
  "displaydoc",
  "futures 0.3.21",
  "jsonrpc-core",
@@ -1610,6 +1612,7 @@ dependencies = [
  "massa_models",
  "massa_network_exports",
  "massa_pool",
+ "massa_serialization",
  "massa_signature",
  "massa_time",
  "serde 1.0.136",

--- a/docs/technical-doc/api.rst
+++ b/docs/technical-doc/api.rst
@@ -443,8 +443,19 @@ pool.
 .. code-block:: javascript
 
     [[
+        {
+            "serialized_content": String,
+            "creator_public_key": String,
+            "signature": String
+        }
+    ]]
+
+The `serialized_content` parameter contains all the content encoded in byte compact (see https://github.com/massalabs/massa/blob/main/massa-models/src/operation.rs#L185) base58 encoded.
+Here is an example of the content format :
+
+.. code-block:: javascript
+
     {
-        "content": {
         "expire_period": Number,
         "fee": String, // represent an Amount in coins
         "op": {
@@ -478,11 +489,9 @@ pool.
                 "gas_price": Number, // Amount
             }
         },
-        "sender_public_key": String
-        },
-        "signature": String
     }
-    ]]
+
+For the signature you need to use the bytes of the public_key and content in byte compact concatenated and sign it with blake3.
 
 -   Return:
 

--- a/massa-api/Cargo.toml
+++ b/massa-api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bs58 = { version = "0.4", features = ["check"] }
 displaydoc = "0.2"
 futures = "0.3"
 jsonrpc-core = "18.0"
@@ -23,6 +24,7 @@ massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }
 massa_network_exports = { path = "../massa-network-exports" }
 massa_pool = { path = "../massa-pool" }
+massa_serialization = { path = "../massa-serialization"}
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
 

--- a/massa-api/src/lib.rs
+++ b/massa-api/src/lib.rs
@@ -12,8 +12,8 @@ use massa_consensus_exports::{ConsensusCommandSender, ConsensusConfig};
 use massa_execution_exports::ExecutionController;
 use massa_models::api::{
     AddressInfo, BlockInfo, BlockSummary, DatastoreEntryInput, DatastoreEntryOutput,
-    EndorsementInfo, EventFilter, NodeStatus, OperationInfo, ReadOnlyBytecodeExecution,
-    ReadOnlyCall, TimeInterval,
+    EndorsementInfo, EventFilter, NodeStatus, OperationInfo, OperationInput,
+    ReadOnlyBytecodeExecution, ReadOnlyCall, TimeInterval,
 };
 use massa_models::clique::Clique;
 use massa_models::composite::PubkeySig;
@@ -22,7 +22,7 @@ use massa_models::node::NodeId;
 use massa_models::operation::OperationId;
 use massa_models::output_event::SCOutputEvent;
 use massa_models::prehash::Set;
-use massa_models::{Address, BlockId, EndorsementId, Version, WrappedOperation};
+use massa_models::{Address, BlockId, EndorsementId, Version};
 use massa_network_exports::{NetworkCommandSender, NetworkSettings};
 use massa_pool::PoolCommandSender;
 use massa_signature::PrivateKey;
@@ -247,7 +247,7 @@ pub trait Endpoints {
     #[rpc(name = "send_operations")]
     fn send_operations(
         &self,
-        _: Vec<WrappedOperation>,
+        _: Vec<OperationInput>,
     ) -> BoxFuture<Result<Vec<OperationId>, ApiError>>;
 
     /// Get events optionally filtered by:

--- a/massa-api/src/private.rs
+++ b/massa-api/src/private.rs
@@ -9,8 +9,8 @@ use massa_consensus_exports::{ConsensusCommandSender, ConsensusConfig};
 use massa_execution_exports::ExecutionController;
 use massa_models::api::{
     AddressInfo, BlockInfo, BlockSummary, DatastoreEntryInput, DatastoreEntryOutput,
-    EndorsementInfo, EventFilter, NodeStatus, OperationInfo, ReadOnlyBytecodeExecution,
-    ReadOnlyCall, TimeInterval,
+    EndorsementInfo, EventFilter, NodeStatus, OperationInfo, OperationInput,
+    ReadOnlyBytecodeExecution, ReadOnlyCall, TimeInterval,
 };
 use massa_models::clique::Clique;
 use massa_models::composite::PubkeySig;
@@ -18,7 +18,7 @@ use massa_models::execution::ExecuteReadOnlyResponse;
 use massa_models::node::NodeId;
 use massa_models::output_event::SCOutputEvent;
 use massa_models::prehash::Set;
-use massa_models::{Address, BlockId, EndorsementId, OperationId, WrappedOperation};
+use massa_models::{Address, BlockId, EndorsementId, OperationId};
 use massa_network_exports::NetworkCommandSender;
 use massa_signature::PrivateKey;
 use std::net::{IpAddr, SocketAddr};
@@ -182,7 +182,7 @@ impl Endpoints for API<Private> {
 
     fn send_operations(
         &self,
-        _: Vec<WrappedOperation>,
+        _: Vec<OperationInput>,
     ) -> BoxFuture<Result<Vec<OperationId>, ApiError>> {
         crate::wrong_api::<Vec<OperationId>>()
     }

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bs58 = { version = "0.4", features = ["check"] }
 anyhow = "1.0"
 atty = "0.2"
 console = "0.15"

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -3,7 +3,7 @@
 use crate::repl::Output;
 use anyhow::{anyhow, bail, Result};
 use console::style;
-use massa_models::api::{AddressInfo, CompactAddressInfo, EventFilter};
+use massa_models::api::{AddressInfo, CompactAddressInfo, EventFilter, OperationInput};
 use massa_models::api::{ReadOnlyBytecodeExecution, ReadOnlyCall};
 use massa_models::node::NodeId;
 use massa_models::prehash::Map;
@@ -1061,7 +1061,15 @@ async fn send_operation(
         addr,
     )?;
 
-    match client.public.send_operations(vec![op]).await {
+    match client
+        .public
+        .send_operations(vec![OperationInput {
+            creator_public_key: op.creator_public_key,
+            serialized_content: bs58::encode(op.serialized_data).with_check().into_string(),
+            signature: op.signature,
+        }])
+        .await
+    {
         Ok(operation_ids) => {
             if !json {
                 println!("Sent operation IDs:");

--- a/massa-models/src/api.rs
+++ b/massa-models/src/api.rs
@@ -11,10 +11,22 @@ use crate::{
     Address, Amount, Block, BlockId, CompactConfig, EndorsementId, OperationId, Slot, Version,
 };
 use massa_hash::Hash;
+use massa_signature::{PublicKey, Signature};
 use massa_time::MassaTime;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
+
+/// operation input
+#[derive(Serialize, Deserialize, Debug)]
+pub struct OperationInput {
+    /// The public key of the creator of the TX
+    pub creator_public_key: PublicKey,
+    /// The signature of the operation
+    pub signature: Signature,
+    /// The serialized version of the content
+    pub serialized_content: String,
+}
 
 /// node status
 #[derive(Debug, Deserialize, Serialize)]

--- a/massa-models/src/api.rs
+++ b/massa-models/src/api.rs
@@ -24,7 +24,7 @@ pub struct OperationInput {
     pub creator_public_key: PublicKey,
     /// The signature of the operation
     pub signature: Signature,
-    /// The serialized version of the content
+    /// The serialized version of the content base58 encoded
     pub serialized_content: String,
 }
 

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -8,7 +8,7 @@ use jsonrpc_core_client::transports::http;
 use jsonrpc_core_client::{RpcChannel, RpcError, RpcResult, TypedClient};
 use massa_models::api::{
     AddressInfo, BlockInfo, BlockSummary, EndorsementInfo, EventFilter, NodeStatus, OperationInfo,
-    ReadOnlyBytecodeExecution, ReadOnlyCall, TimeInterval,
+    OperationInput, ReadOnlyBytecodeExecution, ReadOnlyCall, TimeInterval,
 };
 use massa_models::clique::Clique;
 use massa_models::composite::PubkeySig;
@@ -16,7 +16,7 @@ use massa_models::execution::ExecuteReadOnlyResponse;
 use massa_models::node::NodeId;
 use massa_models::output_event::SCOutputEvent;
 use massa_models::prehash::{Map, Set};
-use massa_models::{Address, BlockId, EndorsementId, OperationId, WrappedOperation};
+use massa_models::{Address, BlockId, EndorsementId, OperationId};
 use massa_signature::PrivateKey;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -237,7 +237,7 @@ impl RpcClient {
     /// Adds operations to pool. Returns operations that were ok and sent to pool.
     pub async fn send_operations(
         &self,
-        operations: Vec<WrappedOperation>,
+        operations: Vec<OperationInput>,
     ) -> RpcResult<Vec<OperationId>> {
         self.call_method("send_operations", "Vec<OperationId>", vec![operations])
             .await


### PR DESCRIPTION
The `send_operations` API endpoint now have this format as input : 
```rust
#[derive(Serialize, Deserialize, Debug)]
pub struct OperationInput {
    pub creator_public_key: PublicKey,
    pub signature: Signature,
    pub serialized_content: String,
}
```