### PR TITLE
Change endorsements

### DIFF
--- a/massa-consensus-exports/src/commands.rs
+++ b/massa-consensus-exports/src/commands.rs
@@ -43,7 +43,7 @@ pub enum ConsensusCommand {
         /// wanted slot
         slot: Slot,
         /// response channel
-        response_tx: oneshot::Sender<Option<BlockId>>,
+        response_tx: oneshot::Sender<BlockId>,
     },
     /// Get the best parents and their period
     GetBestParents {

--- a/massa-consensus-exports/src/commands.rs
+++ b/massa-consensus-exports/src/commands.rs
@@ -38,6 +38,13 @@ pub enum ConsensusCommand {
         /// response channel
         response_tx: oneshot::Sender<Option<BlockId>>,
     },
+    /// Get a block at a given slot in a blockclique
+    GetLatestBlockcliqueBlockAtSlot {
+        /// wanted slot
+        slot: Slot,
+        /// response channel
+        response_tx: oneshot::Sender<Option<BlockId>>,
+    },
     /// Get the best parents and their period
     GetBestParents {
         /// response channel

--- a/massa-consensus-exports/src/consensus_controller.rs
+++ b/massa-consensus-exports/src/consensus_controller.rs
@@ -161,7 +161,7 @@ impl ConsensusCommandSender {
     pub fn get_latest_blockclique_block_at_slot(
         &self,
         slot: Slot,
-    ) -> Result<Option<BlockId>, ConsensusError> {
+    ) -> Result<BlockId, ConsensusError> {
         let (response_tx, response_rx) = oneshot::channel();
         self.0
             .blocking_send(ConsensusCommand::GetLatestBlockcliqueBlockAtSlot { slot, response_tx })

--- a/massa-consensus-exports/src/consensus_controller.rs
+++ b/massa-consensus-exports/src/consensus_controller.rs
@@ -157,6 +157,26 @@ impl ConsensusCommandSender {
         })
     }
 
+    /// get latest block id of a slot in a blockclique
+    pub fn get_latest_blockclique_block_at_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<Option<BlockId>, ConsensusError> {
+        let (response_tx, response_rx) = oneshot::channel();
+        self.0
+            .blocking_send(ConsensusCommand::GetLatestBlockcliqueBlockAtSlot { slot, response_tx })
+            .map_err(|_| {
+                ConsensusError::SendChannelError(
+                    "send error consensus command get_blockclique_block_at_slot".into(),
+                )
+            })?;
+        response_rx.blocking_recv().map_err(|_| {
+            ConsensusError::ReceiveChannelError(
+                "consensus command get_blockclique_block_at_slot response read error".to_string(),
+            )
+        })
+    }
+
     /// get current consensus stats
     pub async fn get_stats(&self) -> Result<ConsensusStats, ConsensusError> {
         let (response_tx, response_rx) = oneshot::channel();

--- a/massa-factory-worker/src/block_factory.rs
+++ b/massa-factory-worker/src/block_factory.rs
@@ -167,13 +167,14 @@ impl BlockFactoryWorker {
 
         // get the parent in the same thread, with its period
         // will not panic because the thread is validated before the call
-        let (same_thread_parent_id, same_thread_parent_period) = parents[slot.thread as usize];
+        let (same_thread_parent_id, _) = parents[slot.thread as usize];
 
         // gather endorsements
-        let (endorsements_ids, endo_storage) = self.channels.pool.get_block_endorsements(
-            &same_thread_parent_id,
-            &Slot::new(same_thread_parent_period, slot.thread),
-        );
+        let (endorsements_ids, endo_storage) = self
+            .channels
+            .pool
+            .get_block_endorsements(&same_thread_parent_id, &slot);
+
         //TODO: Do we want ot populate only with endorsement id in the future ?
         let endorsements: Vec<WrappedEndorsement> = {
             let endo_read = endo_storage.read_endorsements();

--- a/massa-factory-worker/src/endorsement_factory.rs
+++ b/massa-factory-worker/src/endorsement_factory.rs
@@ -62,7 +62,7 @@ impl EndorsementFactoryWorker {
         // get delayed time
         let shifted_now = MassaTime::now(self.cfg.clock_compensation_millis)
             .expect("could not get current time")
-            .saturating_sub(self.half_t0);
+            .saturating_sub(self.cfg.t0);
 
         // if it's the first computed slot, add a time shift to prevent double-production on node restart with clock skew
         let base_time = if previous_slot.is_none() {
@@ -74,7 +74,7 @@ impl EndorsementFactoryWorker {
         // get closest slot according to the current absolute time
         let mut next_slot = get_closest_slot_to_timestamp(
             self.cfg.thread_count,
-            self.cfg.t0,
+            self.half_t0,
             self.cfg.genesis_timestamp,
             base_time,
         );
@@ -96,7 +96,7 @@ impl EndorsementFactoryWorker {
             next_slot,
         )
         .expect("could not get block slot timestamp")
-        .saturating_add(self.half_t0)
+        .saturating_sub(self.half_t0)
         .estimate_instant(self.cfg.clock_compensation_millis)
         .expect("could not estimate block slot instant");
 

--- a/massa-factory-worker/src/endorsement_factory.rs
+++ b/massa-factory-worker/src/endorsement_factory.rs
@@ -164,17 +164,14 @@ impl EndorsementFactoryWorker {
             // error getting block ID at target slot
             Err(_) => {
                 warn!(
-                    "could not get blockclique block to create endorsement targeting slot {}",
+                    "could not get latest blockclique block to create endorsement targeting slot {}",
                     slot
                 );
                 return;
             }
 
-            // the target slot is a miss: ignore
-            Ok(None) => return,
-
-            // there is a block a the target slot
-            Ok(Some(b_id)) => b_id,
+            // latest block found
+            Ok(b_id) => b_id,
         };
 
         // produce endorsements

--- a/massa-factory-worker/src/endorsement_factory.rs
+++ b/massa-factory-worker/src/endorsement_factory.rs
@@ -164,7 +164,7 @@ impl EndorsementFactoryWorker {
             // error getting block ID at target slot
             Err(_) => {
                 warn!(
-                    "could not get latest blockclique block to create endorsement targeting slot {}",
+                    "could not get latest blockclique block to create endorsement to be included at slot {}",
                     slot
                 );
                 return;

--- a/massa-factory-worker/src/endorsement_factory.rs
+++ b/massa-factory-worker/src/endorsement_factory.rs
@@ -118,7 +118,7 @@ impl EndorsementFactoryWorker {
         }
     }
 
-    /// Process a slot: produce a block at that slot if one of the managed keys is drawn.
+    /// Process a slot: produce an endorsement at that slot if one of the managed keys is drawn.
     fn process_slot(&mut self, slot: Slot) {
         // get endorsement producer addresses for that slot
         let producer_addrs = match self.channels.selector.get_selection(slot) {
@@ -156,23 +156,26 @@ impl EndorsementFactoryWorker {
         }
 
         // get consensus block ID for that slot
-        let endorsed_block: BlockId =
-            match self.channels.consensus.get_blockclique_block_at_slot(slot) {
-                // error getting block ID at target slot
-                Err(_) => {
-                    warn!(
-                        "could not get blockclique block to create endorsement targeting slot {}",
-                        slot
-                    );
-                    return;
-                }
+        let endorsed_block: BlockId = match self
+            .channels
+            .consensus
+            .get_latest_blockclique_block_at_slot(slot)
+        {
+            // error getting block ID at target slot
+            Err(_) => {
+                warn!(
+                    "could not get blockclique block to create endorsement targeting slot {}",
+                    slot
+                );
+                return;
+            }
 
-                // the target slot is a miss: ignore
-                Ok(None) => return,
+            // the target slot is a miss: ignore
+            Ok(None) => return,
 
-                // there is a block a the target slot
-                Ok(Some(b_id)) => b_id,
-            };
+            // there is a block a the target slot
+            Ok(Some(b_id)) => b_id,
+        };
 
         // produce endorsements
         let mut endorsements: Vec<WrappedEndorsement> = Vec::with_capacity(producers_indices.len());

--- a/massa-graph/src/block_graph.rs
+++ b/massa-graph/src/block_graph.rs
@@ -1584,22 +1584,12 @@ impl BlockGraph {
                     ),
                 )));
             }
-            // check that the endorsement slot matches the endorsed block
-            if endorsement.content.slot != header.content.slot {
-                return Ok(EndorsementsCheckOutcome::Discard(DiscardReason::Invalid(
-                    format!("endorsement slot does not match the slot of the block that contains it. Block slot: {}, endorsement slot: {}",
-                    header.content.slot, endorsement.content.slot),
-                )));
-            }
 
             // note that the following aspects are checked in protocol
-            // * PoS draws
             // * signature
-            // * intra block endorsement reuse
-            // * intra block index reuse
-            // * slot in the same thread as block's slot
-            // * slot is before the block's slot
-            // * the endorsed block is the current block at the slot
+            // * index reuse
+            // * slot matching the block's
+            // * the endorsed block is the containing block's parent
         }
 
         Ok(EndorsementsCheckOutcome::Proceed)

--- a/massa-pool-exports/src/controller_traits.rs
+++ b/massa-pool-exports/src/controller_traits.rs
@@ -23,7 +23,7 @@ pub trait PoolController: Send + Sync {
     fn get_block_endorsements(
         &self,
         target_block: &BlockId,
-        target_slot: &Slot,
+        slot: &Slot,
     ) -> (Vec<Option<EndorsementId>>, Storage);
 
     /// Get the number of endorsements in the pool

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -148,17 +148,17 @@ impl EndorsementPool {
     /// get endorsements for block creation
     pub fn get_block_endorsements(
         &self,
-        target_slot: &Slot,
+        slot: &Slot, // slot of the block
         target_block: &BlockId,
     ) -> (Vec<Option<EndorsementId>>, Storage) {
-        // init list of selected operation IDs
+        // init list of selected endorsement IDs
         let mut endo_ids = Vec::with_capacity(self.config.max_block_endorsement_count as usize);
 
         // gather endorsements
         for index in 0..self.config.max_block_endorsement_count {
             endo_ids.push(
                 self.endorsements_indexed
-                    .get(&(*target_slot, index, *target_block))
+                    .get(&(*slot, index, *target_block))
                     .copied(),
             );
         }

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -54,13 +54,13 @@ impl EndorsementPool {
         // update internal final CS period counter
         self.last_cs_final_periods = final_cs_periods.to_vec();
 
-        // remove old endorsements
+        // remove all endorsements whose periods <= last_cs_final_periods[endorsement.thread]
         let mut removed: PreHashSet<EndorsementId> = Default::default();
         for thread in 0..self.config.thread_count {
             while let Some((&(target_slot, index, block_id), &endo_id)) =
                 self.endorsements_sorted[thread as usize].first_key_value()
             {
-                if target_slot.period < self.last_cs_final_periods[thread as usize] {
+                if target_slot.period <= self.last_cs_final_periods[thread as usize] {
                     self.endorsements_sorted[thread as usize].pop_first();
                     self.endorsements_indexed
                         .remove(&(target_slot, index, block_id))

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -148,7 +148,7 @@ impl EndorsementPool {
     /// get endorsements for block creation
     pub fn get_block_endorsements(
         &self,
-        slot: &Slot, // slot of the block
+        slot: &Slot, // slot of the block that will contain the endorsement
         target_block: &BlockId,
     ) -> (Vec<Option<EndorsementId>>, Storage) {
         // init list of selected endorsement IDs

--- a/massa-pos-exports/src/controller_traits.rs
+++ b/massa-pos-exports/src/controller_traits.rs
@@ -63,7 +63,9 @@ pub trait SelectorController: Send + Sync {
     ///
     /// Only used in tests for post-bootstrap selection matching.
     #[cfg(feature = "testing")]
-    fn get_entire_selection(&self) -> VecDeque<(u64, HashMap<Slot, Selection>)>;
+    fn get_entire_selection(&self) -> VecDeque<(u64, HashMap<Slot, Selection>)> {
+        unimplemented!("mock implementation only")
+    }
 }
 
 /// Allow cloning `Box<dyn SelectorController>`

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -812,9 +812,7 @@ impl ProtocolWorker {
                 return Ok(None);
             }
             // check slot
-            if (endorsement.content.slot.thread != header.content.slot.thread)
-                || (endorsement.content.slot >= header.content.slot)
-            {
+            if endorsement.content.slot != header.content.slot {
                 massa_trace!("protocol.protocol_worker.check_header.err_endorsement_invalid_slot", { "header": header, "endorsement": endorsement});
                 return Ok(None);
             }

--- a/massa-storage/src/block_indexes.rs
+++ b/massa-storage/src/block_indexes.rs
@@ -23,8 +23,6 @@ pub struct BlockIndexes {
     index_by_op: PreHashMap<OperationId, PreHashSet<BlockId>>,
     /// Structure mapping endorsement id with ids of blocks they are contained in
     index_by_endorsement: PreHashMap<EndorsementId, PreHashSet<BlockId>>,
-    /// Structure mapping threads with their Block id
-    index_by_thread: HashMap<u8, PreHashSet<BlockId>>,
 }
 
 impl BlockIndexes {
@@ -42,11 +40,6 @@ impl BlockIndexes {
             // update slot index
             self.index_by_slot
                 .entry(b.content.header.content.slot)
-                .or_default()
-                .insert(b.id);
-
-            self.index_by_thread
-                .entry(b.content.header.content.slot.thread)
                 .or_default()
                 .insert(b.id);
 
@@ -83,17 +76,6 @@ impl BlockIndexes {
             // update slot index
             if let hash_map::Entry::Occupied(mut occ) =
                 self.index_by_slot.entry(b.content.header.content.slot)
-            {
-                occ.get_mut().remove(&b.id);
-                if occ.get().is_empty() {
-                    occ.remove();
-                }
-            }
-
-            // update thread index
-            if let hash_map::Entry::Occupied(mut occ) = self
-                .index_by_thread
-                .entry(b.content.header.content.slot.thread)
             {
                 occ.get_mut().remove(&b.id);
                 if occ.get().is_empty() {
@@ -158,16 +140,6 @@ impl BlockIndexes {
     /// - the block ids of the blocks at the slot if any, None otherwise
     pub fn get_blocks_by_slot(&self, slot: &Slot) -> Option<&PreHashSet<BlockId>> {
         self.index_by_slot.get(slot)
-    }
-
-    /// Get the block ids of the blocks at a given slot.
-    /// Arguments:
-    /// - thread: index of the thread to get the block id of
-    ///
-    /// Returns:
-    /// - the block ids of the blocks at the thread if any, None otherwise
-    pub fn get_blocks_by_thread(&self, thread: u8) -> Option<&PreHashSet<BlockId>> {
-        self.index_by_thread.get(&thread)
     }
 
     /// Get the block ids of the blocks containing a given operation.

--- a/massa-storage/src/block_indexes.rs
+++ b/massa-storage/src/block_indexes.rs
@@ -23,6 +23,8 @@ pub struct BlockIndexes {
     index_by_op: PreHashMap<OperationId, PreHashSet<BlockId>>,
     /// Structure mapping endorsement id with ids of blocks they are contained in
     index_by_endorsement: PreHashMap<EndorsementId, PreHashSet<BlockId>>,
+    /// Structure mapping threads with their Block id
+    index_by_thread: HashMap<u8, PreHashSet<BlockId>>,
 }
 
 impl BlockIndexes {
@@ -40,6 +42,11 @@ impl BlockIndexes {
             // update slot index
             self.index_by_slot
                 .entry(b.content.header.content.slot)
+                .or_default()
+                .insert(b.id);
+
+            self.index_by_thread
+                .entry(b.content.header.content.slot.thread)
                 .or_default()
                 .insert(b.id);
 
@@ -76,6 +83,17 @@ impl BlockIndexes {
             // update slot index
             if let hash_map::Entry::Occupied(mut occ) =
                 self.index_by_slot.entry(b.content.header.content.slot)
+            {
+                occ.get_mut().remove(&b.id);
+                if occ.get().is_empty() {
+                    occ.remove();
+                }
+            }
+
+            // update thread index
+            if let hash_map::Entry::Occupied(mut occ) = self
+                .index_by_thread
+                .entry(b.content.header.content.slot.thread)
             {
                 occ.get_mut().remove(&b.id);
                 if occ.get().is_empty() {
@@ -140,6 +158,16 @@ impl BlockIndexes {
     /// - the block ids of the blocks at the slot if any, None otherwise
     pub fn get_blocks_by_slot(&self, slot: &Slot) -> Option<&PreHashSet<BlockId>> {
         self.index_by_slot.get(slot)
+    }
+
+    /// Get the block ids of the blocks at a given slot.
+    /// Arguments:
+    /// - thread: index of the thread to get the block id of
+    ///
+    /// Returns:
+    /// - the block ids of the blocks at the thread if any, None otherwise
+    pub fn get_blocks_by_thread(&self, thread: u8) -> Option<&PreHashSet<BlockId>> {
+        self.index_by_thread.get(&thread)
     }
 
     /// Get the block ids of the blocks containing a given operation.


### PR DESCRIPTION
#2976

On processing a slot, select the latest block on the same thread as endorsed block.
Target the current slot to check the endorsements for the best parent.