### PR TITLE
Clean up massa-network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,7 +2035,6 @@ dependencies = [
  "massa_network_exports",
  "massa_serialization",
  "massa_signature",
- "massa_storage",
  "massa_time",
  "nom 7.1.1",
  "num_enum",

--- a/massa-execution-worker/src/active_history.rs
+++ b/massa-execution-worker/src/active_history.rs
@@ -20,6 +20,7 @@ pub enum HistorySearchResult<T> {
 }
 
 /// Result of the search for a slot index in history
+#[derive(Debug)]
 pub enum SlotIndexPosition {
     /// out of bounds in the past
     Past,
@@ -257,7 +258,7 @@ impl ActiveHistory {
             // cycle ends before history starts
             (_, SlotIndexPosition::Past) => (0..0, true, false),
 
-            // the history is stricly icluded within the cycle
+            // the history is strictly included within the cycle
             (SlotIndexPosition::Past, SlotIndexPosition::Future) => (0..self.0.len(), true, true),
 
             // cycle begins before and ends during history

--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -704,7 +704,7 @@ impl ExecutionContext {
             self.cancel_async_message(&msg);
         }
 
-        // execute the deferred credites comming from roll sells
+        // execute the deferred credits coming from roll sells
         self.execute_deferred_credits(&slot);
 
         // if the current slot is last in cycle check the production stats and act accordingly

--- a/massa-graph/src/export_active_block.rs
+++ b/massa-graph/src/export_active_block.rs
@@ -178,8 +178,6 @@ impl Serializer<ExportActiveBlock> for ExportActiveBlockSerializer {
         // finality
         buffer.push(if value.is_final { 1u8 } else { 0u8 });
 
-        // Todo aurelien : virer
-
         Ok(())
     }
 }

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-network-exports/src/lib.rs
+++ b/massa-network-exports/src/lib.rs
@@ -6,7 +6,7 @@
 
 pub use commands::{
     AskForBlocksInfo, BlockInfoReply, NetworkCommand, NetworkEvent, NetworkManagementCommand,
-    NodeCommand, NodeEvent, NodeEventType, ReplyForBlocksInfo,
+    NodeCommand, NodeEvent, NodeEventType,
 };
 
 pub use common::{ConnectionClosureReason, ConnectionId};

--- a/massa-network-exports/src/network_controller.rs
+++ b/massa-network-exports/src/network_controller.rs
@@ -1,16 +1,16 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::{
-    commands::{AskForBlocksInfo, NetworkManagementCommand, ReplyForBlocksInfo},
+    commands::{AskForBlocksInfo, NetworkManagementCommand},
     error::NetworkError,
-    BootstrapPeers, NetworkCommand, NetworkEvent, Peers,
+    BlockInfoReply, BootstrapPeers, NetworkCommand, NetworkEvent, Peers,
 };
 use massa_models::{
-    block::BlockId,
+    block::{BlockId, WrappedHeader},
     composite::PubkeySig,
     endorsement::WrappedEndorsement,
     node::NodeId,
-    operation::{OperationId, OperationPrefixIds},
+    operation::{OperationPrefixIds, WrappedOperation},
     stats::NetworkStats,
 };
 use std::{
@@ -88,7 +88,7 @@ impl NetworkCommandSender {
     pub async fn send_block_info(
         &self,
         node: NodeId,
-        info: Vec<(BlockId, ReplyForBlocksInfo)>,
+        info: Vec<(BlockId, BlockInfoReply)>,
     ) -> Result<(), NetworkError> {
         self.0
             .send(NetworkCommand::SendBlockInfo { node, info })
@@ -120,10 +120,10 @@ impl NetworkCommandSender {
     pub async fn send_block_header(
         &self,
         node: NodeId,
-        block_id: BlockId,
+        header: WrappedHeader,
     ) -> Result<(), NetworkError> {
         self.0
-            .send(NetworkCommand::SendBlockHeader { node, block_id })
+            .send(NetworkCommand::SendBlockHeader { node, header })
             .await
             .map_err(|_| {
                 NetworkError::ChannelError("could not send SendBlockHeader command".into())
@@ -177,7 +177,7 @@ impl NetworkCommandSender {
     pub async fn send_operations(
         &self,
         node: NodeId,
-        operations: Vec<OperationId>,
+        operations: Vec<WrappedOperation>,
     ) -> Result<(), NetworkError> {
         self.0
             .send(NetworkCommand::SendOperations { node, operations })

--- a/massa-network-worker/Cargo.toml
+++ b/massa-network-worker/Cargo.toml
@@ -24,7 +24,6 @@ massa_network_exports = { path = "../massa-network-exports" }
 massa_logging = { path = "../massa-logging" }
 massa_models = { path = "../massa-models" }
 massa_serialization = { path = "../massa-serialization" }
-massa_storage = { path = "../massa-storage" }
 massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
 

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -171,7 +171,7 @@ impl ReadBinder {
             .message_deserializer
             .deserialize::<DeserializeError>(&self.buf)
             .map_err(|err| {
-                panic!("deserialization error: {:?}, input: {}", err, &self.buf);
+                panic!("deserialization error: {:?}, input: {:#?}", err, &self.buf);
                 NetworkError::ModelsError(ModelsError::DeserializeError(err.to_string()))
             })?;
 

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -11,7 +11,6 @@ use massa_models::{
 };
 use massa_network_exports::{NetworkError, ReadHalf, WriteHalf};
 use massa_serialization::{DeserializeError, Deserializer};
-use tracing::info;
 use std::convert::TryInto;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -172,7 +171,7 @@ impl ReadBinder {
             .message_deserializer
             .deserialize::<DeserializeError>(&self.buf)
             .map_err(|err| {
-                panic("deserialization error: {:?}, input: {}", err, &self.buf);
+                panic!("deserialization error: {:?}, input: {}", err, &self.buf);
                 NetworkError::ModelsError(ModelsError::DeserializeError(err.to_string()))
             })?;
 

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 //! `Flexbuffer` layer between raw data and our objects.
-use crate::messages::MessageDeserializer;
+use crate::messages::{MessageDeserializer, MessageSerializer};
 
 use super::messages::Message;
 use async_speed_limit::{clock::StandardClock, Limiter, Resource};
@@ -13,6 +13,7 @@ use massa_network_exports::{NetworkError, ReadHalf, WriteHalf};
 use massa_serialization::{DeserializeError, Deserializer};
 use std::convert::TryInto;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use massa_serialization::Serializer;
 
 /// Used to serialize and send data.
 pub struct WriteBinder {
@@ -39,19 +40,20 @@ impl WriteBinder {
     ///
     /// # Argument
     /// * `buf`: data to transmit.
-    pub async fn send(&mut self, buf: &[u8]) -> Result<u64, NetworkError> {
+    pub async fn send(&mut self, msg: &Message) -> Result<u64, NetworkError> {
         //        massa_trace!("binder.send", { "msg": msg });
+        let mut buf = Vec::new();
+        MessageSerializer::new().serialize(&msg, &mut buf)?;
         let msg_size: u32 = buf
             .len()
             .try_into()
             .map_err(|_| NetworkError::GeneralProtocolError("message too long".into()))?;
-
         self.write_half
             .write_all(&msg_size.to_be_bytes_min(self.max_message_size)?[..])
             .await?;
 
         // send message
-        self.write_half.write_all(buf).await?;
+        self.write_half.write_all(&buf).await?;
 
         let res_index = self.message_index;
         self.message_index += 1;

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -11,6 +11,7 @@ use massa_models::{
 };
 use massa_network_exports::{NetworkError, ReadHalf, WriteHalf};
 use massa_serialization::{DeserializeError, Deserializer};
+use tracing::info;
 use std::convert::TryInto;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -171,6 +172,7 @@ impl ReadBinder {
             .message_deserializer
             .deserialize::<DeserializeError>(&self.buf)
             .map_err(|err| {
+                panic("deserialization error: {:?}, input: {}", err, &self.buf);
                 NetworkError::ModelsError(ModelsError::DeserializeError(err.to_string()))
             })?;
 

--- a/massa-network-worker/src/binders.rs
+++ b/massa-network-worker/src/binders.rs
@@ -10,10 +10,10 @@ use massa_models::{
     serialization::{DeserializeMinBEInt, SerializeMinBEInt},
 };
 use massa_network_exports::{NetworkError, ReadHalf, WriteHalf};
+use massa_serialization::Serializer;
 use massa_serialization::{DeserializeError, Deserializer};
 use std::convert::TryInto;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use massa_serialization::Serializer;
 
 /// Used to serialize and send data.
 pub struct WriteBinder {
@@ -43,7 +43,7 @@ impl WriteBinder {
     pub async fn send(&mut self, msg: &Message) -> Result<u64, NetworkError> {
         //        massa_trace!("binder.send", { "msg": msg });
         let mut buf = Vec::new();
-        MessageSerializer::new().serialize(&msg, &mut buf)?;
+        MessageSerializer::new().serialize(msg, &mut buf)?;
         let msg_size: u32 = buf
             .len()
             .try_into()
@@ -173,7 +173,6 @@ impl ReadBinder {
             .message_deserializer
             .deserialize::<DeserializeError>(&self.buf)
             .map_err(|err| {
-                panic!("deserialization error: {:?}, input: {:#?}", err, &self.buf);
                 NetworkError::ModelsError(ModelsError::DeserializeError(err.to_string()))
             })?;
 

--- a/massa-network-worker/src/handshake_worker.rs
+++ b/massa-network-worker/src/handshake_worker.rs
@@ -130,17 +130,12 @@ impl HandshakeWorker {
         StdRng::from_entropy().fill_bytes(&mut self_random_bytes);
         let self_random_hash = Hash::compute_from(&self_random_bytes);
         // send handshake init future
-        let send_init_msg = Message::HandshakeInitiation {
+        let msg = Message::HandshakeInitiation {
             public_key: self.self_node_id.0,
             random_bytes: self_random_bytes,
             version: self.version,
         };
-        let mut bytes_vec: Vec<u8> = Vec::new();
-        let message_serializer = MessageSerializer::new();
-        message_serializer
-            .serialize(&send_init_msg, &mut bytes_vec)
-            .unwrap();
-        let send_init_fut = self.writer.send(&bytes_vec);
+        let send_init_fut = self.writer.send(&msg);
 
         // receive handshake init future
         let recv_init_fut = self.reader.next();
@@ -181,14 +176,10 @@ impl HandshakeWorker {
         let self_signature = self.keypair.sign(&other_random_hash)?;
 
         // send handshake reply future
-        let send_reply_msg = Message::HandshakeReply {
+        let msg = Message::HandshakeReply {
             signature: self_signature,
         };
-        let mut bytes_vec: Vec<u8> = Vec::new();
-        message_serializer
-            .serialize(&send_reply_msg, &mut bytes_vec)
-            .unwrap();
-        let send_reply_fut = self.writer.send(&bytes_vec);
+        let send_reply_fut = self.writer.send(&msg);
 
         // receive handshake reply future
         let recv_reply_fut = self.reader.next();

--- a/massa-network-worker/src/handshake_worker.rs
+++ b/massa-network-worker/src/handshake_worker.rs
@@ -2,7 +2,7 @@
 
 //! Here are happening handshakes.
 
-use crate::messages::{MessageDeserializer, MessageSerializer};
+use crate::messages::MessageDeserializer;
 
 use super::{
     binders::{ReadBinder, WriteBinder},
@@ -27,7 +27,6 @@ use massa_network_exports::{
     throw_handshake_error as throw, ConnectionId, HandshakeErrorType, NetworkError, ReadHalf,
     WriteHalf,
 };
-use massa_serialization::Serializer;
 use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use rand::{rngs::StdRng, RngCore, SeedableRng};

--- a/massa-network-worker/src/lib.rs
+++ b/massa-network-worker/src/lib.rs
@@ -18,7 +18,6 @@ use massa_network_exports::{
     NetworkEvent, NetworkEventReceiver, NetworkManagementCommand, NetworkManager,
 };
 use massa_signature::KeyPair;
-use massa_storage::Storage;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -44,7 +43,6 @@ pub async fn start_network_controller(
     mut establisher: Establisher,
     clock_compensation: i64,
     initial_peers: Option<BootstrapPeers>,
-    storage: Storage,
     version: Version,
 ) -> Result<
     (
@@ -124,7 +122,6 @@ pub async fn start_network_controller(
                 controller_event_tx,
                 controller_manager_rx,
             },
-            storage,
             version,
         )
         .run_loop()

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, trace, warn, info};
+use tracing::{debug, info, trace, warn};
 
 /// Real job is done by network worker
 pub struct NetworkWorker {
@@ -733,13 +733,9 @@ impl NetworkWorker {
                             max_parameters_size,
                         ),
                     );
-                    let mut serialized_message = Vec::new();
-                    MessageSerializer::new()
-                        .serialize(&msg, &mut serialized_message)
-                        .unwrap();
                     match tokio::time::timeout(
                         timeout,
-                        futures::future::try_join(writer.send(&serialized_message), reader.next()),
+                        futures::future::try_join(writer.send(&msg), reader.next()),
                     )
                     .await
                     {

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, trace, warn};
+use tracing::{debug, trace, warn, info};
 
 /// Real job is done by network worker
 pub struct NetworkWorker {
@@ -241,6 +241,7 @@ impl NetworkWorker {
                     if let Some((connection_id, _)) = self
                         .active_nodes
                         .remove(&node_id) {
+                        info!("AURELIEN:1 node {} closed, reason: {:?}", node_id, reason);
                         massa_trace!("protocol channel closed", {"node_id": node_id});
                         self.connection_closed(connection_id, reason).await?;
                     }

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 
 /// Real job is done by network worker
 pub struct NetworkWorker {
@@ -235,7 +235,6 @@ impl NetworkWorker {
                     if let Some((connection_id, _)) = self
                         .active_nodes
                         .remove(&node_id) {
-                        info!("AURELIEN:1 node {} closed, reason: {:?}", node_id, reason);
                         massa_trace!("protocol channel closed", {"node_id": node_id});
                         self.connection_closed(connection_id, reason).await?;
                     }

--- a/massa-network-worker/src/network_worker.rs
+++ b/massa-network-worker/src/network_worker.rs
@@ -7,7 +7,7 @@ use super::{
 use crate::{
     binders::{ReadBinder, WriteBinder},
     handshake_worker::HandshakeWorker,
-    messages::{Message, MessageDeserializer, MessageSerializer},
+    messages::{Message, MessageDeserializer},
     network_event::EventSender,
 };
 use futures::{stream::FuturesUnordered, StreamExt};
@@ -18,9 +18,7 @@ use massa_network_exports::{
     NetworkCommand, NetworkConfig, NetworkConnectionErrorType, NetworkError, NetworkEvent,
     NetworkManagementCommand, NodeCommand, NodeEvent, NodeEventType, ReadHalf, WriteHalf,
 };
-use massa_serialization::Serializer;
 use massa_signature::KeyPair;
-use massa_storage::Storage;
 use std::{
     collections::{hash_map, HashMap, HashSet},
     net::{IpAddr, SocketAddr},
@@ -62,8 +60,6 @@ pub struct NetworkWorker {
         FuturesUnordered<JoinHandle<(NodeId, Result<ConnectionClosureReason, NetworkError>)>>,
     /// Map of connection to ip, `is_outgoing`.
     pub(crate) active_connections: HashMap<ConnectionId, (IpAddr, bool)>,
-    /// Shared storage.
-    storage: Storage,
     /// Node version
     version: Version,
     /// Event sender
@@ -99,7 +95,6 @@ impl NetworkWorker {
             controller_event_tx,
             controller_manager_rx,
         }: NetworkWorkerChannels,
-        storage: Storage,
         version: Version,
     ) -> NetworkWorker {
         let self_node_id = NodeId(keypair.get_public_key());
@@ -124,7 +119,6 @@ impl NetworkWorker {
             active_nodes: HashMap::new(),
             node_worker_handles: FuturesUnordered::new(),
             active_connections: HashMap::new(),
-            storage,
             version,
         }
     }
@@ -392,7 +386,6 @@ impl NetworkWorker {
                             mpsc::channel::<NodeCommand>(self.cfg.node_command_channel_size);
                         let node_event_tx_clone = self.event.clone_node_sender();
                         let cfg_copy = self.cfg.clone();
-                        let storage = self.storage.clone_without_refs();
                         let node_fn_handle = tokio::spawn(async move {
                             let res = NodeWorker::new(
                                 cfg_copy,
@@ -401,7 +394,6 @@ impl NetworkWorker {
                                 socket_writer,
                                 node_command_rx,
                                 node_event_tx_clone,
-                                storage,
                             )
                             .run_loop()
                             .await;
@@ -518,8 +510,8 @@ impl NetworkWorker {
         match cmd {
             NetworkCommand::NodeBanByIps(ips) => on_node_ban_by_ips_cmd(self, ips).await?,
             NetworkCommand::NodeBanByIds(ids) => on_node_ban_by_ids_cmd(self, ids).await?,
-            NetworkCommand::SendBlockHeader { node, block_id } => {
-                on_send_block_header_cmd(self, node, block_id).await?
+            NetworkCommand::SendBlockHeader { node, header } => {
+                on_send_block_header_cmd(self, node, header).await?
             }
             NetworkCommand::AskForBlocks { list } => on_ask_for_block_cmd(self, list).await,
             NetworkCommand::SendBlockInfo { node, info } => {

--- a/massa-network-worker/src/node_worker.rs
+++ b/massa-network-worker/src/node_worker.rs
@@ -49,50 +49,6 @@ pub struct NodeWorker {
     storage: Storage,
 }
 
-/// The message to send,
-/// or the id(s) of the objects required to construct such a message,
-/// so the actual object(s) can be retrieved from shared storage.
-/// TODO: decide whether to address the clippy warning.
-#[allow(clippy::large_enum_variant)]
-pub enum ToSend {
-    Msg(Message),
-    Header(BlockId),
-    ReplyForBlocksInfo(Vec<(BlockId, ReplyForBlocksInfo)>),
-    Operations(Vec<OperationId>),
-}
-
-async fn send_data(
-    socket_writer: &mut WriteBinder,
-    node_id: NodeId,
-    write_timeout: MassaTime,
-    data: &[u8],
-) -> Result<(), NetworkError> {
-    match timeout(write_timeout.to_duration(), socket_writer.send(data)).await {
-        Err(_err) => {
-            massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.timeout", {
-                "node": node_id,
-            });
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                "node data writing timed out",
-            )
-            .into());
-        }
-        Ok(Err(err)) => {
-            massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.error", {
-                "node": node_id, "err":  format!("{}", err),
-            });
-            return Err(err);
-        }
-        Ok(Ok(id)) => {
-            massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.ok", {
-                "node": node_id, "msg_id": id,
-            })
-        }
-    }
-    Ok(())
-}
-
 impl NodeWorker {
     /// Creates a new node worker
     ///
@@ -148,8 +104,8 @@ impl NodeWorker {
     /// If the channel dropped, return an error
     pub fn try_send_to_node(
         &self,
-        sender: &Sender<ToSend>,
-        msg: ToSend,
+        sender: &Sender<Message>,
+        msg: Message,
     ) -> Result<(), NetworkError> {
         match sender.try_send(msg) {
             Err(TrySendError::Full(_)) => {
@@ -172,7 +128,7 @@ impl NodeWorker {
     /// node event loop. Consumes self.
     pub async fn run_loop(mut self) -> Result<ConnectionClosureReason, NetworkError> {
         let (writer_command_tx, mut writer_command_rx) =
-            mpsc::channel::<ToSend>(NODE_SEND_CHANNEL_SIZE);
+            mpsc::channel::<Message>(NODE_SEND_CHANNEL_SIZE);
         let mut socket_writer = self.socket_writer_opt.take().ok_or_else(|| {
             NetworkError::GeneralProtocolError(
                 "NodeWorker call run_loop more than once".to_string(),
@@ -186,132 +142,29 @@ impl NodeWorker {
             loop {
                 match writer_command_rx.recv().await {
                     Some(to_send) => {
-                        let bytes_vec: Vec<u8> = match to_send {
-                            ToSend::Msg(msg) => {
-                                let mut res = Vec::new();
-                                MessageSerializer::new().serialize(&msg, &mut res)?;
-                                res
+                        match timeout(write_timeout.to_duration(), socket_writer.send(&to_send)).await {
+                            Err(_err) => {
+                                massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.timeout", {
+                                    "node": node_id_copy,
+                                });
+                                return Err(std::io::Error::new(
+                                    std::io::ErrorKind::TimedOut,
+                                    "node data writing timed out",
+                                )
+                                .into());
                             }
-                            ToSend::ReplyForBlocksInfo(reply_list) => {
-                                for replies in reply_list.chunks(self.cfg.max_ask_blocks as usize) {
-                                    let mut res: Vec<u8> = Vec::new();
-                                    u32_serializer.serialize(
-                                        &u32::from(MessageTypeId::ReplyForBlocks),
-                                        &mut res,
-                                    )?;
-                                    u32_serializer.serialize(
-                                        &reply_list.len().try_into().map_err(|_| {
-                                            NetworkError::GeneralProtocolError(
-                                                "ReplyForBlocksInfo list too long".to_string(),
-                                            )
-                                        })?,
-                                        &mut res,
-                                    )?;
-                                    for (hash, info) in replies {
-                                        res.extend(hash.to_bytes());
-                                        match info {
-                                            ReplyForBlocksInfo::Info(op_ids) => {
-                                                u32_serializer.serialize(
-                                                    &u32::from(BlockInfoType::Info),
-                                                    &mut res,
-                                                )?;
-                                                let op_ids_serializer =
-                                                    OperationIdsSerializer::new();
-                                                op_ids_serializer.serialize(op_ids, &mut res)?;
-                                            }
-                                            ReplyForBlocksInfo::Operations(operation_ids) => {
-                                                u32_serializer.serialize(
-                                                    &u32::from(BlockInfoType::Operations),
-                                                    &mut res,
-                                                )?;
-                                                u32_serializer.serialize(
-                                                    &(operation_ids.len() as u32),
-                                                    &mut res,
-                                                )?;
-                                                let wrapped_operation_serializer =
-                                                    WrappedSerializer::new();
-                                                let op_store = storage.read_operations();
-                                                for operation_id in operation_ids {
-                                                    match op_store.get(operation_id) {
-                                                        Some(operation) => {
-                                                            wrapped_operation_serializer
-                                                                .serialize(operation, &mut res)?;
-                                                        }
-                                                        None => {
-                                                            return Err(
-                                                                NetworkError::MissingOperation,
-                                                            )
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                            ReplyForBlocksInfo::NotFound => {
-                                                u32_serializer.serialize(
-                                                    &u32::from(BlockInfoType::NotFound),
-                                                    &mut res,
-                                                )?;
-                                            }
-                                        }
-                                        send_data(
-                                            &mut socket_writer,
-                                            node_id_copy,
-                                            write_timeout,
-                                            &res,
-                                        )
-                                        .await?;
-                                    }
-                                }
-                                continue;
+                            Ok(Err(err)) => {
+                                massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.error", {
+                                    "node": node_id_copy, "err":  format!("{}", err),
+                                });
+                                return Err(err);
                             }
-                            ToSend::Header(block_id) => {
-                                // Construct the message,
-                                // using the serialized header retrieved from shared storage.
-                                let mut res: Vec<u8> = Vec::new();
-                                u32_serializer
-                                    .serialize(&u32::from(MessageTypeId::BlockHeader), &mut res)?;
-                                WrappedSerializer::new().serialize(
-                                    &storage
-                                        .read_blocks()
-                                        .get(&block_id)
-                                        .ok_or(NetworkError::MissingBlock)?
-                                        .content
-                                        .header,
-                                    &mut res,
-                                )?;
-                                res
+                            Ok(Ok(id)) => {
+                                massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv.send.ok", {
+                                    "node": node_id_copy, "msg_id": id,
+                                })
                             }
-                            ToSend::Operations(operation_ids) => {
-                                // Construct the message,
-                                // using the serialized operations retrieved from shared storage.
-                                let mut res: Vec<u8> = Vec::new();
-                                u32_serializer
-                                    .serialize(&u32::from(MessageTypeId::Operations), &mut res)?;
-                                u32_serializer.serialize(
-                                    &operation_ids.len().try_into().map_err(|_| {
-                                        NetworkError::SerializeError(SerializeError::NumberTooBig(
-                                            "Too much operations".to_string(),
-                                        ))
-                                    })?,
-                                    &mut res,
-                                )?;
-                                let wrapped_operation_serializer = WrappedSerializer::new();
-                                {
-                                    let op_read = storage.read_operations();
-                                    for op_id in operation_ids {
-                                        match op_read.get(&op_id) {
-                                            Some(operation) => {
-                                                wrapped_operation_serializer
-                                                    .serialize(operation, &mut res)?;
-                                            }
-                                            None => return Err(NetworkError::MissingOperation),
-                                        }
-                                    }
-                                }
-                                res
-                            }
-                        };
-                        send_data(&mut socket_writer, node_id_copy, write_timeout, &bytes_vec)
-                            .await?;
+                        }
                     }
                     None => {
                         massa_trace!("node_worker.run_loop.loop.writer_command_rx.recv. None", {});
@@ -441,13 +294,13 @@ impl NodeWorker {
                         },
                         Some(NodeCommand::SendPeerList(ip_vec)) => {
                             massa_trace!("node_worker.run_loop. send Message::PeerList", {"peerlist": ip_vec, "node": self.node_id});
-                            if self.try_send_to_node(&writer_command_tx, ToSend::Msg(Message::PeerList(ip_vec))).is_err() {
+                            if self.try_send_to_node(&writer_command_tx, Message::PeerList(ip_vec)).is_err() {
                                 break;
                             }
                         },
                         Some(NodeCommand::SendBlockHeader(block_id)) => {
                             massa_trace!("node_worker.run_loop. send Message::BlockHeader", {"hash": block_id, "node": self.node_id});
-                            if self.try_send_to_node(&writer_command_tx, ToSend::Header(block_id)).is_err() {
+                            if self.try_send_to_node(&writer_command_tx, Message::BlockHeader(block_id)).is_err() {
                                 break;
                             }
                         },
@@ -455,7 +308,7 @@ impl NodeWorker {
                             // cut hash list on sub list if exceed max_ask_blocks_per_message
                             massa_trace!("node_worker.run_loop. send Message::AskForBlocks", {"hashlist": list, "node": self.node_id});
                             for to_send_list in list.chunks(self.cfg.max_ask_blocks as usize) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::Msg(Message::AskForBlocks(to_send_list.to_vec()))).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::AskForBlocks(to_send_list.to_vec())).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -464,7 +317,7 @@ impl NodeWorker {
                             // cut hash list on sub list if exceed max_ask_blocks_per_message
                             massa_trace!("node_worker.run_loop. send Message::ReplyForBlocks", {"hashlist": list, "node": self.node_id});
                             for to_send_list in list.chunks(self.cfg.max_ask_blocks as usize) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::ReplyForBlocksInfo(to_send_list.to_vec())).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::ReplyForBlocks(to_send_list.to_vec())).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -473,7 +326,7 @@ impl NodeWorker {
                             massa_trace!("node_worker.run_loop. send Message::SendOperations", {"node": self.node_id, "operations": operations});
                             let ops: Vec<OperationId> = operations.into_iter().collect();
                             for chunk in ops.chunks(self.cfg.max_operations_per_message as usize) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::Operations(chunk.into())).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::Operations(chunk.to_vec())).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -485,7 +338,7 @@ impl NodeWorker {
                             .chunks(self.cfg.max_operations_per_message as usize)
                             .into_iter()
                             .map(|chunk| chunk.collect()) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::Msg(Message::OperationsAnnouncement(chunk))).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::OperationsAnnouncement(chunk)).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -501,7 +354,7 @@ impl NodeWorker {
                             .chunks(self.cfg.max_operations_per_message as usize)
                             .into_iter()
                             .map(|chunk| chunk.collect()) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::Msg(Message::AskForOperations(chunk))).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::AskForOperations(chunk)).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -510,7 +363,7 @@ impl NodeWorker {
                             massa_trace!("node_worker.run_loop. send Message::SendEndorsements", {"node": self.node_id, "endorsements": endorsements});
                             // cut endorsement list if it exceed max_endorsements_per_message
                             for to_send_list in endorsements.chunks(MAX_ENDORSEMENTS_PER_MESSAGE as usize) {
-                                if self.try_send_to_node(&writer_command_tx, ToSend::Msg(Message::Endorsements(to_send_list.to_vec()))).is_err() {
+                                if self.try_send_to_node(&writer_command_tx, Message::Endorsements(to_send_list.to_vec())).is_err() {
                                     break 'select_loop;
                                 }
                             }
@@ -528,7 +381,7 @@ impl NodeWorker {
                     debug!("timer-based asking node_id={} for peer list", self.node_id);
                     massa_trace!("node_worker.run_loop. timer_ask_peer_list", {"node_id": self.node_id});
                     massa_trace!("node_worker.run_loop.select.timer send Message::AskPeerList", {"node": self.node_id});
-                    writer_command_tx.send(ToSend::Msg(Message::AskPeerList)).await.map_err(
+                    writer_command_tx.send(Message::AskPeerList).await.map_err(
                         |_| NetworkError::ChannelError("writer send ask peer list failed".into())
                     )?;
                     trace!("after sending Message::AskPeerList from writer_command_tx in node_worker run_loop");

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -248,7 +248,6 @@ async fn launch(
             Establisher::new(),
             bootstrap_state.compensation_millis,
             bootstrap_state.peers,
-            shared_storage.clone(),
             *VERSION,
         )
         .await

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -14,7 +14,7 @@ use massa_models::{
     prehash::{CapacityAllocator, PreHashSet},
     wrapped::{Id, Wrapped},
 };
-use massa_network_exports::{AskForBlocksInfo, BlockInfoReply, NetworkEvent, ReplyForBlocksInfo};
+use massa_network_exports::{AskForBlocksInfo, BlockInfoReply, NetworkEvent};
 use massa_protocol_exports::{ProtocolError, ProtocolEvent};
 use massa_serialization::Serializer;
 use massa_storage::Storage;
@@ -168,12 +168,12 @@ impl ProtocolWorker {
                 Some(wrapped_block) => wrapped_block.content.operations.clone(),
                 None => {
                     // let the node know we don't have the block.
-                    all_blocks_info.push((*hash, ReplyForBlocksInfo::NotFound));
+                    all_blocks_info.push((*hash, BlockInfoReply::NotFound));
                     continue;
                 }
             };
             let block_info = match info_wanted {
-                AskForBlocksInfo::Info => ReplyForBlocksInfo::Info(operations_ids),
+                AskForBlocksInfo::Info => BlockInfoReply::Info(operations_ids),
                 AskForBlocksInfo::Operations(op_ids) => {
                     // Mark the node as having the block.
                     node_info.insert_known_blocks(
@@ -183,12 +183,17 @@ impl ProtocolWorker {
                         self.config.max_node_known_blocks_size,
                     );
 
-                    // Send only the missing operations.
-                    let needed_ops = operations_ids
-                        .into_iter()
-                        .filter(|id| op_ids.contains(id))
-                        .collect();
-                    ReplyForBlocksInfo::Operations(needed_ops)
+                    // Send only the missing operations that is in storage.
+                    let needed_ops = {
+                        let operations = self.storage.read_operations();
+                        operations_ids
+                            .into_iter()
+                            .filter(|id| op_ids.contains(id))
+                            .filter_map(|id| operations.get(&id))
+                            .cloned()
+                            .collect()
+                    };
+                    BlockInfoReply::Operations(needed_ops)
                 }
             };
             all_blocks_info.push((*hash, block_info));


### PR DESCRIPTION
This PR clean the code of massa-network : 

- Remove `ToSend` enum that was introduced for shared storage and old serialization format that was incompatible. Now it's useless
- So now we send directly Message to binders so that the serialization/deserialization is only in binders.
- Remove the chunks of block informations has it's already chunk by the parent function and also was bugged because the `send_data` call was in a too much inner loop.
- Pass full object to network and therefore remove usage of storage and fetch elements directly in protocol.
- So the two enum for blocks infos was regrouped.

This also fix a bug of nodes that disconnect because the serializing was bugged because the `send_data` was in the wrong loop and so it sent only the first element in the first message that serialize the full size. of the list.

This PR has been tested in simulator.