### PR TITLE
Add the ARM64 build target in cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,16 +14,29 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macOS-latest, windows-latest]
+        platform: [x86_64, arm64]
         include:
           - os: ubuntu-18.04
-            target: x86_64-unknown-linux-musl
+            platform: x86_64
+            target: x86_64-unknown-linux-gnu
             name: release_linux.tar.gz
+          - os: ubuntu-18.04
+            platform: arm64
+            target: aarch64-unknown-linux-gnu
+            name: release_linux_arm64.tar.gz
           - os: windows-latest
-            target: x86_64-pc-windows-msvc
+            platform: x86_64
+            target: x86_64-pc-windows-gnu
             name: release_windows.zip
           - os: macOS-latest
+            platform: x86_64
             target: x86_64-apple-darwin
             name: release_macos.tar.gz
+        exclude:
+          - os: windows-latest
+            platform: arm64
+          - os: macOS-latest
+            platform: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -37,15 +50,28 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
+        if: matrix.platform != 'arm64'
         with:
           command: build
           args: --release
+      - uses: actions-rs/cargo@v1
+        if: matrix.platform == 'arm64'
+        with:
+          use-cross: true
+          command: build
+          args: --release --target ${{ matrix.target }}
       - name: Package
         shell: bash
         run: |
           mkdir massa && cd massa && mkdir massa-node && mkdir massa-client
-          cp -v ../target/release/massa-node massa-node/massa-node
-          cp -v ../target/release/massa-client massa-client/massa-client
+          if [[ "${{ matrix.platform }}" == "arm64" ]]
+          then
+            cp -v ../target/${{ matrix.target }}/release/massa-node massa-node/massa-node
+            cp -v ../target/${{ matrix.target }}/release/massa-client massa-client/massa-client
+          else
+            cp -v ../target/release/massa-node massa-node/massa-node
+            cp -v ../target/release/massa-client massa-client/massa-client
+          fi
           cp -rv ../massa-node/config massa-node/config
           cp -rv ../massa-node/base_config massa-node/base_config
           cp -rv ../massa-node/storage massa-node/storage

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,3 @@
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install --assume-yes libssl-dev:arm64"]


### PR DESCRIPTION
This pull request is linked to the issue #2854.

It adds, when releasing, the generation of a package for linux with arm64 processor architecture.

To build the arm64 binaries on a Github Actions runner with x86_64 processor architecture, it uses [cross](https://github.com/cross-rs/cross).

To enable cross, it passes the value `true` to the argument `use-cross` of the Github Action `actions-rs/cargo@v1`.

When compiling, `cross` creates a new Docker container and build the sources inside it. But, by default, the container created doesn't provide the openssl library. To tell `cross` to install some dependancies before compiling, I have created the config file `Cross.toml`. In this file, for each target architectures, we can define the docker image used by `cross` and a command executed before building.

The more targets we want, the more complex the config will be. That's why, I kept only the arm64 linux target. I think that the others arm64 architectures will not be so expected by users. Moreover, it uses `cross` only for arm64 architectures to not have to add some configs.

Links :
- [Release](https://github.com/fsidhoum/massa/releases/tag/TEST.13.0)
- [CI Workflow](https://github.com/fsidhoum/massa/actions/runs/2820017800)
- [CD Workflow](https://github.com/fsidhoum/massa/actions/runs/2820019853)