### PR TITLE
Remove ops from storage.

### DIFF
--- a/massa-pool/src/operation_pool.rs
+++ b/massa-pool/src/operation_pool.rs
@@ -187,6 +187,7 @@ impl OperationPool {
                     self.ops_by_address.insert_op(*addr, *op_id);
                 });
             self.ops.insert(*op_id, wrapped_op);
+            self.storage.store_operation(op.clone());
         }
 
         // remove excess operations if pool is full
@@ -215,11 +216,6 @@ impl OperationPool {
             .filter(|id| !removed.contains(id))
             .copied()
             .collect();
-
-        // Add newly added to shared storage.
-        for (_, op) in operations.into_iter() {
-            self.storage.store_operation(op);
-        }
 
         Ok(newly_added_ids)
     }

--- a/massa-pool/src/operation_pool.rs
+++ b/massa-pool/src/operation_pool.rs
@@ -204,6 +204,7 @@ impl OperationPool {
                         self.ops_by_address
                             .remove_op_for_address(&addr, &removed_id);
                     }
+                    self.storage.remove_operations(vec![removed_id].as_slice());
                 }
                 operations.remove(&removed_id);
             }
@@ -236,6 +237,8 @@ impl OperationPool {
                 }
             } // else final op wasn't in pool.
         }
+        self.storage
+            .remove_operations(&ops.keys().cloned().collect::<Vec<OperationId>>().as_slice());
         self.final_operations.extend(ops);
         Ok(())
     }
@@ -284,7 +287,7 @@ impl OperationPool {
         self.storage.remove_operations(&op_ids);
 
         // Remove from internal structures.
-        for op_id in op_ids.into_iter() {
+        for &op_id in op_ids.iter() {
             if let Some(wrapped_op) = self.ops.remove(&op_id) {
                 // complexity: const
                 let interest = (std::cmp::Reverse(wrapped_op.fee_density), op_id);
@@ -296,6 +299,7 @@ impl OperationPool {
                 }
             }
         }
+        self.storage.remove_operations(&op_ids);
 
         Ok(())
     }


### PR DESCRIPTION
Fix #2750 

The blocks are still saved full (before #2747) in storage with all of their operation we just need to delete the operations from the `operations` hashmap in storage and they will still be accessible in the full blocks for graph etc...