### PR TITLE
Fix node basic features in sandbox.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,6 +2019,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/massa-api/src/lib.rs
+++ b/massa-api/src/lib.rs
@@ -241,7 +241,7 @@ pub trait Endpoints {
 
     /// Get information on the block at a slot in the blockclique.
     /// If there is no block at this slot a `None` is returned.
-    #[rpc(name = "get_block")]
+    #[rpc(name = "get_blockclique_block_by_slot")]
     fn get_blockclique_block_by_slot(&self, _: Slot) -> BoxFuture<Result<Option<Block>, ApiError>>;
 
     /// Get the block graph within the specified time interval.

--- a/massa-factory-worker/src/tests/tools.rs
+++ b/massa-factory-worker/src/tests/tools.rs
@@ -191,11 +191,11 @@ impl TestFactory {
                         let ids = operations.iter().map(|op| op.id).collect();
                         let mut storage = self.storage.clone_without_refs();
                         storage.store_operations(operations.clone());
-                        response_tx.send((ids, self.storage.clone())).unwrap();
+                        response_tx.send((ids, storage.clone())).unwrap();
                         Some(())
                     } else {
                         response_tx.send((vec![], Storage::default())).unwrap();
-                        None
+                        Some(())
                     }
                 }
                 _ => panic!("unexpected message"),

--- a/massa-network-exports/Cargo.toml
+++ b/massa-network-exports/Cargo.toml
@@ -20,6 +20,10 @@ massa_serialization = { path = "../massa-serialization" }
 massa_signature = { path = "../massa-signature" }
 serde_json = "1.0"
 tempfile = { version = "3.3", optional = true }   #used with testing feature
+tracing = { version = "0.1", features = [
+    "max_level_debug",
+    "release_max_level_debug",
+] }
 
 [dev-dependencies]
 massa_models = { path = "../massa-models", features = ["testing"] }

--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -9,6 +9,7 @@ use massa_models::{
     composite::PubkeySig, node::NodeId, operation::OperationPrefixIds, stats::NetworkStats,
     BlockId, OperationId, WrappedEndorsement,
 };
+use tracing::info;
 use std::{
     collections::{HashMap, VecDeque},
     net::IpAddr,
@@ -292,9 +293,11 @@ impl NetworkManager {
         self,
         network_event_receiver: NetworkEventReceiver,
     ) -> Result<(), NetworkError> {
+        info!("stopping network manager...");
         drop(self.manager_tx);
         let _remaining_events = network_event_receiver.drain().await;
         let _ = self.join_handle.await?;
+        info!("network manager stopped");
         Ok(())
     }
 }

--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -9,7 +9,6 @@ use massa_models::{
     composite::PubkeySig, node::NodeId, operation::OperationPrefixIds, stats::NetworkStats,
     BlockId, OperationId, WrappedEndorsement,
 };
