### PR TITLE
Modify AddressInfo format

### DIFF
--- a/massa-models/src/api.rs
+++ b/massa-models/src/api.rs
@@ -232,42 +232,107 @@ impl std::fmt::Display for AddressInfo {
             "Final datastore keys:\n{:?}\n",
             self.final_datastore_keys
         )?;
+        let mut b = false;
         writeln!(
             f,
-            "Block draws: {}",
+            "\nBlock draws:{}",
             self.block_draws
                 .iter()
-                .fold("\n".to_string(), |acc, s| format!("{}    {}", acc, s))
+                .fold("\n".to_string(), |acc, s| format!(
+                    "{}{}{}",
+                    acc,
+                    {
+                        b = !b;
+                        if !b {
+                            ' '
+                        } else {
+                            '\n'
+                        }
+                    },
+                    s
+                ))
         )?;
+        b = false;
         writeln!(
             f,
-            "Endorsement draws: {}",
+            "\nEndorsement draws:{}",
             self.endorsement_draws
                 .iter()
-                .fold("\n".to_string(), |acc, s| format!("{}    {}", acc, s))
+                .fold("\n".to_string(), |acc, s| format!(
+                    "{}{}{}",
+                    acc,
+                    {
+                        b = !b;
+                        if !b {
+                            ' '
+                        } else {
+                            '\n'
+                        }
+                    },
+                    s
+                ))
         )?;
+        b = false;
         writeln!(
             f,
-            "Blocks created: {}",
+            "\nBlocks created:{}",
             self.blocks_created
                 .iter()
-                .fold("\n".to_string(), |acc, s| format!("{}    {}", acc, s))
+                .fold("\n".to_string(), |acc, s| format!(
+                    "{}{}{}",
+                    acc,
+                    {
+                        b = !b;
+                        if !b {
+                            ' '
+                        } else {
+                            '\n'
+                        }
+                    },
+                    s
+                ))
         )?;
+        b = false;
         writeln!(
             f,
-            "Involved in endorsements: {}",
+            "\nInvolved in endorsements:{}",
             self.involved_in_endorsements
                 .iter()
-                .fold("\n".to_string(), |acc, s| format!("{}    {}", acc, s))
+                .fold("\n".to_string(), |acc, s| format!(
+                    "{}{}{}",
+                    acc,
+                    {
+                        b = !b;
+                        if !b {
+                            ' '
+                        } else {
+                            '\n'
+                        }
+                    },
+                    s
+                ))
         )?;
+        b = false;
         writeln!(
             f,
-            "Involved in operations: {}",
+            "\nInvolved in operations:{}",
             self.involved_in_operations
                 .iter()
-                .fold("\n".to_string(), |acc, s| format!("{}    {}", acc, s))
+                .fold("\n".to_string(), |acc, s| format!(
+                    "{}{}{}",
+                    acc,
+                    {
+                        b = !b;
+                        if !b {
+                            ' '
+                        } else {
+                            '\n'
+                        }
+                    },
+                    s
+                ))
         )?;
-        writeln!(f, "Production stats:")?;
+        writeln!(f, "\nProduction stats:")?;
         let mut sorted_production_stats = self.production_stats.clone();
         sorted_production_stats.sort_unstable_by_key(|v| v.cycle);
         for cycle_stat in sorted_production_stats.into_iter() {


### PR DESCRIPTION
Format the display of `AddressInfo`. (align 2 by 2 elements for big vectors) 

I just realized how much it would be great to add an option `-n` when we dump information like `AddressInfo` to get the n latest blocks, endorsement draws, block draws, etc. I can do it here.

Also, I think the `fold` is a bit hard to use for just that simple use case.
