### PR TITLE
Modify selector stop handler

### DIFF
--- a/massa-pos-worker/src/controller.rs
+++ b/massa-pos-worker/src/controller.rs
@@ -3,15 +3,13 @@
 //! This module implements a selector controller.
 //! See `massa-pos-exports/controller_traits.rs` for functional details.
 
-use std::sync::{atomic::AtomicBool, Arc};
-
 use anyhow::{bail, Result};
 use massa_models::{Address, Slot};
 
 use massa_pos_exports::{CycleInfo, PosResult, Selection, SelectorController, SelectorManager};
 use tracing::{info, warn};
 
-use crate::{DrawCachePtr, InputDataPtr};
+use crate::{Command, DrawCachePtr, InputDataPtr};
 
 #[derive(Clone)]
 /// implementation of the selector controller
@@ -31,7 +29,10 @@ impl SelectorController for SelectorControllerImpl {
     /// * `cycle_info`: give or regive a cycle info for a background
     ///                 computation of the draws.
     fn feed_cycle(&self, cycle_info: CycleInfo) {
-        self.input_data.1.lock().push_back(cycle_info);
+        self.input_data
+            .1
+            .lock()
+            .push_back(Command::CycleInfo(cycle_info));
         self.input_data.0.notify_one();
     }
 
@@ -73,15 +74,18 @@ pub struct SelectorManagerImpl {
     //       thread to stop.
     /// handle used to join the worker thread
     pub(crate) thread_handle: Option<std::thread::JoinHandle<PosResult<()>>>,
-    pub(crate) stop_flag: Arc<AtomicBool>,
+    /// Input data pointer used to stop the selector thread
+    pub(crate) input_data: InputDataPtr,
 }
 
 impl SelectorManager for SelectorManagerImpl {
     /// stops the worker
     fn stop(&mut self) {
         info!("stopping selector worker...");
-        self.stop_flag
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        {
+            self.input_data.1.lock().push_front(Command::Stop);
+            self.input_data.0.notify_one();
+        }
         // join the selector thread
         if let Some(join_handle) = self.thread_handle.take() {
             if let Err(err) = join_handle

--- a/massa-pos-worker/src/draw.rs
+++ b/massa-pos-worker/src/draw.rs
@@ -174,7 +174,6 @@ impl SelectorThread {
 
         // truncate cache to keep only the desired number of elements
         // we do it first to free memory space
-        let cache = &mut self.cache.write();
         while cache.len() > self.cfg.max_draw_cache {
             cache.pop_first();
         }

--- a/massa-pos-worker/src/lib.rs
+++ b/massa-pos-worker/src/lib.rs
@@ -17,10 +17,15 @@ use std::{
     sync::Arc,
 };
 
+pub(crate) enum Command {
+    CycleInfo(CycleInfo),
+    Stop,
+}
+
 /// Same structure pointer that will be used by the selector controller and his
 /// thread. It will store all new CycleInfo declared by massa (in the
 /// Execution module) and will be used to compute the draws in background.
-pub(crate) type InputDataPtr = Arc<(Condvar, Mutex<VecDeque<CycleInfo>>)>;
+pub(crate) type InputDataPtr = Arc<(Condvar, Mutex<VecDeque<Command>>)>;
 
 /// Structure of the shared pointer to the computed draws.
 pub(crate) type DrawCachePtr = Arc<RwLock<BTreeMap<u64, HashMap<Slot, Selection>>>>;

--- a/massa-pos-worker/src/worker.rs
+++ b/massa-pos-worker/src/worker.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use std::collections::BTreeMap;
-use std::sync::{atomic::AtomicBool, Arc};
 use std::thread::JoinHandle;
 
 use massa_hash::Hash;
@@ -15,8 +14,7 @@ use massa_pos_exports::SelectorManager;
 
 use crate::controller::SelectorControllerImpl;
 use crate::controller::SelectorManagerImpl;
-use crate::DrawCachePtr;
-use crate::InputDataPtr;
+use crate::{Command, DrawCachePtr, InputDataPtr};
 
 /// Structure gathering all elements needed by the selector thread
 #[allow(dead_code)]
@@ -48,7 +46,6 @@ impl SelectorThread {
         input_data: InputDataPtr,
         cache: DrawCachePtr,
         initial_rolls: Vec<Map<Address, u64>>,
-        stop_flag: Arc<AtomicBool>,
         cfg: SelectorConfig,
     ) -> JoinHandle<PosResult<()>> {
         std::thread::spawn(|| {
@@ -61,7 +58,7 @@ impl SelectorThread {
                 initial_rolls,
             };
 
-            this.run(stop_flag)
+            this.run()
         })
     }
 
@@ -69,15 +66,14 @@ impl SelectorThread {
     /// for future cycle.
     /// # Arguments
     /// * `cycle_info`: a cycle info with roll counts, seed, etc...
-    fn run(mut self, stop_flag: Arc<AtomicBool>) -> PosResult<()> {
+    fn run(mut self) -> PosResult<()> {
         loop {
-            if stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
-                break;
-            }
             let input_data = self.input_data.clone();
             let mut data = input_data.1.lock();
-            if let Some(cycle_info) = data.pop_front() {
-                self.draws(cycle_info)?
+            match data.pop_front() {
+                Some(Command::CycleInfo(cycle_info)) => self.draws(cycle_info)?,
+                Some(Command::Stop) => break,
+                None => {}
             }
             // Wait to be notified of new input
             // The return value is ignored because we don't care what woke up the condition variable.
@@ -108,18 +104,15 @@ pub fn start_selector_worker(
     };
 
     // launch the selector thread
-    let stop_flag = Arc::new(AtomicBool::new(false));
-    let stop_flag_clone = stop_flag.clone();
     let thread_handle = SelectorThread::spawn(
-        input_data,
+        input_data.clone(),
         cache,
         get_initial_rolls(&selector_config).unwrap(),
-        stop_flag_clone,
         selector_config,
     );
     let manager = SelectorManagerImpl {
         thread_handle: Some(thread_handle),
-        stop_flag,
+        input_data,
     };
     (Box::new(manager), Box::new(controller))
 }


### PR DESCRIPTION
Ensure that the thread stop correctly: Before it was a possible deadlock when the selector controller stopped the thread after the execution thread.

Profit of the input data pointer to pass a `Command::Stop`