-use tracing::info;
 use std::{
     collections::{HashMap, VecDeque},
     net::IpAddr,
@@ -18,6 +17,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
+use tracing::info;
 
 /// Network command sender
 #[derive(Clone)]

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -31,7 +31,7 @@ impl EndorsementPool {
         EndorsementPool {
             last_cs_final_periods: vec![0u64; config.thread_count as usize],
             endorsements_indexed: Default::default(),
-            endorsements_sorted: Default::default(),
+            endorsements_sorted: vec![Default::default(); config.thread_count as usize],
             config,
             storage: storage.clone_without_refs(),
         }
@@ -52,10 +52,6 @@ impl EndorsementPool {
         // update internal final CS period counter
         self.last_cs_final_periods = final_cs_periods.to_vec();
 
-        // At start there is no endorsements in `endorsements_sorted`.
-        if self.endorsements_sorted.is_empty() {
-            return;
-        }
         // remove old endorsements
         let mut removed: Set<EndorsementId> = Default::default();
         for thread in 0..self.config.thread_count {

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -52,6 +52,10 @@ impl EndorsementPool {
         // update internal final CS period counter
         self.last_cs_final_periods = final_cs_periods.to_vec();
 
+        // At start there is no endorsements in `endorsements_sorted`.
+        if self.endorsements_sorted.is_empty() {
+            return;
+        }
         // remove old endorsements
         let mut removed: Set<EndorsementId> = Default::default();
         for thread in 0..self.config.thread_count {

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -104,7 +104,12 @@ impl EndorsementPool {
                 );
                 // note that we don't want equivalent endorsements (slot, index, block etc...) to overwrite each other
                 if self.endorsements_indexed.try_insert(key, endo.id).is_ok() {
-                    self.endorsements_sorted[endo.content.slot.thread as usize].insert(key,endo.id).expect("endorsement is expected to be absent from endorsements_sorted at this point");
+                    if self.endorsements_sorted[endo.content.slot.thread as usize]
+                        .insert(key, endo.id)
+                        .is_some()
+                    {
+                        panic!("endorsement is expected to be absent from endorsements_sorted at this point");
+                    }
                     added.insert(endo.id);
                 }
             }

--- a/massa-pos-exports/src/pos_final_state_impl.rs
+++ b/massa-pos-exports/src/pos_final_state_impl.rs
@@ -1,4 +1,7 @@
-use std::{collections::{BTreeMap, VecDeque}, path::PathBuf};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    path::PathBuf,
+};
 
 use massa_hash::Hash;
 use massa_models::{prehash::Map, Address, Amount, Slot};
@@ -33,7 +36,7 @@ impl PoSFinalState {
             rng_seed: Default::default(),
             production_stats: Default::default(),
             roll_counts: initial_rolls.clone(),
-            complete: false
+            complete: false,
         });
         Ok(Self {
             cycle_history,

--- a/massa-pos-exports/src/pos_final_state_impl.rs
+++ b/massa-pos-exports/src/pos_final_state_impl.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::{BTreeMap, VecDeque}, path::PathBuf};
 
 use massa_hash::Hash;
 use massa_models::{prehash::Map, Address, Amount, Slot};
@@ -22,12 +22,21 @@ impl PoSFinalState {
         )
         .map_err(|err| PosError::RollsFileLoadingError(format!("error opening file: {}", err)))?;
 
-        // Seeds used as the initial seeds for negative cycles (-2 and -1 respecrively)
+        // Seeds used as the initial seeds for negative cycles (-2 and -1 respectively)
         let init_seed = Hash::compute_from(initial_seed_string.as_bytes());
         let initial_seeds = vec![Hash::compute_from(init_seed.to_bytes()), init_seed];
 
+        let mut cycle_history = VecDeque::new();
+        cycle_history.push_back(CycleInfo {
+            cycle: 0,
+            // TODO: Feed with genesis block hashes
+            rng_seed: Default::default(),
+            production_stats: Default::default(),
+            roll_counts: initial_rolls.clone(),
+            complete: false
+        });
         Ok(Self {
-            cycle_history: Default::default(),
+            cycle_history,
             deferred_credits: Default::default(),
             selector,
             initial_rolls,
@@ -115,6 +124,7 @@ impl PoSFinalState {
             if info.cycle != cycle {
                 self.cycle_history.push_back(CycleInfo {
                     cycle,
+                    roll_counts: info.roll_counts.clone(),
                     ..Default::default()
                 });
                 // add 1 for the current cycle and 1 for bootstrap safety
@@ -125,6 +135,7 @@ impl PoSFinalState {
         } else {
             self.cycle_history.push_back(CycleInfo {
                 cycle,
+                roll_counts: self.initial_rolls.clone(),
                 ..Default::default()
             });
         }

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -14,7 +14,7 @@ use massa_network_exports::NetworkEventReceiver;
 use massa_storage::Storage;
 use serde::Serialize;
 use tokio::{sync::mpsc, task::JoinHandle};
-use tracing::debug;
+use tracing::{debug, info};
 
 /// Possible types of events that can happen.
 #[allow(clippy::large_enum_variant)]
@@ -216,10 +216,11 @@ impl ProtocolManager {
         protocol_event_receiver: ProtocolEventReceiver,
         //protocol_pool_event_receiver: ProtocolPoolEventReceiver,
     ) -> Result<NetworkEventReceiver, ProtocolError> {
-        let _remaining_events = protocol_event_receiver.drain().await;
+        info!("stopping protocol controller...");
         drop(self.manager_tx);
-        //let _remaining_events = protocol_pool_event_receiver.drain().await;
+        let _remaining_events = protocol_event_receiver.drain().await;
         let network_event_receiver = self.join_handle.await??;
+        info!("protocol controller stopped");
         Ok(network_event_receiver)
     }
 }

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -78,9 +78,6 @@ pub struct ProtocolConfig {
 
 impl From<ProtocolSettings> for ProtocolConfig {
     fn from(settings: ProtocolSettings) -> Self {
-        #[cfg(feature = "sandbox")]
-        let thread_count = *THREAD_COUNT;
-        #[cfg(not(feature = "sandbox"))]
         let thread_count = THREAD_COUNT;
 
         Self {


### PR DESCRIPTION
Fix included here : 

- Stop the node where stuck in protocol stop
- Endorsement pool crash at launch because try to fetch endorsements that are not created at first period.
- Initial rolls not stored in `cycle_history`
- Get block endpoint API was override
- Fix #2917 

Working on : 
- No endorsements in block
- No rewards for block creator
- Client formatting

More to come in this PR...