### PR TITLE
Fix ops propagation

### DIFF
--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -134,8 +134,6 @@ pub const MAX_RNG_SEED_LENGTH: u32 = PERIODS_PER_CYCLE.saturating_mul(THREAD_COU
 pub const MAX_ROLLS_UPDATE_LENGTH: u64 = u64::MAX;
 /// Maximum length of rolls_counts in thread cycle
 pub const MAX_ROLLS_COUNTS_LENGTH: u64 = u64::MAX;
-/// max size of all serialized operations in bytes in a block
-pub const MAX_SERIALIZED_OPERATIONS_SIZE_PER_BLOCK: usize = usize::MAX;
 /// Maximum length of production_stats in thread cycle
 pub const MAX_PRODUCTION_STATS_LENGTH: u64 = u64::MAX;
 // ***********************

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -135,7 +135,7 @@ pub const MAX_ROLLS_UPDATE_LENGTH: u64 = u64::MAX;
 /// Maximum length of rolls_counts in thread cycle
 pub const MAX_ROLLS_COUNTS_LENGTH: u64 = u64::MAX;
 /// max size of all serialized operations in bytes in a block
-pub const MAX_SERIALIZED_OPERATIONS_SIZE_PER_BLOCK: usize = 2 ^ 10;
+pub const MAX_SERIALIZED_OPERATIONS_SIZE_PER_BLOCK: usize = usize::MAX;
 /// Maximum length of production_stats in thread cycle
 pub const MAX_PRODUCTION_STATS_LENGTH: u64 = u64::MAX;
 // ***********************

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -38,7 +38,7 @@ use massa_models::config::constants::{
 };
 use massa_models::config::{
     ASYNC_POOL_PART_SIZE_MESSAGE_BYTES, CHANNEL_SIZE, DELTA_F0,
-    MAX_SERIALIZED_OPERATIONS_SIZE_PER_BLOCK, NETWORK_NODE_COMMAND_CHANNEL_SIZE,
+    NETWORK_NODE_COMMAND_CHANNEL_SIZE,
     NETWORK_NODE_EVENT_CHANNEL_SIZE, POS_MISS_RATE_DEACTIVATION_THRESHOLD,
     PROTOCOL_CONTROLLER_CHANNEL_SIZE, PROTOCOL_EVENT_CHANNEL_SIZE,
 };
@@ -318,7 +318,7 @@ async fn launch(
         operation_batch_proc_period: SETTINGS.protocol.operation_batch_proc_period,
         asked_operations_pruning_period: SETTINGS.protocol.asked_operations_pruning_period,
         max_operations_per_message: SETTINGS.protocol.max_operations_per_message,
-        max_serialized_operations_size_per_block: MAX_SERIALIZED_OPERATIONS_SIZE_PER_BLOCK,
+        max_serialized_operations_size_per_block: MAX_BLOCK_SIZE,
         controller_channel_size: PROTOCOL_CONTROLLER_CHANNEL_SIZE,
         event_channel_size: PROTOCOL_EVENT_CHANNEL_SIZE,
     };

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -273,8 +273,6 @@ impl ProtocolWorker {
         });
 
         // Check operation_list against expected operations hash from header.
-        info!("AURELIEN: Merkle root1: {:#?}", info.header.content.operation_merkle_root);
-        info!("AURELIEN: Merkle root2: {:#?}", Hash::compute_from(&total_hash));
         if info.header.content.operation_merkle_root == Hash::compute_from(&total_hash) {
             // Add the ops of info.
             info.operations = Some(operation_ids.clone());

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -288,7 +288,6 @@ impl ProtocolWorker {
                 Self::get_total_operations_size(&self.storage, &known_operations);
 
             if info.operations_size > self.config.max_serialized_operations_size_per_block {
-                info!("bad operations size");
                 let _ = self.ban_node(&from_node_id).await;
                 return Ok(());
             }
@@ -314,7 +313,6 @@ impl ProtocolWorker {
                     .await;
             }
         } else {
-            info!("bad merkle root");
             let _ = self.ban_node(&from_node_id).await;
         }
         Ok(())
@@ -343,7 +341,6 @@ impl ProtocolWorker {
             .note_operations_from_node(operations.clone(), &from_node_id)
             .is_err()
         {
-            info!("bad operations full received");
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());
         }
@@ -378,13 +375,11 @@ impl ProtocolWorker {
                 || !received_ids.insert(op.id)
                 || full_op_size > self.config.max_serialized_operations_size_per_block
             {
-                info!("bad operations full 2");
                 let _ = self.ban_node(&from_node_id).await;
                 return Ok(());
             }
         }
         if wanted_operation_ids != received_ids {
-            info!("not all id error");
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());
         }


### PR DESCRIPTION
Remove duplicate constat that had a bad value causing the node that receive operations to ban the node.