### PR TITLE
Remove shortened operations name and maintain operation order in blocks.

### DIFF
--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -6,8 +6,8 @@ use crate::prehash::{Map, PreHashed, Set};
 use crate::wrapped::{Id, Wrapped, WrappedContent, WrappedDeserializer, WrappedSerializer};
 use crate::{
     Address, Endorsement, EndorsementDeserializer, EndorsementId, ModelsError, OperationId,
-    OperationIds, OperationIdsDeserializer, OperationIdsSerializer, Slot, SlotDeserializer,
-    SlotSerializer, WrappedEndorsement, WrappedOperation,
+    OperationIdsDeserializer, OperationIdsSerializer, Slot, SlotDeserializer, SlotSerializer,
+    WrappedEndorsement, WrappedOperation,
 };
 use massa_hash::{Hash, HashDeserializer};
 use massa_serialization::{
@@ -125,7 +125,7 @@ pub struct Block {
     /// signed header
     pub header: WrappedHeader,
     /// operations
-    pub operations: OperationIds,
+    pub operations: Vec<OperationId>,
 }
 
 /// Wrapped Block

--- a/massa-models/src/lib.rs
+++ b/massa-models/src/lib.rs
@@ -22,12 +22,11 @@ pub use endorsement::{
 };
 pub use error::ModelsError;
 pub use operation::{
-    Operation, OperationDeserializer, OperationId, OperationIdDeserializer, OperationIds,
+    Operation, OperationDeserializer, OperationId, OperationIdDeserializer,
     OperationIdsDeserializer, OperationIdsSerializer, OperationPrefixId,
     OperationPrefixIdDeserializer, OperationPrefixIds, OperationPrefixIdsDeserializer,
     OperationPrefixIdsSerializer, OperationSerializer, OperationType, OperationTypeDeserializer,
-    OperationTypeSerializer, Operations, OperationsDeserializer, OperationsSerializer,
-    WrappedOperation,
+    OperationTypeSerializer, OperationsDeserializer, OperationsSerializer, WrappedOperation,
 };
 pub use serialization::{
     array_from_slice, u8_from_slice, BitVecDeserializer, BitVecSerializer, DeserializeMinBEInt,

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -914,12 +914,10 @@ impl WrappedOperation {
     }
 }
 
-/// Set of operation ids
-pub type OperationIds = Set<OperationId>;
 /// Set of operation id's prefix
 pub type OperationPrefixIds = Set<OperationPrefixId>;
 
-/// Serializer for `OperationIds`
+/// Serializer for `Set<OperationId>`
 pub struct OperationIdsSerializer {
     u32_serializer: U32VarIntSerializer,
 }
@@ -939,22 +937,28 @@ impl Default for OperationIdsSerializer {
     }
 }
 
