### PR TITLE
Enhancements for storage in protocol

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -798,6 +798,7 @@ impl Endpoints for API<Public> {
         let mut cmd_sender = self.0.pool_command_sender.clone();
         let mut protocol_sender = self.0.protocol_command_sender.clone();
         let api_cfg = self.0.api_settings;
+        let mut to_send = self.0.storage.clone_without_refs();
         let closure = async move || {
             if ops.len() as u64 > api_cfg.max_arguments {
                 return Err(ApiError::TooManyArguments("too many arguments".into()));
@@ -835,7 +836,6 @@ impl Endpoints for API<Public> {
                     Err(e) => Err(e),
                 })
                 .collect::<Result<Vec<WrappedOperation>, ApiError>>()?;
-            let mut to_send = Storage::default();
             to_send.store_operations(verified_ops.clone());
             let ids: Vec<OperationId> = verified_ops.iter().map(|op| op.id).collect();
             cmd_sender.add_operations(to_send.clone());

--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -838,10 +838,8 @@ impl Endpoints for API<Public> {
             let mut to_send = Storage::default();
             to_send.store_operations(verified_ops.clone());
             let ids: Vec<OperationId> = verified_ops.iter().map(|op| op.id).collect();
-            cmd_sender.add_operations(to_send);
-            protocol_sender
-                .propagate_operations(ids.iter().cloned().collect())
-                .await?;
+            cmd_sender.add_operations(to_send.clone());
+            protocol_sender.propagate_operations(to_send).await?;
             Ok(ids)
         };
         Box::pin(closure())

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -70,7 +70,7 @@ pub enum ProtocolCommand {
     /// Propagate operations (send batches)
     /// note: Set<OperationId> are replaced with OperationPrefixIds
     ///       by the controller
-    PropagateOperations(Set<OperationId>),
+    PropagateOperations(Storage),
     /// Propagate endorsements
     PropagateEndorsements(Storage),
 }
@@ -134,15 +134,12 @@ impl ProtocolCommandSender {
     /// Propagate a batch of operation ids (from pool).
     ///
     /// note: Full `OperationId` is replaced by a `OperationPrefixId` later by the worker.
-    pub async fn propagate_operations(
-        &mut self,
-        operation_ids: Set<OperationId>,
-    ) -> Result<(), ProtocolError> {
+    pub async fn propagate_operations(&mut self, operations: Storage) -> Result<(), ProtocolError> {
         massa_trace!("protocol.command_sender.propagate_operations", {
-            "operations": operation_ids
+            "operations": operations.get_op_refs()
         });
         self.0
-            .send(ProtocolCommand::PropagateOperations(operation_ids))
+            .send(ProtocolCommand::PropagateOperations(operations))
             .await
             .map_err(|_| {
                 ProtocolError::ChannelError("propagate_operation command send error".into())

--- a/massa-protocol-worker/src/checked_operations.rs
+++ b/massa-protocol-worker/src/checked_operations.rs
@@ -22,7 +22,9 @@ impl CheckedOperations {
     }
 
     pub fn extend(&mut self, ids: &Set<OperationId>) {
-        let _ = ids.iter().map(|id| self.insert(id));
+        ids.iter().for_each(|id| {
+            self.insert(id);
+        });
     }
 
     /// Get a operation id matching with the givec `prefix` or None if there is none.

--- a/massa-protocol-worker/src/checked_operations.rs
+++ b/massa-protocol-worker/src/checked_operations.rs
@@ -21,6 +21,10 @@ impl CheckedOperations {
         self.0.insert(prefix, *id).is_none()
     }
 
+    pub fn extend(&mut self, ids: &Set<OperationId>) {
+        let _ = ids.iter().map(|id| self.insert(id));
+    }
+
     /// Get a operation id matching with the givec `prefix` or None if there is none.
     pub fn get(&self, prefix: &OperationPrefixId) -> Option<&OperationId> {
         self.0.get(prefix)

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -375,11 +375,13 @@ impl ProtocolWorker {
                     {}
                 );
             }
-            ProtocolCommand::PropagateOperations(operation_ids) => {
+            ProtocolCommand::PropagateOperations(operations) => {
+                let operation_ids = operations.get_op_refs().clone();
                 massa_trace!(
                     "protocol.protocol_worker.process_command.propagate_operations.begin",
                     { "operation_ids": operation_ids }
                 );
+                self.storage.extend(operations);
                 for id in operation_ids.iter() {
                     self.checked_operations.insert(id);
                 }

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -141,7 +141,7 @@ pub struct ProtocolWorker {
     pub(crate) active_nodes: HashMap<NodeId, NodeInfo>,
     /// List of wanted blocks,
     /// with the info representing their state withint the as_block workflow.
-    pub(crate) block_wishlist: Map<BlockId, AskForBlocksInfo>,
+    pub(crate) block_wishlist: Map<BlockId, (AskForBlocksInfo, Option<Storage>)>,
     /// List of processed endorsements
     checked_endorsements: Set<EndorsementId>,
     /// List of processed operations
@@ -367,7 +367,8 @@ impl ProtocolWorker {
                 massa_trace!("protocol.protocol_worker.process_command.wishlist_delta.begin", { "new": new, "remove": remove });
                 self.stop_asking_blocks(remove)?;
                 for block in new.into_iter() {
-                    self.block_wishlist.insert(block, AskForBlocksInfo::Info);
+                    self.block_wishlist
+                        .insert(block, (AskForBlocksInfo::Info, None));
                 }
                 self.update_ask_block(timer).await?;
                 massa_trace!(
@@ -623,7 +624,7 @@ impl ProtocolWorker {
                 ask_block_list
                     .entry(best_node)
                     .or_insert_with(Vec::new)
-                    .push((hash, required_info.clone()));
+                    .push((hash, required_info.0.clone()));
 
                 let timeout_at = now
                     .checked_add(self.config.ask_block_timeout.into())


### PR DESCRIPTION
- Keep a storage while getting block information to ensure that we don't drop the operations.
- Replace Set<OperationId> with a storage in Propagate operation.