### PR TITLE
Increase timeout and remove check in bs58.

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -706,7 +706,6 @@ impl Endpoints for API<Public> {
                     op_serialized.extend(op_input.creator_public_key.to_bytes());
                     op_serialized.extend(
                         bs58::decode(op_input.serialized_content)
-                            .with_check(None)
                             .into_vec()
                             .map_err(|err| {
                                 ApiError::ModelsError(ModelsError::CheckedOperationError(format!(

--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -1,6 +1,6 @@
 history = 10
 history_file_path = "config/.massa_history"
-timeout = 1000
+timeout = 100000
 
 [default_node]
 ip = "127.0.0.1"

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -1065,7 +1065,7 @@ async fn send_operation(
         .public
         .send_operations(vec![OperationInput {
             creator_public_key: op.creator_public_key,
-            serialized_content: bs58::encode(op.serialized_data).with_check().into_string(),
+            serialized_content: bs58::encode(op.serialized_data).into_string(),
             signature: op.signature,
         }])
         .await

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -55,7 +55,7 @@ impl From<RpcChannel> for RpcClient {
     fn from(channel: RpcChannel) -> Self {
         RpcClient {
             client: channel.into(),
-            timeout: 10000,
+            timeout: 100000,
         }
     }
 }


### PR DESCRIPTION
Now that we transfer the content of the operation in serialized data base58 encoded in the case of a SC deployment it can be quite long to encode and decode bs58 so I removed the check and increase the timeout.