-impl Serializer<OperationIds> for OperationIdsSerializer {
+impl Serializer<Vec<OperationId>> for OperationIdsSerializer {
     /// ## Example:
     /// ```
-    /// use massa_models::{OperationIds, OperationId, OperationIdsSerializer};
+    /// use massa_models::{OperationId, OperationIdsSerializer};
     /// use massa_serialization::Serializer;
     /// use std::str::FromStr;
     ///
-    /// let mut operations_ids = OperationIds::default();
-    /// operations_ids.insert(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
-    /// operations_ids.insert(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
+    /// let mut operations_ids = Vec::new();
+    /// operations_ids.push(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
+    /// operations_ids.push(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
     /// let mut buffer = Vec::new();
     /// OperationIdsSerializer::new().serialize(&operations_ids, &mut buffer).unwrap();
     /// ```
-    fn serialize(&self, value: &OperationIds, buffer: &mut Vec<u8>) -> Result<(), SerializeError> {
+    fn serialize(
+        &self,
+        value: &Vec<OperationId>,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), SerializeError> {
         let list_len: u32 = value.len().try_into().map_err(|_| {
-            SerializeError::NumberTooBig("could not encode OperationIds list length as u32".into())
+            SerializeError::NumberTooBig(
+                "could not encode Set<OperationId> list length as u32".into(),
+            )
         })?;
         self.u32_serializer.serialize(&list_len, buffer)?;
         for hash in value {
@@ -964,7 +968,7 @@ impl Serializer<OperationIds> for OperationIdsSerializer {
     }
 }
 
-/// Deserializer for `OperationIds`
+/// Deserializer for `Set<OperationId>`
 pub struct OperationIdsDeserializer {
     length_deserializer: U32VarIntDeserializer,
     hash_deserializer: HashDeserializer,
@@ -983,16 +987,16 @@ impl OperationIdsDeserializer {
     }
 }
 
-impl Deserializer<OperationIds> for OperationIdsDeserializer {
+impl Deserializer<Vec<OperationId>> for OperationIdsDeserializer {
     /// ## Example:
     /// ```
-    /// use massa_models::{OperationIds, OperationId, OperationIdsSerializer, OperationIdsDeserializer};
+    /// use massa_models::{OperationId, OperationIdsSerializer, OperationIdsDeserializer};
     /// use massa_serialization::{Serializer, Deserializer, DeserializeError};
     /// use std::str::FromStr;
     ///
-    /// let mut operations_ids = OperationIds::default();
-    /// operations_ids.insert(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
-    /// operations_ids.insert(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
+    /// let mut operations_ids = Vec::new();
+    /// operations_ids.push(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
+    /// operations_ids.push(OperationId::from_str("2AGSu2kBG9FZ649h18F82CYfsymkhVH2epMafMN2sPZNBQXTrz").unwrap());
     /// let mut buffer = Vec::new();
     /// OperationIdsSerializer::new().serialize(&operations_ids, &mut buffer).unwrap();
     /// let (rest, deserialized_operations_ids) = OperationIdsDeserializer::new(1000).deserialize::<DeserializeError>(&buffer).unwrap();
@@ -1002,9 +1006,9 @@ impl Deserializer<OperationIds> for OperationIdsDeserializer {
     fn deserialize<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
         &self,
         buffer: &'a [u8],
-    ) -> IResult<&'a [u8], OperationIds, E> {
+    ) -> IResult<&'a [u8], Vec<OperationId>, E> {
         context(
-            "Failed OperationIds deserialization",
+            "Failed Set<OperationId> deserialization",
             length_count(
                 context("Failed length deserialization", |input| {
                     self.length_deserializer.deserialize(input)
@@ -1154,7 +1158,9 @@ impl Serializer<OperationPrefixIds> for OperationPrefixIdsSerializer {
         buffer: &mut Vec<u8>,
     ) -> Result<(), SerializeError> {
         let list_len: u32 = value.len().try_into().map_err(|_| {
-            SerializeError::NumberTooBig("could not encode OperationIds list length as u32".into())
+            SerializeError::NumberTooBig(
+                "could not encode Set<OperationId> list length as u32".into(),
+            )
         })?;
         self.u32_serializer.serialize(&list_len, buffer)?;
         for prefix in value {
@@ -1163,9 +1169,6 @@ impl Serializer<OperationPrefixIds> for OperationPrefixIdsSerializer {
         Ok(())
     }
 }
-
-/// Set of self containing signed operations.
-pub type Operations = Vec<WrappedOperation>;
 
 /// Serializer for `Operations`
 pub struct OperationsSerializer {
@@ -1189,10 +1192,10 @@ impl Default for OperationsSerializer {
     }
 }
 
-impl Serializer<Operations> for OperationsSerializer {
+impl Serializer<Vec<WrappedOperation>> for OperationsSerializer {
     /// ## Example:
     /// ```rust
-    /// use massa_models::{WrappedOperation, wrapped::WrappedContent, OperationSerializer, Address, Amount, Operations, Operation, OperationType, OperationsSerializer};
+    /// use massa_models::{WrappedOperation, wrapped::WrappedContent, OperationSerializer, Address, Amount, Operation, OperationType, OperationsSerializer};
     /// use massa_signature::KeyPair;
     /// use massa_serialization::Serializer;
     /// use std::str::FromStr;
@@ -1212,7 +1215,11 @@ impl Serializer<Operations> for OperationsSerializer {
     /// let mut buffer = Vec::new();
     /// OperationsSerializer::new().serialize(&operations, &mut buffer).unwrap();
     /// ```
-    fn serialize(&self, value: &Operations, buffer: &mut Vec<u8>) -> Result<(), SerializeError> {
+    fn serialize(
+        &self,
+        value: &Vec<WrappedOperation>,
+        buffer: &mut Vec<u8>,
+    ) -> Result<(), SerializeError> {
         let list_len: u32 = value.len().try_into().map_err(|_| {
             SerializeError::NumberTooBig("could not encode Operations list length as u32".into())
         })?;
@@ -1252,10 +1259,10 @@ impl OperationsDeserializer {
     }
 }
 
-impl Deserializer<Operations> for OperationsDeserializer {
+impl Deserializer<Vec<WrappedOperation>> for OperationsDeserializer {
     /// ## Example:
     /// ```rust
-    /// use massa_models::{WrappedOperation, wrapped::WrappedContent, OperationSerializer, Address, Amount, Operations, Operation, OperationType, OperationsSerializer, OperationsDeserializer};
+    /// use massa_models::{WrappedOperation, wrapped::WrappedContent, OperationSerializer, Address, Amount, Operation, OperationType, OperationsSerializer, OperationsDeserializer};
     /// use massa_signature::KeyPair;
     /// use massa_serialization::{Serializer, Deserializer, DeserializeError};
     /// use std::str::FromStr;
@@ -1285,7 +1292,7 @@ impl Deserializer<Operations> for OperationsDeserializer {
     fn deserialize<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
         &self,
         buffer: &'a [u8],
-    ) -> IResult<&'a [u8], Operations, E> {
+    ) -> IResult<&'a [u8], Vec<WrappedOperation>, E> {
         context(
             "Failed Operations deserialization",
             length_count(

--- a/massa-network-exports/src/commands.rs
+++ b/massa-network-exports/src/commands.rs
@@ -18,7 +18,7 @@
 //!    +-------------->|                |           Forward to Protocol
 //!    |               +--------------->|           Forward to Network, then Node
 //!    |               |                #
-//!    |               |                #           Propagate the batch of OperationIds through the network
+//!    |               |                #           Propagate the batch of Set<OperationId> through the network
 //! ```
 //!
 //! When receiving an operation batch from the network, the `NodeWorker` will
@@ -71,11 +71,8 @@
 
 use crate::{BootstrapPeers, ConnectionClosureReason, Peers};
 use massa_models::{
-    composite::PubkeySig,
-    node::NodeId,
-    operation::{OperationIds, OperationPrefixIds, Operations},
-    stats::NetworkStats,
-    BlockId, WrappedEndorsement, WrappedHeader,
+    composite::PubkeySig, node::NodeId, operation::OperationPrefixIds, prehash::Set,
+    stats::NetworkStats, BlockId, OperationId, WrappedEndorsement, WrappedHeader, WrappedOperation,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, net::IpAddr};
@@ -95,7 +92,7 @@ pub enum NodeCommand {
     /// Close the node worker.
     Close(ConnectionClosureReason),
     /// Send full Operations (send to a node that previously asked for)
-    SendOperations(OperationIds),
+    SendOperations(Set<OperationId>),
     /// Send a batch of operation ids
     SendOperationAnnouncements(OperationPrefixIds),
     /// Ask for a set of operations
@@ -121,7 +118,7 @@ pub enum NodeEventType {
     /// Node we are connected sent info on a list of blocks.
     ReceivedReplyForBlocks(Vec<(BlockId, BlockInfoReply)>),
     /// Received full operations.
-    ReceivedOperations(Operations),
+    ReceivedOperations(Vec<WrappedOperation>),
     /// Received an operation id batch announcing new operations
     ReceivedOperationAnnouncements(OperationPrefixIds),
     /// Receive a list of wanted operations
@@ -142,16 +139,16 @@ pub enum AskForBlocksInfo {
     #[default]
     Info,
     /// The actual operations are required.
-    Operations(OperationIds),
+    Operations(Vec<OperationId>),
 }
 
 /// Reply with the info about a block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ReplyForBlocksInfo {
     /// The info about the block is required(list of operations ids).
-    Info(OperationIds),
+    Info(Vec<OperationId>),
     /// The actual operations required.
-    Operations(OperationIds),
+    Operations(Vec<OperationId>),
     /// Block not found
     NotFound,
 }
@@ -215,7 +212,7 @@ pub enum NetworkCommand {
         /// to node id
         node: NodeId,
         /// operations
-        operations: OperationIds,
+        operations: Set<OperationId>,
     },
     /// Send operation ids batch to a node
     SendOperationAnnouncements {
@@ -241,9 +238,9 @@ pub enum NetworkCommand {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BlockInfoReply {
     /// The info about the block is required(list of operations ids).
-    Info(OperationIds),
+    Info(Vec<OperationId>),
     /// The actual operations required.
-    Operations(Operations),
+    Operations(Vec<WrappedOperation>),
     /// Block not found
     NotFound,
 }
@@ -282,7 +279,7 @@ pub enum NetworkEvent {
         /// node id
         node: NodeId,
         /// operations
-        operations: Operations,
+        operations: Vec<WrappedOperation>,
     },
     /// Receive a list of `OperationId`
     ReceivedOperationAnnouncements {

--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -6,11 +6,8 @@ use crate::{
     BootstrapPeers, NetworkCommand, NetworkEvent, Peers,
 };
 use massa_models::{
-    composite::PubkeySig,
-    node::NodeId,
-    operation::{OperationIds, OperationPrefixIds},
-    stats::NetworkStats,
-    BlockId, WrappedEndorsement,
+    composite::PubkeySig, node::NodeId, operation::OperationPrefixIds, prehash::Set,
+    stats::NetworkStats, BlockId, OperationId, WrappedEndorsement,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -175,7 +172,7 @@ impl NetworkCommandSender {
     pub async fn send_operations(
         &self,
         node: NodeId,
-        operations: OperationIds,
+        operations: Set<OperationId>,
     ) -> Result<(), NetworkError> {
         self.0
             .send(NetworkCommand::SendOperations { node, operations })
@@ -186,7 +183,7 @@ impl NetworkCommandSender {
         Ok(())
     }
 
-    /// Create a new call to the network, sending a announcement of `OperationIds` to a
+    /// Create a new call to the network, sending a announcement of `Set<OperationId>` to a
     /// target node (`to_node`)
     ///
     /// # Returns

--- a/massa-network-worker/src/messages.rs
+++ b/massa-network-worker/src/messages.rs
@@ -7,12 +7,12 @@ use massa_models::{
     operation::OperationPrefixIds,
     operation::{
         OperationIdsDeserializer, OperationIdsSerializer, OperationPrefixIdsDeserializer,
-        OperationPrefixIdsSerializer, Operations, OperationsDeserializer, OperationsSerializer,
+        OperationPrefixIdsSerializer, OperationsDeserializer, OperationsSerializer,
     },
     wrapped::{WrappedDeserializer, WrappedSerializer},
     BlockHeader, BlockHeaderDeserializer, BlockId, Endorsement, EndorsementDeserializer,
     IpAddrDeserializer, IpAddrSerializer, Version, VersionDeserializer, VersionSerializer,
-    WrappedEndorsement, WrappedHeader,
+    WrappedEndorsement, WrappedHeader, WrappedOperation,
 };
 use massa_network_exports::{AskForBlocksInfo, BlockInfoReply};
 use massa_serialization::{
@@ -68,7 +68,7 @@ pub enum Message {
     /// Someone ask for operations.
     AskForOperations(OperationPrefixIds),
     /// A list of operations
-    Operations(Operations),
+    Operations(Vec<WrappedOperation>),
     /// Endorsements
     Endorsements(Vec<WrappedEndorsement>),
 }

--- a/massa-network-worker/src/network_cmd_impl.rs
+++ b/massa-network-worker/src/network_cmd_impl.rs
@@ -24,11 +24,8 @@ use futures::{stream::FuturesUnordered, StreamExt};
 use massa_hash::Hash;
 use massa_logging::massa_trace;
 use massa_models::{
-    composite::PubkeySig,
-    node::NodeId,
-    operation::{OperationIds, OperationPrefixIds},
-    stats::NetworkStats,
-    BlockId, WrappedEndorsement,
+    composite::PubkeySig, node::NodeId, operation::OperationPrefixIds, prehash::Set,
+    stats::NetworkStats, BlockId, OperationId, WrappedEndorsement,
 };
 use massa_network_exports::{
     AskForBlocksInfo, BootstrapPeers, ConnectionClosureReason, ConnectionId, NetworkError,
@@ -354,7 +351,7 @@ pub async fn on_get_stats_cmd(
 pub async fn on_send_operations_cmd(
     worker: &mut NetworkWorker,
     to_node: NodeId,
-    operations: OperationIds,
+    operations: Set<OperationId>,
 ) {
     massa_trace!(
         "network_worker.manage_network_command receive NetworkCommand::SendOperations",

--- a/massa-network-worker/src/network_event.rs
+++ b/massa-network-worker/src/network_event.rs
@@ -79,9 +79,10 @@ impl EventSender {
 pub mod event_impl {
     use crate::network_worker::NetworkWorker;
     use massa_logging::massa_trace;
+    use massa_models::WrappedOperation;
     use massa_models::{
-        node::NodeId, operation::OperationPrefixIds, operation::Operations, wrapped::Id, BlockId,
-        WrappedEndorsement, WrappedHeader,
+        node::NodeId, operation::OperationPrefixIds, wrapped::Id, BlockId, WrappedEndorsement,
+        WrappedHeader,
     };
     use massa_network_exports::{AskForBlocksInfo, BlockInfoReply, NodeCommand};
     use massa_network_exports::{NetworkError, NetworkEvent};
@@ -192,7 +193,7 @@ pub mod event_impl {
     pub async fn on_received_operations(
         worker: &mut NetworkWorker,
         from: NodeId,
-        operations: Operations,
+        operations: Vec<WrappedOperation>,
     ) {
         massa_trace!(
             "network_worker.on_node_event receive NetworkEvent::ReceivedOperations",

--- a/massa-pool-exports/src/controller_traits.rs
+++ b/massa-pool-exports/src/controller_traits.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use massa_models::{Address, BlockId, EndorsementId, OperationId, Operations, Slot};
+use massa_models::{Address, BlockId, EndorsementId, OperationId, Slot};
 use massa_storage::Storage;
 
 /// Trait defining a pool controller

--- a/massa-pool-worker/src/controller_impl.rs
+++ b/massa-pool-worker/src/controller_impl.rs
@@ -1,4 +1,4 @@
-use massa_models::{Address, BlockId, EndorsementId, OperationId, Operations, Slot};
+use massa_models::{Address, BlockId, EndorsementId, OperationId, Slot};
 use massa_pool_exports::{PoolConfig, PoolController};
 use massa_storage::Storage;
 use std::sync::{Arc, RwLock};

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -1,10 +1,8 @@
 use crate::operation_pool::OperationPool;
 use massa_execution_exports::test_exports::MockExecutionController;
 use massa_models::{
-    prehash::{Map, Set},
-    wrapped::WrappedContent,
-    Address, Amount, Operation, OperationId, OperationSerializer, OperationType, Slot,
-    WrappedOperation,
+    prehash::Map, wrapped::WrappedContent, Address, Amount, Operation, OperationSerializer,
+    OperationType, Slot, WrappedOperation,
 };
 use massa_signature::KeyPair;
 use massa_storage::Storage;

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -4,7 +4,6 @@ use crate::error::ProtocolError;
 use massa_logging::massa_trace;
 
 use massa_models::{
-    operation::OperationIds,
     prehash::{Map, Set},
     Slot, WrappedBlock,
 };
@@ -80,7 +79,7 @@ pub enum ProtocolCommand {
         /// block id
         block_id: BlockId,
         /// operations ids in the block
-        operation_ids: OperationIds,
+        operation_ids: Set<OperationId>,
         /// endorsement ids in the block
         endorsement_ids: Vec<EndorsementId>,
     },
@@ -94,9 +93,9 @@ pub enum ProtocolCommand {
         remove: Set<BlockId>,
     },
     /// Propagate operations (send batches)
-    /// note: OperationIds are replaced with OperationPrefixIds
+    /// note: Set<OperationId> are replaced with OperationPrefixIds
     ///       by the controller
-    PropagateOperations(OperationIds),
+    PropagateOperations(Set<OperationId>),
     /// Propagate endorsements
     PropagateEndorsements(Map<EndorsementId, WrappedEndorsement>),
 }
@@ -166,7 +165,7 @@ impl ProtocolCommandSender {
     /// note: Full `OperationId` is replaced by a `OperationPrefixId` later by the worker.
     pub async fn propagate_operations(
         &mut self,
-        operation_ids: OperationIds,
+        operation_ids: Set<OperationId>,
     ) -> Result<(), ProtocolError> {
         massa_trace!("protocol.command_sender.propagate_operations", {
             "operations": operation_ids

--- a/massa-protocol-exports/src/tests/mock_network_controller.rs
+++ b/massa-protocol-exports/src/tests/mock_network_controller.rs
@@ -1,11 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use massa_models::{
-    constants::CHANNEL_SIZE,
-    node::NodeId,
-    operation::{OperationIds, Operations},
-};
-use massa_models::{BlockId, WrappedEndorsement, WrappedHeader};
+use massa_models::{constants::CHANNEL_SIZE, node::NodeId, prehash::Set, OperationId};
+use massa_models::{BlockId, WrappedEndorsement, WrappedHeader, WrappedOperation};
 use massa_network_exports::{
     AskForBlocksInfo, BlockInfoReply, NetworkCommand, NetworkCommandSender, NetworkEvent,
     NetworkEventReceiver,
@@ -83,7 +79,11 @@ impl MockNetworkController {
 
     /// send operations
     /// todo inconsistency with names
-    pub async fn send_operations(&mut self, source_node_id: NodeId, operations: Operations) {
+    pub async fn send_operations(
+        &mut self,
+        source_node_id: NodeId,
+        operations: Vec<WrappedOperation>,
+    ) {
         self.network_event_tx
             .send(NetworkEvent::ReceivedOperations {
                 node: source_node_id,
@@ -98,7 +98,7 @@ impl MockNetworkController {
     pub async fn send_operation_batch(
         &mut self,
         source_node_id: NodeId,
-        operation_ids: OperationIds,
+        operation_ids: Set<OperationId>,
     ) {
         self.network_event_tx
             .send(NetworkEvent::ReceivedOperationAnnouncements {
@@ -114,7 +114,7 @@ impl MockNetworkController {
     pub async fn send_ask_for_operation(
         &mut self,
         source_node_id: NodeId,
-        operation_ids: OperationIds,
+        operation_ids: Set<OperationId>,
     ) {
         self.network_event_tx
             .send(NetworkEvent::ReceiveAskForOperations {

--- a/massa-protocol-worker/src/checked_operations.rs
+++ b/massa-protocol-worker/src/checked_operations.rs
@@ -21,7 +21,7 @@ impl CheckedOperations {
         self.0.insert(prefix, *id).is_none()
     }
 
-    /// Get a set of [OperationIds] matching with the givec `prefix`.
+    /// Get a set of [Set<OperationId>] matching with the givec `prefix`.
     pub fn get(&self, prefix: &OperationPrefixId) -> Option<&OperationId> {
         self.0.get(prefix)
     }

--- a/massa-protocol-worker/src/node_info.rs
+++ b/massa-protocol-worker/src/node_info.rs
@@ -6,10 +6,7 @@
 //! Same as for wanted/known blocks, we remember here in cache which node asked
 //! for operations and which operations he seem to already know.
 
-use massa_models::{
-    operation::OperationIds,
-    prehash::{BuildMap, Map, Set},
-};
+use massa_models::prehash::{BuildMap, Map, Set};
 use massa_models::{BlockId, EndorsementId, OperationId};
 use massa_protocol_exports::ProtocolConfig;
 use std::collections::VecDeque;
@@ -27,7 +24,7 @@ pub(crate) struct NodeInfo {
     /// Instant when the node was added
     pub connection_instant: Instant,
     /// all known operations
-    known_operations: OperationIds,
+    known_operations: Set<OperationId>,
     /// Same as `known_operations` but sorted for a premature optimization :-)
     known_operations_queue: VecDeque<OperationId>,
     /// all known endorsements

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -8,10 +8,9 @@ use massa_hash::Hash;
 use massa_logging::massa_trace;
 use massa_models::{
     node::NodeId,
-    operation::{OperationIds, Operations},
     prehash::{BuildMap, Set},
     wrapped::{Id, Wrapped},
-    BlockId, BlockSerializer,
+    BlockId, BlockSerializer, OperationId, WrappedOperation,
 };
 use massa_models::{Block, WrappedBlock};
 use massa_network_exports::{AskForBlocksInfo, BlockInfoReply, NetworkEvent, ReplyForBlocksInfo};
@@ -224,7 +223,7 @@ impl ProtocolWorker {
         &mut self,
         from_node_id: NodeId,
         block_id: BlockId,
-        operation_ids: OperationIds,
+        operation_ids: Vec<OperationId>,
     ) -> Result<(), ProtocolError> {
         match self.block_wishlist.get(&block_id) {
             Some(AskForBlocksInfo::Info) => {}
@@ -302,15 +301,15 @@ impl ProtocolWorker {
         &mut self,
         from_node_id: NodeId,
         block_id: BlockId,
-        operations: Operations,
+        operations: Vec<WrappedOperation>,
     ) -> Result<(), ProtocolError> {
         let (tx, rx) = oneshot::channel();
         self.note_operations_from_node(operations.clone(), &from_node_id, Some(tx))
             .await?;
         let _ = rx.await;
 
-        let wanted_operation_ids = match self.block_wishlist.get(&block_id) {
-            Some(AskForBlocksInfo::Operations(ids)) => ids,
+        let wanted_operation_ids: Set<OperationId> = match self.block_wishlist.get(&block_id) {
+            Some(AskForBlocksInfo::Operations(ids)) => ids.clone().into_iter().collect(),
             _ => return Ok(()),
         };
         let info = match self.checked_headers.get(&block_id) {
@@ -321,7 +320,7 @@ impl ProtocolWorker {
             }
         };
 
-        let mut received_ids: OperationIds = Default::default();
+        let mut received_ids: Set<OperationId> = Default::default();
         let mut full_op_size = info.operations_size;
 
         // Ban the node if:
@@ -339,7 +338,7 @@ impl ProtocolWorker {
                 return Ok(());
             }
         }
-        if wanted_operation_ids != &received_ids {
+        if wanted_operation_ids != received_ids {
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());
         }

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -8,11 +8,11 @@ use massa_logging::massa_trace;
 use massa_models::{
     constants::CHANNEL_SIZE,
     node::NodeId,
-    operation::{OperationIds, OperationPrefixId, Operations},
+    operation::OperationPrefixId,
     prehash::{BuildMap, Map, Set},
     BlockHeaderSerializer, BlockId, EndorsementId, OperationId, WrappedEndorsement, WrappedHeader,
 };
-use massa_models::{EndorsementSerializer, OperationSerializer};
+use massa_models::{EndorsementSerializer, OperationSerializer, WrappedOperation};
 use massa_network_exports::{AskForBlocksInfo, NetworkCommandSender, NetworkEventReceiver};
 use massa_protocol_exports::{
     ProtocolCommand, ProtocolCommandSender, ProtocolConfig, ProtocolError, ProtocolEvent,
@@ -104,7 +104,7 @@ pub(crate) struct BlockInfo {
     pub(crate) endorsements: Map<EndorsementId, u32>,
     /// Operations contained in the block,
     /// if we've received them already, and none otherwise.
-    pub(crate) operations: Option<Set<OperationId>>,
+    pub(crate) operations: Option<Vec<OperationId>>,
     /// The header of the block.
     pub(crate) header: WrappedHeader,
     /// Full operations size in bytes
@@ -412,7 +412,7 @@ impl ProtocolWorker {
                     self.checked_operations.insert(id);
                 }
                 for (node, node_info) in self.active_nodes.iter_mut() {
-                    let new_ops: OperationIds = operation_ids
+                    let new_ops: Set<OperationId> = operation_ids
                         .iter()
                         .filter(|id| !node_info.knows_op(id))
                         .copied()
@@ -871,7 +871,7 @@ impl ProtocolWorker {
     /// - Valid signature
     pub(crate) async fn note_operations_from_node(
         &mut self,
-        operations: Operations,
+        operations: Vec<WrappedOperation>,
         source_node_id: &NodeId,
         done_signal: Option<oneshot::Sender<()>>,
     ) -> Result<(Vec<OperationId>, Map<OperationId, usize>), ProtocolError> {

--- a/massa-protocol-worker/src/tests/operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/operations_scenarios.rs
@@ -5,8 +5,8 @@
 use super::tools::{protocol_test, protocol_test_with_storage};
 use massa_models::constants::THREAD_COUNT;
 use massa_models::prehash::Map;
-use massa_models::{self, Address, Amount, Slot};
-use massa_models::{operation::OperationIds, prehash::Set};
+use massa_models::prehash::Set;
+use massa_models::{self, Address, Amount, OperationId, Slot};
 use massa_network_exports::NetworkCommand;
 use massa_protocol_exports::tests::tools;
 use massa_protocol_exports::{BlocksResults, ProtocolEvent, ProtocolPoolEvent};
@@ -188,7 +188,7 @@ async fn test_protocol_propagates_operations_to_active_nodes() {
 
             let expected_operation_id = operation.verify_integrity().unwrap();
 
-            let mut ops = OperationIds::default();
+            let mut ops: Set<OperationId> = Set::default();
             ops.insert(expected_operation_id);
             protocol_command_sender
                 .propagate_operations(ops)
@@ -267,7 +267,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
 
             let expected_operation_id = operation.verify_integrity().unwrap();
 
-            let mut ops = OperationIds::default();
+            let mut ops: Set<OperationId> = Set::default();
             ops.insert(expected_operation_id);
 
             // send endorsement to protocol
@@ -355,7 +355,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             // Send the endorsement to protocol
             // it should not propagate to the node that already knows about it
             // because of the previously integrated block.
-            let mut ops = OperationIds::default();
+            let mut ops: Set<OperationId> = Set::default();
             ops.insert(operation_id);
             protocol_command_sender
                 .propagate_operations(ops)
@@ -425,7 +425,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
 
             // Send the block as search results.
             let mut results: BlocksResults = Map::default();
-            let mut ops = OperationIds::default();
+            let mut ops: Set<OperationId> = Set::default();
             ops.insert(operation_id);
             results.insert(expected_block_id, Some((Some(ops), None)));
 
@@ -750,7 +750,7 @@ async fn test_protocol_ask_operations_on_batch_received() {
             network_controller
                 .send_operation_batch(
                     creator_node.id,
-                    OperationIds::from_iter(vec![expected_operation_id].iter().cloned()),
+                    Set::from_iter(vec![expected_operation_id].iter().cloned()),
                 )
                 .await;
 
@@ -815,10 +815,7 @@ async fn test_protocol_on_ask_operations() {
             let asker_node = nodes.pop().expect("Failed to get the second node info.");
 
             network_controller
-                .send_ask_for_operation(
-                    asker_node.id,
-                    OperationIds::from_iter(vec![expected_operation_id]),
-                )
+                .send_ask_for_operation(asker_node.id, Set::from_iter(vec![expected_operation_id]))
                 .await;
 
             // 4. Assert the operation is sent to the node.

--- a/massa-protocol-worker/src/tests/scenarios.rs
+++ b/massa-protocol-worker/src/tests/scenarios.rs
@@ -257,7 +257,7 @@ async fn test_protocol_propagates_block_to_node_who_asked_for_it_and_only_header
                 .map(|endo| endo.id)
                 .collect();
             protocol_command_sender
-                .integrated_block(ref_hash, op_ids, endo_ids)
+                .integrated_block(ref_hash, op_ids.into_iter().collect(), endo_ids)
                 .await
                 .expect("Failed to ask for block.");
 

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -14,8 +14,9 @@ use crate::protocol_worker::ProtocolWorker;
 use massa_logging::massa_trace;
 use massa_models::{
     node::NodeId,
-    operation::{OperationIds, OperationPrefixIds, Operations},
-    prehash::BuildMap,
+    operation::OperationPrefixIds,
+    prehash::{BuildMap, Set},
+    WrappedOperation,
 };
 use massa_protocol_exports::ProtocolError;
 use massa_time::TimeError;
@@ -132,7 +133,11 @@ impl ProtocolWorker {
     /// - Update the cache `received_operations` ids and each
     ///   `node_info.known_operations`
     /// - Notify the operations to he local node, to be propagated
-    pub(crate) async fn on_operations_received(&mut self, node_id: NodeId, operations: Operations) {
+    pub(crate) async fn on_operations_received(
+        &mut self,
+        node_id: NodeId,
+        operations: Vec<WrappedOperation>,
+    ) {
         if self
             .note_operations_from_node(operations, &node_id, None)
             .await
@@ -197,7 +202,7 @@ impl ProtocolWorker {
         node_id: NodeId,
         op_pre_ids: OperationPrefixIds,
     ) -> Result<(), ProtocolError> {
-        let mut req_operation_ids = OperationIds::default();
+        let mut req_operation_ids = Set::default();
         for prefix in op_pre_ids {
             if let Some(op_id) = self.checked_operations.get(&prefix) {
                 req_operation_ids.insert(*op_id);

--- a/massa-storage/src/block_indexes.rs
+++ b/massa-storage/src/block_indexes.rs
@@ -19,6 +19,9 @@ pub struct BlockIndexes {
 }
 
 impl BlockIndexes {
+    /// Insert a block and populate the indexes.
+    /// Arguments:
+    /// - block: the block to insert
     pub(crate) fn insert(&mut self, block: WrappedBlock) {
         let id = block.id;
         let creator = block.creator_address;
@@ -30,6 +33,9 @@ impl BlockIndexes {
             .or_insert(Arc::new(RwLock::new(block)));
     }
 
+    /// Remove a block, remove from the indexes and made some clean-up in indexes if necessary.
+    /// Arguments:
+    /// - block_id: the block id to remove
     pub(crate) fn remove(&mut self, block_id: &BlockId) {
         let block = self
             .blocks
@@ -45,6 +51,12 @@ impl BlockIndexes {
         self.index_by_slot.remove(&slot);
     }
 
+    /// Get the block ids created by an address.
+    /// Arguments:
+    /// - address: the address to get the blocks created by
+    ///
+    /// Returns:
+    /// - the block ids created by the address
     pub fn get_blocks_created_by(&self, address: &Address) -> Vec<BlockId> {
         match self.index_by_creator.get(address) {
             Some(blocks) => blocks.iter().cloned().collect(),
@@ -52,6 +64,12 @@ impl BlockIndexes {
         }
     }
 
+    /// Get the block id of the block at a slot.
+    /// Arguments:
+    /// - slot: the slot to get the block id of
+    ///
+    /// Returns:
+    /// - the block id of the block at the slot if exists, None otherwise
     pub fn get_block_by_slot(&self, slot: Slot) -> Option<&BlockId> {
         self.index_by_slot.get(&slot)
     }

--- a/massa-storage/src/endorsement_indexes.rs
+++ b/massa-storage/src/endorsement_indexes.rs
@@ -16,6 +16,9 @@ pub struct EndorsementIndexes {
 }
 
 impl EndorsementIndexes {
+    /// Insert a batch of endorsements and populate the indexes.
+    /// Arguments:
+    /// - endorsements: the endorsements to insert
     pub(crate) fn batch_insert(&mut self, endorsements: Vec<WrappedEndorsement>) {
         for endorsement in endorsements {
             let id = endorsement.id;
@@ -25,13 +28,16 @@ impl EndorsementIndexes {
         }
     }
 
+    /// Remove a batch of endorsements, remove from the indexes and made some clean-up in indexes if necessary.
+    /// Arguments:
+    /// - endorsement_ids: the endorsement ids to remove
     pub(crate) fn batch_remove(&mut self, endorsement_ids: Vec<EndorsementId>) {
         for id in endorsement_ids {
-            let operation = self
+            let endorsement = self
                 .endorsements
                 .remove(&id)
                 .expect("removing absent object from storage");
-            let creator = operation.creator_address;
+            let creator = endorsement.creator_address;
             let entry = self.index_by_creator.entry(creator).or_default();
             entry.remove(&id);
             if entry.is_empty() {
@@ -40,21 +46,34 @@ impl EndorsementIndexes {
         }
     }
 
+    /// Link a vector of endorsements to a block. Should be used in case of the block is added to the storage.
+    /// Arguments:
+    /// - block_id: the block id to link the endorsements to
+    /// - endorsement_ids: the endorsements to link to the block
     pub(crate) fn link_endorsements_with_block(
         &mut self,
         block_id: &BlockId,
-        operations: &Vec<EndorsementId>,
+        endorsement_ids: &Vec<EndorsementId>,
     ) {
         self.index_by_block
             .entry(*block_id)
             .or_default()
-            .extend(operations);
+            .extend(endorsement_ids);
     }
 
+    /// Unlink a vector of endorsements from a block. Should be used in case of the block is removed from the storage.
+    /// Arguments:
+    /// - block_id: the block id to unlink the endorsements from
     pub(crate) fn unlink_endorsements_from_block(&mut self, block_id: &BlockId) {
         self.index_by_block.remove(block_id);
     }
 
+    /// Get endorsements created by an address
+    /// Arguments:
+    /// - address: the address to get the endorsements created by
+    ///
+    /// Returns:
+    /// - the endorsements created by the address
     pub fn _get_endorsements_created_by(&self, address: &Address) -> Vec<EndorsementId> {
         match self.index_by_creator.get(address) {
             Some(endorsements) => endorsements.iter().cloned().collect(),
@@ -62,6 +81,12 @@ impl EndorsementIndexes {
         }
     }
 
+    /// Get endorsements by the id of the block they are contained in
+    /// Arguments:
+    /// - block_id: the id of the block to get the endorsements from
+    ///
+    /// Returns:
+    /// - the endorsements contained in the block
     pub fn _get_endorsements_in_block(&self, block_id: &BlockId) -> Vec<EndorsementId> {
         match self.index_by_block.get(block_id) {
             Some(endorsements) => endorsements.iter().cloned().collect(),


### PR DESCRIPTION
Fix #2874