### PR TITLE
Use statics (or lazy) de/serializer in message.rs

### DIFF
--- a/massa-hash/src/hash.rs
+++ b/massa-hash/src/hash.rs
@@ -129,7 +129,7 @@ pub struct HashDeserializer;
 
 impl HashDeserializer {
     /// Creates a deserializer for `Hash`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -258,7 +258,7 @@ pub struct AddressDeserializer {
 
 impl AddressDeserializer {
     /// Creates a new deserializer for `Address`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             hash_deserializer: HashDeserializer::new(),
         }

--- a/massa-models/src/amount.rs
+++ b/massa-models/src/amount.rs
@@ -233,7 +233,7 @@ pub struct AmountDeserializer {
 
 impl AmountDeserializer {
     /// Create a new `AmountDeserializer`
-    pub fn new(min_amount: Bound<u64>, max_amount: Bound<u64>) -> Self {
+    pub const fn new(min_amount: Bound<u64>, max_amount: Bound<u64>) -> Self {
         Self {
             u64_deserializer: U64VarIntDeserializer::new(min_amount, max_amount),
         }

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -243,7 +243,7 @@ pub struct BlockDeserializer {
 
 impl BlockDeserializer {
     /// Creates a new `BlockDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         BlockDeserializer {
             header_deserializer: WrappedDeserializer::new(BlockHeaderDeserializer::new()),
             operation_deserializer: WrappedDeserializer::new(OperationDeserializer::new()),
@@ -475,7 +475,7 @@ pub struct BlockHeaderDeserializer {
 
 impl BlockHeaderDeserializer {
     /// Creates a new `BlockHeaderDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         #[cfg(feature = "sandbox")]
         let thread_count = *THREAD_COUNT;
         #[cfg(not(feature = "sandbox"))]

--- a/massa-models/src/endorsement.rs
+++ b/massa-models/src/endorsement.rs
@@ -168,7 +168,7 @@ pub struct EndorsementDeserializer {
 
 impl EndorsementDeserializer {
     /// Creates a new `EndorsementDeserializer`
-    pub fn new(endorsement_count: u32) -> Self {
+    pub const fn new(endorsement_count: u32) -> Self {
         #[cfg(feature = "sandbox")]
         let thread_count = *THREAD_COUNT;
         #[cfg(not(feature = "sandbox"))]

--- a/massa-models/src/error.rs
+++ b/massa-models/src/error.rs
@@ -50,10 +50,18 @@ pub enum ModelsError {
     WrongPrefix(String, String),
     /// Wrong operation id size deduced on join
     OperationPrefixJoinError,
+    /// Error raised {0}
+    ErrorRaised(String),
 }
 
 impl From<nom::Err<nom::error::Error<&[u8]>>> for ModelsError {
     fn from(err: nom::Err<nom::error::Error<&[u8]>>) -> Self {
         ModelsError::DeserializeError(err.to_string())
+    }
+}
+
+impl From<&'static str> for ModelsError {
+    fn from(err: &'static str) -> Self {
+        ModelsError::ErrorRaised(err.to_string())
     }
 }

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -272,7 +272,7 @@ pub struct OperationDeserializer {
 
 impl OperationDeserializer {
     /// Creates a `OperationDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u64_deserializer: U64VarIntDeserializer::new(Included(0), Included(u64::MAX)),
             amount_deserializer: AmountDeserializer::new(Included(0), Included(u64::MAX)),
@@ -523,7 +523,7 @@ pub struct OperationTypeDeserializer {
 
 impl OperationTypeDeserializer {
     /// Creates a new `OperationTypeDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_deserializer: U32VarIntDeserializer::new(Included(0), Included(u32::MAX)),
             u64_deserializer: U64VarIntDeserializer::new(Included(0), Included(u64::MAX)),
@@ -839,7 +839,7 @@ pub struct OperationPrefixIdDeserializer;
 
 impl OperationPrefixIdDeserializer {
     /// Creates a deserializer for [OperationPrefixId]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -884,7 +884,7 @@ pub struct OperationPrefixIdsDeserializer {
 
 impl OperationPrefixIdsDeserializer {
     /// Creates a new `OperationIdsDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_deserializer: U32VarIntDeserializer::new(
                 Included(0),
@@ -929,7 +929,7 @@ pub struct OperationPrefixIdsSerializer {
 
 impl OperationPrefixIdsSerializer {
     /// Creates a new `OperationIdsSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_serializer: U32VarIntSerializer::new(),
         }
@@ -970,7 +970,7 @@ pub struct OperationsSerializer {
 
 impl OperationsSerializer {
     /// Creates a new `OperationsSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_serializer: U32VarIntSerializer::new(),
             signed_op_serializer: WrappedSerializer::new(),
@@ -1005,7 +1005,7 @@ pub struct OperationsDeserializer {
 
 impl OperationsDeserializer {
     /// Creates a new `OperationsDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_deserializer: U32VarIntDeserializer::new(
                 Included(0),

--- a/massa-models/src/serialization.rs
+++ b/massa-models/src/serialization.rs
@@ -249,7 +249,7 @@ pub struct IpAddrSerializer;
 
 impl IpAddrSerializer {
     /// Creates a `IpAddrSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -287,7 +287,7 @@ pub struct IpAddrDeserializer;
 
 impl IpAddrDeserializer {
     /// Creates a `IpAddrDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -397,7 +397,7 @@ pub struct VecU8Deserializer {
 
 impl VecU8Deserializer {
     /// Creates a new `VecU8Deserializer`
-    pub fn new(min_length: Bound<u64>, max_length: Bound<u64>) -> Self {
+    pub const fn new(min_length: Bound<u64>, max_length: Bound<u64>) -> Self {
         Self {
             varint_u64_deserializer: U64VarIntDeserializer::new(min_length, max_length),
         }
@@ -494,7 +494,7 @@ where
     ///
     /// # Arguments:
     /// - `length_deserializer`: Serializer for the length of the string (should be one of `UXXVarIntSerializer`)
-    pub fn new(length_deserializer: DL) -> Self {
+    pub const fn new(length_deserializer: DL) -> Self {
         Self {
             length_deserializer,
             marker_l: std::marker::PhantomData,

--- a/massa-models/src/slot.rs
+++ b/massa-models/src/slot.rs
@@ -73,7 +73,7 @@ pub struct SlotDeserializer {
 
 impl SlotDeserializer {
     /// Creates a `SlotDeserializer`
-    pub fn new(
+    pub const fn new(
         range_period: (Bound<u64>, Bound<u64>),
         range_thread: (Bound<u8>, Bound<u8>),
     ) -> Self {

--- a/massa-models/src/version.rs
+++ b/massa-models/src/version.rs
@@ -70,7 +70,7 @@ pub struct VersionSerializer {
 
 impl VersionSerializer {
     /// Creates a `VersionSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_serializer: U32VarIntSerializer::new(),
         }
@@ -114,7 +114,7 @@ pub struct VersionDeserializer {
 
 impl VersionDeserializer {
     /// Creates a `VersionSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             u32_deserializer: U32VarIntDeserializer::new(Included(0), Included(1000)),
         }

--- a/massa-models/src/wrapped.rs
+++ b/massa-models/src/wrapped.rs
@@ -183,7 +183,7 @@ pub struct WrappedSerializer;
 
 impl WrappedSerializer {
     /// Creates a new `WrappedSerializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -224,7 +224,7 @@ where
     ///
     /// # Arguments
     /// * `content_deserializer` - Deserializer for the content
-    pub fn new(content_deserializer: DT) -> Self {
+    pub const fn new(content_deserializer: DT) -> Self {
         Self {
             signature_deserializer: SignatureDeserializer::new(),
             public_key_deserializer: PublicKeyDeserializer::new(),

--- a/massa-network-worker/Cargo.toml
+++ b/massa-network-worker/Cargo.toml
@@ -11,6 +11,7 @@ async-speed-limit = { git = "https://github.com/adrien-zinger/async-speed-limit"
 enum-map = { version = "2.4", features = ["serde"] }
 futures = "0.3"
 itertools = "0.10"
+maybe_static = "0.1.1"
 num_enum = "0.5"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/massa-network-worker/src/messages.rs
+++ b/massa-network-worker/src/messages.rs
@@ -3,6 +3,7 @@
 use massa_models::{
     array_from_slice,
     constants::{BLOCK_ID_SIZE_BYTES, HANDSHAKE_RANDOMNESS_SIZE_BYTES},
+    error::ModelsResult,
     operation::OperationPrefixIds,
     operation::{
         OperationPrefixIdsDeserializer, OperationPrefixIdsSerializer, Operations,
@@ -10,16 +11,44 @@ use massa_models::{
     },
     with_serialization_context,
     wrapped::{WrappedDeserializer, WrappedSerializer},
-    BlockDeserializer, BlockHeaderDeserializer, BlockId, DeserializeCompact, DeserializeVarInt,
-    EndorsementDeserializer, IpAddrDeserializer, IpAddrSerializer, ModelsError, SerializeCompact,
-    SerializeVarInt, Version, VersionDeserializer, VersionSerializer, WrappedBlock,
-    WrappedEndorsement, WrappedHeader,
+    Block, BlockDeserializer, BlockHeader, BlockHeaderDeserializer, BlockId, DeserializeCompact,
+    DeserializeVarInt, Endorsement, EndorsementDeserializer, IpAddrDeserializer, IpAddrSerializer,
+    ModelsError, SerializeCompact, SerializeVarInt, Version, VersionDeserializer,
+    VersionSerializer, WrappedBlock, WrappedEndorsement, WrappedHeader,
 };
 use massa_serialization::{DeserializeError, Deserializer, Serializer};
 use massa_signature::{PublicKey, Signature, PUBLIC_KEY_SIZE_BYTES, SIGNATURE_SIZE_BYTES};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, net::IpAddr};
+
+static IP_SERIALIZER: IpAddrSerializer = IpAddrSerializer::new();
+
+static IP_DESERIALIZER: IpAddrDeserializer = IpAddrDeserializer::new();
+
+static OPERATION_PREFIX_ID_DESERIALIZER: OperationPrefixIdsDeserializer =
+    OperationPrefixIdsDeserializer::new();
+
+static OPERATION_PREFIX_ID_SERIALIZER: OperationPrefixIdsSerializer =
+    OperationPrefixIdsSerializer::new();
+
+static OPERATIONS_DESERIALIZER: OperationsDeserializer = OperationsDeserializer::new();
+
+static OPERATIONS_SERIALIZER: OperationsSerializer = OperationsSerializer::new();
+
+static VERSION_DESERIALIZER: VersionDeserializer = VersionDeserializer::new();
+
+static VERSION_SERIALIZER: VersionSerializer = VersionSerializer::new();
+
+static WRAPPED_BLOCK_DESERIALIZER: WrappedDeserializer<Block, BlockDeserializer> =
+    WrappedDeserializer::new(BlockDeserializer::new());
+
+static WRAPPED_BLOCK_HEADER_DESERIALIZER: WrappedDeserializer<
+    BlockHeader,
+    BlockHeaderDeserializer,
+> = WrappedDeserializer::new(BlockHeaderDeserializer::new());
+
+static WRAPPED_SERIALIZER: WrappedSerializer = WrappedSerializer::new();
 
 /// All messages that can be sent or received.
 #[allow(clippy::large_enum_variant)]
@@ -93,11 +122,10 @@ impl SerializeCompact for Message {
                 random_bytes,
                 version,
             } => {
-                let version_serializer = VersionSerializer::new();
                 res.extend(u32::from(MessageTypeId::HandshakeInitiation).to_varint_bytes());
                 res.extend(&public_key.to_bytes());
                 res.extend(random_bytes);
-                version_serializer.serialize(version, &mut res)?;
+                VERSION_SERIALIZER.serialize(version, &mut res)?;
             }
             Message::HandshakeReply { signature } => {
                 res.extend(u32::from(MessageTypeId::HandshakeReply).to_varint_bytes());
@@ -105,11 +133,11 @@ impl SerializeCompact for Message {
             }
             Message::Block(block) => {
                 res.extend(u32::from(MessageTypeId::Block).to_varint_bytes());
-                WrappedSerializer::new().serialize(block, &mut res)?;
+                WRAPPED_SERIALIZER.serialize(block, &mut res)?;
             }
             Message::BlockHeader(header) => {
                 res.extend(u32::from(MessageTypeId::BlockHeader).to_varint_bytes());
-                WrappedSerializer::new().serialize(header, &mut res)?;
+                WRAPPED_SERIALIZER.serialize(header, &mut res)?;
             }
             Message::AskForBlocks(list) => {
                 res.extend(u32::from(MessageTypeId::AskForBlocks).to_varint_bytes());
@@ -129,9 +157,8 @@ impl SerializeCompact for Message {
             Message::PeerList(ip_vec) => {
                 res.extend(u32::from(MessageTypeId::PeerList).to_varint_bytes());
                 res.extend((ip_vec.len() as u64).to_varint_bytes());
-                let ip_serializer = IpAddrSerializer::new();
                 for ip in ip_vec {
-                    ip_serializer.serialize(ip, &mut res)?
+                    IP_SERIALIZER.serialize(ip, &mut res)?
                 }
             }
             Message::BlockNotFound(hash) => {
@@ -140,22 +167,21 @@ impl SerializeCompact for Message {
             }
             Message::AskForOperations(operation_ids) => {
                 res.extend(u32::from(MessageTypeId::AskForOperations).to_varint_bytes());
-                OperationPrefixIdsSerializer::new().serialize(operation_ids, &mut res)?;
+                OPERATION_PREFIX_ID_SERIALIZER.serialize(operation_ids, &mut res)?;
             }
             Message::OperationsAnnouncement(operation_ids) => {
                 res.extend(u32::from(MessageTypeId::OperationsAnnouncement).to_varint_bytes());
-                OperationPrefixIdsSerializer::new().serialize(operation_ids, &mut res)?;
+                OPERATION_PREFIX_ID_SERIALIZER.serialize(operation_ids, &mut res)?;
             }
             Message::Operations(operations) => {
                 res.extend(u32::from(MessageTypeId::Operations).to_varint_bytes());
-                OperationsSerializer::new().serialize(operations, &mut res)?;
+                OPERATIONS_SERIALIZER.serialize(operations, &mut res)?;
             }
             Message::Endorsements(endorsements) => {
                 res.extend(u32::from(MessageTypeId::Endorsements).to_varint_bytes());
                 res.extend((endorsements.len() as u32).to_varint_bytes());
-                let endorsement_serializer = WrappedSerializer::new();
                 for endorsement in endorsements.iter() {
-                    endorsement_serializer.serialize(endorsement, &mut res)?;
+                    WRAPPED_SERIALIZER.serialize(endorsement, &mut res)?;
                 }
             }
         }
@@ -166,7 +192,7 @@ impl SerializeCompact for Message {
 /// For more details on how incoming objects are checked for validity at this stage,
 /// see their implementation of `from_bytes_compact` in `models`.
 impl DeserializeCompact for Message {
-    fn from_bytes_compact(buffer: &[u8]) -> Result<(Self, usize), ModelsError> {
+    fn from_bytes_compact(buffer: &[u8]) -> ModelsResult<(Self, usize)> {
         let mut cursor = 0usize;
 
         let (max_ask_blocks_per_message, max_peer_list_length, max_endorsements_per_message) =
@@ -187,7 +213,6 @@ impl DeserializeCompact for Message {
 
         let res = match type_id {
             MessageTypeId::HandshakeInitiation => {
-                let version_deserializer = VersionDeserializer::new();
                 // public key
                 let public_key = PublicKey::from_bytes(&array_from_slice(&buffer[cursor..])?)?;
                 cursor += PUBLIC_KEY_SIZE_BYTES;
@@ -197,7 +222,7 @@ impl DeserializeCompact for Message {
                 cursor += HANDSHAKE_RANDOMNESS_SIZE_BYTES;
 
                 // version
-                let (rest, version) = version_deserializer.deserialize(&buffer[cursor..])?;
+                let (rest, version) = VERSION_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
 
                 // return message
@@ -214,15 +239,13 @@ impl DeserializeCompact for Message {
             }
             MessageTypeId::Block => {
                 let (rest, block): (&[u8], WrappedBlock) =
-                    WrappedDeserializer::new(BlockDeserializer::new())
-                        .deserialize(&buffer[cursor..])?;
+                    WRAPPED_BLOCK_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
                 Message::Block(block)
             }
             MessageTypeId::BlockHeader => {
                 let (rest, header): (&[u8], WrappedHeader) =
-                    WrappedDeserializer::new(BlockHeaderDeserializer::new())
-                        .deserialize(&buffer[cursor..])?;
+                    WRAPPED_BLOCK_HEADER_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
                 Message::BlockHeader(header)
             }
@@ -247,9 +270,8 @@ impl DeserializeCompact for Message {
                 cursor += delta;
                 // peer list
                 let mut peers: Vec<IpAddr> = Vec::with_capacity(length as usize);
-                let ip_deserializer = IpAddrDeserializer::new();
                 for _ in 0..length {
-                    let (rest, ip) = ip_deserializer
+                    let (rest, ip) = IP_DESERIALIZER
                         .deserialize::<DeserializeError>(&buffer[cursor..])
                         .map_err(|_| {
                             ModelsError::DeserializeError(
@@ -267,20 +289,19 @@ impl DeserializeCompact for Message {
                 Message::BlockNotFound(b_id)
             }
             MessageTypeId::Operations => {
-                let (rest, operations) =
-                    OperationsDeserializer::new().deserialize(&buffer[cursor..])?;
+                let (rest, operations) = OPERATIONS_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
                 Message::Operations(operations)
             }
             MessageTypeId::AskForOperations => {
                 let (rest, operation_prefix_ids) =
-                    OperationPrefixIdsDeserializer::new().deserialize(&buffer[cursor..])?;
+                    OPERATION_PREFIX_ID_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
                 Message::AskForOperations(operation_prefix_ids)
             }
             MessageTypeId::OperationsAnnouncement => {
                 let (rest, operation_prefix_ids) =
-                    OperationPrefixIdsDeserializer::new().deserialize(&buffer[cursor..])?;
+                    OPERATION_PREFIX_ID_DESERIALIZER.deserialize(&buffer[cursor..])?;
                 cursor += buffer[cursor..].len() - rest.len();
                 Message::OperationsAnnouncement(operation_prefix_ids)
             }
@@ -293,9 +314,11 @@ impl DeserializeCompact for Message {
                 cursor += delta;
                 // operations
                 let mut endorsements = Vec::with_capacity(length as usize);
-                let endorsement_deserializer = WrappedDeserializer::new(
-                    EndorsementDeserializer::new(max_endorsements_per_message),
-                );
+                let endorsement_deserializer = maybe_static::maybe_static!(
+                    Some(max_endorsements_per_message),
+                    WrappedDeserializer<Endorsement, EndorsementDeserializer>,
+                    |max: u32| WrappedDeserializer::new(EndorsementDeserializer::new(max))
+                )?;
                 for _ in 0..length {
                     let (rest, endorsement) =
                         endorsement_deserializer.deserialize(&buffer[cursor..])?;

--- a/massa-serialization/src/lib.rs
+++ b/massa-serialization/src/lib.rs
@@ -193,7 +193,7 @@ macro_rules! gen_varint {
                 #[doc = $d]
                 #[doc = " in a varint form."]
                 #[allow(dead_code)]
-                pub fn new() -> Self {
+                pub const fn new() -> Self {
                     Self
                 }
             }
@@ -223,7 +223,7 @@ macro_rules! gen_varint {
                 #[doc = $d]
                 #[doc = " in a varint form."]
                 #[allow(dead_code)]
-                pub fn new(min: Bound<$type>, max: Bound<$type>) -> Self {
+                pub const fn new(min: Bound<$type>, max: Bound<$type>) -> Self {
                     Self {
                         range: (min, max)
                     }

--- a/massa-signature/src/signature_impl.rs
+++ b/massa-signature/src/signature_impl.rs
@@ -402,7 +402,7 @@ pub struct PublicKeyDeserializer;
 
 impl PublicKeyDeserializer {
     /// Creates a `SignatureDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }
@@ -802,7 +802,7 @@ pub struct SignatureDeserializer;
 
 impl SignatureDeserializer {
     /// Creates a `SignatureDeserializer`
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 }


### PR DESCRIPTION
Instead of creating a new de/serializer for each message, I use static and lazy static variables.


... in message.rs