### PR TITLE
Refactor block info workflow

### DIFF
--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -12,6 +12,7 @@
 #![warn(unused_crate_dependencies)]
 #![feature(ip)]
 #![feature(map_first_last)]
+#![feature(let_chains)]
 
 pub use establisher::types::Establisher;
 use massa_final_state::FinalState;

--- a/massa-consensus-worker/src/consensus_worker.rs
+++ b/massa-consensus-worker/src/consensus_worker.rs
@@ -6,10 +6,13 @@ use massa_consensus_exports::{
     ConsensusConfig,
 };
 use massa_graph::{BlockGraph, BlockGraphExport};
-use massa_models::prehash::PreHashSet;
 use massa_models::stats::ConsensusStats;
 use massa_models::timeslots::{get_block_slot_timestamp, get_latest_block_slot_at_timestamp};
 use massa_models::{address::Address, block::BlockId, slot::Slot};
+use massa_models::{
+    block::WrappedHeader,
+    prehash::{PreHashMap, PreHashSet},
+};
 use massa_protocol_exports::{ProtocolEvent, ProtocolEventReceiver};
 use massa_time::MassaTime;
 use std::{cmp::max, collections::HashSet, collections::VecDeque};
@@ -29,7 +32,7 @@ pub struct ConsensusWorker {
     /// Next slot
     next_slot: Slot,
     /// blocks we want
-    wishlist: PreHashSet<BlockId>,
+    wishlist: PreHashMap<BlockId, Option<WrappedHeader>>,
     /// latest final periods
     latest_final_periods: Vec<u64>,
     /// clock compensation
@@ -142,7 +145,7 @@ impl ConsensusWorker {
             block_db,
             previous_slot,
             next_slot,
-            wishlist: PreHashSet::<BlockId>::default(),
+            wishlist: Default::default(),
             latest_final_periods,
             clock_compensation,
             channels,

--- a/massa-final-state/src/lib.rs
+++ b/massa-final-state/src/lib.rs
@@ -37,6 +37,7 @@
 #![warn(unused_crate_dependencies)]
 #![feature(hash_drain_filter)]
 #![feature(map_first_last)]
+#![feature(let_chains)]
 #![feature(async_closure)]
 
 mod config;

--- a/massa-graph/src/lib.rs
+++ b/massa-graph/src/lib.rs
@@ -6,6 +6,7 @@
 #![feature(hash_drain_filter)]
 #![feature(map_first_last)]
 #![feature(int_roundings)]
+#![feature(let_chains)]
 
 extern crate massa_logging;
 

--- a/massa-ledger-exports/src/lib.rs
+++ b/massa-ledger-exports/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! TODO
 
+#![feature(let_chains)]
+
 mod config;
 mod controller;
 mod error;

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-logging/src/lib.rs
+++ b/massa-logging/src/lib.rs
@@ -6,6 +6,6 @@
 /// tracing with some context
 macro_rules! massa_trace {
     ($evt:expr, $params:tt) => {
-        tracing::info!("massa:{}:{}", $evt, serde_json::json!($params));
+        tracing::trace!("massa:{}:{}", $evt, serde_json::json!($params));
     };
 }

--- a/massa-network-exports/src/commands.rs
+++ b/massa-network-exports/src/commands.rs
@@ -140,6 +140,8 @@ pub struct NodeEvent(pub NodeId, pub NodeEventType);
 /// Ask for the info about a block.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub enum AskForBlocksInfo {
+    /// Ask header
+    Header,
     /// The info about the block is required(list of operations ids).
     #[default]
     Info,
@@ -232,6 +234,8 @@ pub enum NetworkCommand {
 /// A node replied with info about a block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum BlockInfoReply {
+    /// Header
+    Header(WrappedHeader),
     /// The info about the block is required(list of operations ids).
     Info(Vec<OperationId>),
     /// The actual operations required.

--- a/massa-network-exports/src/commands.rs
+++ b/massa-network-exports/src/commands.rs
@@ -233,6 +233,7 @@ pub enum NetworkCommand {
 
 /// A node replied with info about a block.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::large_enum_variant)]
 pub enum BlockInfoReply {
     /// Header
     Header(WrappedHeader),

--- a/massa-pos-exports/src/lib.rs
+++ b/massa-pos-exports/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![warn(missing_docs)]
 #![feature(map_first_last)]
+#![feature(let_chains)]
 
 mod controller_traits;
 mod error;

--- a/massa-protocol-exports/src/protocol_controller.rs
+++ b/massa-protocol-exports/src/protocol_controller.rs
@@ -67,7 +67,7 @@ pub enum ProtocolCommand {
     /// Wish list delta
     WishlistDelta {
         /// add to wish list
-        new: PreHashSet<BlockId>,
+        new: PreHashMap<BlockId, Option<WrappedHeader>>,
         /// remove from wish list
         remove: PreHashSet<BlockId>,
     },
@@ -123,7 +123,7 @@ impl ProtocolCommandSender {
     /// update the block wish list
     pub async fn send_wishlist_delta(
         &mut self,
-        new: PreHashSet<BlockId>,
+        new: PreHashMap<BlockId, Option<WrappedHeader>>,
         remove: PreHashSet<BlockId>,
     ) -> Result<(), ProtocolError> {
         massa_trace!("protocol.command_sender.send_wishlist_delta", { "new": new, "remove": remove });

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -180,7 +180,7 @@ pub async fn send_and_propagate_block(
 
     protocol_command_sender
         .send_wishlist_delta(
-            vec![block.id].into_iter().collect(),
+            vec![(block.id, None)].into_iter().collect(),
             PreHashSet::<BlockId>::default(),
         )
         .await

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -86,7 +86,7 @@ impl ProtocolWorker {
                 header,
             } => {
                 massa_trace!(BLOCK_HEADER, { "node": source_node_id, "header": header});
-                if let Some((block_id, _endorsement_ids, is_new)) =
+                if let Some((block_id, is_new)) =
                     self.note_header_from_node(&header, &source_node_id).await?
                 {
                     if is_new {
@@ -164,8 +164,11 @@ impl ProtocolWorker {
         };
         let mut all_blocks_info = vec![];
         for (hash, info_wanted) in &list {
-            let operations_ids = match self.storage.read_blocks().get(hash) {
-                Some(wrapped_block) => wrapped_block.content.operations.clone(),
+            let (header, operations_ids) = match self.storage.read_blocks().get(hash) {
+                Some(wrapped_block) => (
+                    wrapped_block.content.header.clone(),
+                    wrapped_block.content.operations.clone(),
+                ),
                 None => {
                     // let the node know we don't have the block.
                     all_blocks_info.push((*hash, BlockInfoReply::NotFound));
@@ -173,6 +176,7 @@ impl ProtocolWorker {
                 }
             };
             let block_info = match info_wanted {
+                AskForBlocksInfo::Header => BlockInfoReply::Header(header),
                 AskForBlocksInfo::Info => BlockInfoReply::Info(operations_ids),
                 AskForBlocksInfo::Operations(op_ids) => {
                     // Mark the node as having the block.
@@ -244,8 +248,7 @@ impl ProtocolWorker {
         operation_ids: Vec<OperationId>,
     ) -> Result<(), ProtocolError> {
         // All operation ids sent into a set
-        let mut operation_ids_set: PreHashSet<OperationId> =
-            operation_ids.iter().cloned().collect();
+        let operation_ids_set: PreHashSet<OperationId> = operation_ids.iter().cloned().collect();
 
         // add to known ops
         if let Some(node_info) = self.active_nodes.get_mut(&from_node_id) {
@@ -255,17 +258,18 @@ impl ProtocolWorker {
             );
         }
 
-        if self.block_wishlist.get(&block_id).is_none() {
+        let info = if let Some(info) = self.block_wishlist.get_mut(&block_id) {
+            info
+        } else {
             return Ok(());
-        }
-
-        let mut info = match self.checked_headers.get_mut(&block_id) {
-            Some(info) => info,
-            _ => {
-                warn!("Missing block header for {}", block_id);
-                return Ok(());
-            }
         };
+
+        let header = if let Some(header) = &info.header {
+            header
+        } else {
+            return Ok(());
+        };
+
         let mut total_hash: Vec<u8> = vec![];
         operation_ids.iter().for_each(|op_id| {
             let op_hash = op_id.get_hash().into_bytes();
@@ -273,16 +277,12 @@ impl ProtocolWorker {
         });
 
         // Check operation_list against expected operations hash from header.
-        if info.header.content.operation_merkle_root == Hash::compute_from(&total_hash) {
+        if header.content.operation_merkle_root == Hash::compute_from(&total_hash) {
             // Add the ops of info.
-            info.operations = Some(operation_ids.clone());
-            let mut block_storage = self.storage.clone_without_refs();
-            let known_operations = block_storage.claim_operation_refs(&operation_ids_set);
+            info.operation_ids = Some(operation_ids.clone());
+            let known_operations = info.storage.claim_operation_refs(&operation_ids_set);
             // remember the claimed operation to prune them later
             self.checked_operations.extend(&known_operations);
-            // Compute the missing operations using `operation_ids_set`
-            let mut missing_operation = std::mem::take(&mut operation_ids_set);
-            missing_operation.retain(|id| !known_operations.contains(id));
 
             info.operations_size =
                 Self::get_total_operations_size(&self.storage, &known_operations);
@@ -295,16 +295,7 @@ impl ProtocolWorker {
             // Update ask block
             let mut set = PreHashSet::<BlockId>::with_capacity(1);
             set.insert(block_id);
-            self.stop_asking_blocks(set)?;
-
-            // Re-add to wishlist with new state.
-            self.block_wishlist.insert(
-                block_id,
-                (
-                    AskForBlocksInfo::Operations(missing_operation.into_iter().collect()),
-                    Some(block_storage),
-                ),
-            );
+            self.remove_asked_blocks_of_node(set)?;
 
             // If the block is empty, go straight to processing the full block info.
             if operation_ids.is_empty() {
@@ -345,32 +336,36 @@ impl ProtocolWorker {
             return Ok(());
         }
 
-        let wanted_operation_ids = match self.block_wishlist.get(&block_id) {
-            Some((AskForBlocksInfo::Operations(ids), Some(_))) => {
-                ids.iter().cloned().collect::<PreHashSet<OperationId>>()
-            }
-            _ => return Ok(()),
+        let info = if let Some(info) = self.block_wishlist.get(&block_id) {
+            info.clone()
+        } else {
+            return Ok(());
         };
-
-        let info = match self.checked_headers.get(&block_id) {
-            Some(info) => info,
-            _ => {
-                warn!("Missing block info for {}", block_id);
-                return Ok(());
-            }
+        let header = if let Some(header) = &info.header {
+            header
+        } else {
+            return Ok(());
+        };
+        let block_operation_ids = if let Some(operations) = &info.operation_ids {
+            operations
+        } else {
+            return Ok(());
         };
 
         // Ban the node if:
-        // - mismatch with wanted operations
+        // - mismatch with asked operations (asked operations are the one that are not in storage) + operations already in storage and block operations
         // - full operations serialized size overflow
         let full_op_size: usize = info.operations_size
             + operations
                 .iter()
                 .map(|op| op.serialized_size())
                 .sum::<usize>();
+        let block_ids_set = block_operation_ids.clone().into_iter().collect();
         let received_ids: PreHashSet<OperationId> = operations.iter().map(|op| op.id).collect();
+        let mut known_operation_ids = self.storage.claim_operation_refs(&block_ids_set);
+        known_operation_ids.extend(&received_ids);
         if full_op_size > self.config.max_serialized_operations_size_per_block
-            || wanted_operation_ids != received_ids
+            || known_operation_ids != block_ids_set
         {
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());
@@ -378,8 +373,8 @@ impl ProtocolWorker {
 
         // Re-constitute block.
         let block = Block {
-            header: info.header.clone(),
-            operations: info.operations.clone().unwrap(),
+            header: header.clone(),
+            operations: block_operation_ids.clone(),
         };
 
         let mut content_serialized = Vec::new();
@@ -389,34 +384,35 @@ impl ProtocolWorker {
 
         // wrap block
         let wrapped_block: WrappedBlock = Wrapped {
-            signature: info.header.signature,
-            creator_public_key: info.header.creator_public_key,
-            creator_address: info.header.creator_address,
+            signature: header.signature,
+            creator_public_key: header.creator_public_key,
+            creator_address: header.creator_address,
             id: block_id,
             content: block,
             serialized_data: content_serialized,
         };
 
         // create block storage (without parents)
-        let mut block_storage = self.block_wishlist.remove(&block_id).unwrap().1.unwrap();
+        let mut block_storage = self.block_wishlist.remove(&block_id).unwrap().storage;
         // add block to local storage and claim ref
         block_storage.store_block(wrapped_block);
         // add operations to local storage and claim ref
         block_storage.store_operations(operations);
         // add endorsements to local storage and claim ref
         // TODO change this if we make endorsements separate from block header
-        block_storage.store_endorsements(info.header.content.endorsements.clone());
+        block_storage.store_endorsements(header.content.endorsements.clone());
 
         // Send to graph
         self.send_protocol_event(ProtocolEvent::ReceivedBlock {
-            slot: info.header.content.slot,
+            slot: header.content.slot,
             block_id,
             storage: block_storage,
         })
         .await;
 
         // Update ask block
-        self.stop_asking_blocks(vec![block_id].into_iter().collect())
+        let remove_hashes = vec![block_id].into_iter().collect();
+        self.remove_asked_blocks_of_node(remove_hashes)
     }
 
     async fn on_block_info_received(
@@ -426,6 +422,13 @@ impl ProtocolWorker {
         info: BlockInfoReply,
     ) -> Result<(), ProtocolError> {
         match info {
+            BlockInfoReply::Header(header) => {
+                // TODO: Speak with damir. The block header is sent to census which will send us a new wishlist with the header into.
+                // So don't need to call ask_from_block with an updated wishlist because it will be already done by consensus and will be a double
+                self.note_header_from_node(&header, &from_node_id)
+                    .await
+                    .map(|_| ())
+            }
             BlockInfoReply::Info(operation_list) => {
                 // Ask for missing operations ids and print a warning if there is no header for
                 // that block.

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -380,17 +380,10 @@ impl ProtocolWorker {
                 massa_trace!("protocol.protocol_worker.process_command.wishlist_delta.begin", { "new": new, "remove": remove });
                 self.remove_asked_blocks_of_node(remove)?;
                 for (block_id, header) in new.into_iter() {
-                    if let Some(header) = header {
-                        self.block_wishlist.insert(
-                            block_id,
-                            BlockInfo::new(Some(header), self.storage.clone_without_refs()),
-                        );
-                    } else {
-                        self.block_wishlist.insert(
-                            block_id,
-                            BlockInfo::new(None, self.storage.clone_without_refs()),
-                        );
-                    }
+                    self.block_wishlist.insert(
+                        block_id,
+                        BlockInfo::new(header, self.storage.clone_without_refs()),
+                    );
                 }
                 self.update_ask_block(timer).await?;
                 massa_trace!(

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -101,23 +101,23 @@ pub async fn start_protocol_controller(
 /// Info about a block we've seen
 #[derive(Debug, Clone)]
 pub(crate) struct BlockInfo {
-    /// Endorsements contained in the block header.
-    pub(crate) endorsements: PreHashMap<EndorsementId, u32>,
-    /// Operations contained in the block,
-    /// if we've received them already, and none otherwise.
-    pub(crate) operations: Option<Vec<OperationId>>,
     /// The header of the block.
-    pub(crate) header: WrappedHeader,
+    pub(crate) header: Option<WrappedHeader>,
+    /// Operations ids. None if not received yet
+    pub(crate) operation_ids: Option<Vec<OperationId>>,
+    /// Operations and endorsements contained in the block,
+    /// if we've received them already, and none otherwise.
+    pub(crate) storage: Storage,
     /// Full operations size in bytes
     pub(crate) operations_size: usize,
 }
 
 impl BlockInfo {
-    fn new(endorsements: PreHashMap<EndorsementId, u32>, header: WrappedHeader) -> Self {
+    fn new(header: Option<WrappedHeader>, storage: Storage) -> Self {
         BlockInfo {
-            endorsements,
-            operations: None,
             header,
+            operation_ids: None,
+            storage,
             operations_size: 0,
         }
     }
@@ -142,14 +142,14 @@ pub struct ProtocolWorker {
     /// Ids of active nodes mapped to node info.
     pub(crate) active_nodes: HashMap<NodeId, NodeInfo>,
     /// List of wanted blocks,
-    /// with the info representing their state withint the as_block workflow.
-    pub(crate) block_wishlist: PreHashMap<BlockId, (AskForBlocksInfo, Option<Storage>)>,
+    /// with the info representing their state with in the as_block workflow.
+    pub(crate) block_wishlist: PreHashMap<BlockId, BlockInfo>,
     /// List of processed endorsements
     checked_endorsements: PreHashSet<EndorsementId>,
     /// List of processed operations
     pub(crate) checked_operations: CheckedOperations,
     /// List of processed headers
-    pub(crate) checked_headers: PreHashMap<BlockId, BlockInfo>,
+    pub(crate) checked_headers: PreHashMap<BlockId, WrappedHeader>,
     /// List of ids of operations that we asked to the nodes
     pub(crate) asked_operations: HashMap<OperationPrefixId, (Instant, Vec<NodeId>)>,
     /// Buffer for operations that we want later
@@ -378,10 +378,19 @@ impl ProtocolWorker {
             }
             ProtocolCommand::WishlistDelta { new, remove } => {
                 massa_trace!("protocol.protocol_worker.process_command.wishlist_delta.begin", { "new": new, "remove": remove });
-                self.stop_asking_blocks(remove)?;
-                for block in new.into_iter() {
-                    self.block_wishlist
-                        .insert(block, (AskForBlocksInfo::Info, None));
+                self.remove_asked_blocks_of_node(remove)?;
+                for (block_id, header) in new.into_iter() {
+                    if let Some(header) = header {
+                        self.block_wishlist.insert(
+                            block_id,
+                            BlockInfo::new(Some(header), self.storage.clone_without_refs()),
+                        );
+                    } else {
+                        self.block_wishlist.insert(
+                            block_id,
+                            BlockInfo::new(None, self.storage.clone_without_refs()),
+                        );
+                    }
                 }
                 self.update_ask_block(timer).await?;
                 massa_trace!(
@@ -458,11 +467,11 @@ impl ProtocolWorker {
     }
 
     /// Remove the given blocks from the local wishlist
-    pub(crate) fn stop_asking_blocks(
+    pub(crate) fn remove_asked_blocks_of_node(
         &mut self,
         remove_hashes: PreHashSet<BlockId>,
     ) -> Result<(), ProtocolError> {
-        massa_trace!("protocol.protocol_worker.stop_asking_blocks", {
+        massa_trace!("protocol.protocol_worker.remove_asked_blocks_of_node", {
             "remove": remove_hashes
         });
         for node_info in self.active_nodes.values_mut() {
@@ -470,8 +479,6 @@ impl ProtocolWorker {
                 .asked_blocks
                 .retain(|h, _| !remove_hashes.contains(h));
         }
-        self.block_wishlist
-            .retain(|h, _| !remove_hashes.contains(h));
         Ok(())
     }
 
@@ -494,7 +501,31 @@ impl ProtocolWorker {
             Default::default();
 
         // list blocks to re-ask and from whom
-        for (hash, required_info) in self.block_wishlist.iter() {
+        for (hash, block_info) in self.block_wishlist.iter_mut() {
+            let required_info = if block_info.header.is_none() {
+                AskForBlocksInfo::Header
+            } else if block_info.operation_ids.is_none() {
+                AskForBlocksInfo::Info
+            } else {
+                let already_stored_operations = block_info.storage.claim_operation_refs(
+                    &block_info
+                        .operation_ids
+                        .clone()
+                        .unwrap()
+                        .into_iter()
+                        .collect(),
+                );
+                AskForBlocksInfo::Operations(
+                    block_info
+                        .operation_ids
+                        .clone()
+                        .unwrap()
+                        .iter()
+                        .filter(|&id| !already_stored_operations.contains(id))
+                        .cloned()
+                        .collect(),
+                )
+            };
             let mut needs_ask = true;
 
             for (node_id, node_info) in self.active_nodes.iter_mut() {
@@ -579,7 +610,7 @@ impl ProtocolWorker {
                 candidate_nodes.entry(*hash).or_insert_with(Vec::new).push((
                     candidate,
                     *node_id,
-                    required_info,
+                    required_info.clone(),
                 ));
             }
 
@@ -636,7 +667,7 @@ impl ProtocolWorker {
                 ask_block_list
                     .entry(best_node)
                     .or_insert_with(Vec::new)
-                    .push((hash, required_info.0.clone()));
+                    .push((hash, required_info.clone()));
 
                 let timeout_at = now
                     .checked_add(self.config.ask_block_timeout.into())
@@ -696,7 +727,7 @@ impl ProtocolWorker {
         &mut self,
         header: &WrappedHeader,
         source_node_id: &NodeId,
-    ) -> Result<Option<(BlockId, PreHashMap<EndorsementId, u32>, bool)>, ProtocolError> {
+    ) -> Result<Option<(BlockId, bool)>, ProtocolError> {
         massa_trace!("protocol.protocol_worker.note_header_from_node", { "node": source_node_id, "header": header });
 
         // check header integrity
@@ -718,7 +749,7 @@ impl ProtocolWorker {
 
         // check if this header was already verified
         let now = Instant::now();
-        if let Some(block_info) = self.checked_headers.get(&block_id) {
+        if let Some(block_header) = self.checked_headers.get(&block_id) {
             if let Some(node_info) = self.active_nodes.get_mut(source_node_id) {
                 node_info.insert_known_blocks(
                     &header.content.parents,
@@ -733,20 +764,19 @@ impl ProtocolWorker {
                     self.config.max_node_known_blocks_size,
                 );
                 node_info.insert_known_endorsements(
-                    block_info.endorsements.keys().copied().collect(),
+                    block_header
+                        .content
+                        .endorsements
+                        .iter()
+                        .map(|e| e.id)
+                        .collect(),
                     self.config.max_node_known_endorsements_size,
                 );
-                if let Some(operations) = block_info.operations.as_ref() {
-                    node_info.insert_known_ops(
-                        operations.iter().cloned().collect(),
-                        self.config.max_node_known_ops_size,
-                    );
-                }
             }
-            return Ok(Some((block_id, block_info.endorsements.clone(), false)));
+            return Ok(Some((block_id, false)));
         }
 
-        let (endorsement_ids, endorsements_reused) = match self.note_endorsements_from_node(
+        let (_endorsement_ids, endorsements_reused) = match self.note_endorsements_from_node(
             header.content.endorsements.clone(),
             source_node_id,
             false,
@@ -801,10 +831,9 @@ impl ProtocolWorker {
             }
         }
 
-        let block_info = BlockInfo::new(endorsement_ids.clone(), header.clone());
         if self
             .checked_headers
-            .insert(block_id, block_info.clone())
+            .insert(block_id, header.clone())
             .is_none()
         {
             self.prune_checked_headers();
@@ -824,17 +853,11 @@ impl ProtocolWorker {
                 self.config.max_node_known_blocks_size,
             );
             node_info.insert_known_endorsements(
-                block_info.endorsements.keys().copied().collect(),
+                header.content.endorsements.iter().map(|e| e.id).collect(),
                 self.config.max_node_known_endorsements_size,
             );
-            if let Some(operations) = block_info.operations.as_ref() {
-                node_info.insert_known_ops(
-                    operations.iter().cloned().collect(),
-                    self.config.max_node_known_ops_size,
-                );
-            }
             massa_trace!("protocol.protocol_worker.note_header_from_node.ok", { "node": source_node_id,"block_id":block_id, "header": header});
-            return Ok(Some((block_id, endorsement_ids, true)));
+            return Ok(Some((block_id, true)));
         }
         Ok(None)
     }

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -500,22 +500,14 @@ impl ProtocolWorker {
             } else if block_info.operation_ids.is_none() {
                 AskForBlocksInfo::Info
             } else {
-                let already_stored_operations = block_info.storage.claim_operation_refs(
-                    &block_info
-                        .operation_ids
-                        .clone()
-                        .unwrap()
-                        .into_iter()
-                        .collect(),
-                );
+                let already_stored_operations = block_info.storage.get_op_refs();
                 AskForBlocksInfo::Operations(
                     block_info
                         .operation_ids
                         .clone()
                         .unwrap()
-                        .iter()
-                        .filter(|&id| !already_stored_operations.contains(id))
-                        .cloned()
+                        .into_iter()
+                        .filter(|id| !already_stored_operations.contains(id))
                         .collect(),
                 )
             };


### PR DESCRIPTION
This PR fix the protocol block workflow as he was using the `checked_headers` as vector to save data but should be used only as a cache. Also added some features. Here is a list just below and an explanation of the workflow.

## Changes

- Wishlist delta -> Add option to ask the header if the consensus don't have it. Use case: the graph ask for a parent block he calculated but only have the hash, he need the header. The header is passed as option and so the workflow can start directly at: asking operations
- Removed insert_knows_ops if we know that a node has an header. Having an header doesn't mean having operations.
- Removed list of endorsements in the return of  `note_heade_from_node`. not used.
- The structure in block_wishlist now named `BlockInfo` and have option on each informations that will be retrieved in the proccess. This options are also used to determine the step we are in `update_ask_block` function.

## Workflow explanation (consensus + protocol) : 

Protocol & Consensus notes

First case: Protocol receive header through classic block header propagation and send it to consensus that check the validity and ask back informations to protocol. 
Second case: Consensus (graph) check that he need a parent and ask full block (header + infos) to protocol 

- Consensus ask informations with the `WishlistDelta` 
- Protocol receive an ask for information with an `Option<WrappedHeader>` if he already know the header.
- If header is already here skip to step 2
- Step 1: Protocol, through `update_ask_block`, ask for block header to an node. When receive it trigger `on_receive_block_header` save it in `BlockInfo` of the wishlist, remove ask on the node and it will trigger the next step automatically in next `update_ask_block` trigger
- Step 2: Same process with operation ids list in function `on_receive_operations_list`. Add to known node info -> compute hash of all operations hash and compare with header -> add operation ids in BlockInfo -> claim operations ids in Storage -> check operations ids list size -> Protocol updates wishlist -> remove node demand -> auto run ask update to make a new demand -> if all ope received or have all op already or no ope direct call next step
- Step 3: Same process with operation list in function `on_receive_full_operations_list` Check validity and send to Pool -> check max size -> check if received and storage equals full block -> build block -> send full block to consensus


Tested on labnet.