### PR TITLE
Remove banning in edge case and more print

### DIFF
--- a/massa-pos-worker/src/draw.rs
+++ b/massa-pos-worker/src/draw.rs
@@ -57,6 +57,7 @@ pub(crate) fn perform_draws(
         ),
     };
 
+    let mut five_first_slots: Vec<(Slot, Selection)> = Vec::new();
     loop {
         // draw block creator
         let producer = if cur_slot.period > 0 {
@@ -71,14 +72,13 @@ pub(crate) fn perform_draws(
             .map(|_index| addresses[dist.sample(&mut rng)])
             .collect();
 
+        let selection = Selection {
+            producer,
+            endorsements,
+        };
+        five_first_slots.push((cur_slot, selection.clone()));
         // add to draws
-        cycle_draws.draws.insert(
-            cur_slot,
-            Selection {
-                producer,
-                endorsements,
-            },
-        );
+        cycle_draws.draws.insert(cur_slot, selection);
 
         if cur_slot == last_slot {
             break;
@@ -92,11 +92,7 @@ pub(crate) fn perform_draws(
         "Draws for cycle {} complete. Look_back seed was {:#?}. Five first selections is : {:#?}",
         cycle,
         lookback_seed.to_bytes(),
-        cycle_draws
-            .draws
-            .iter()
-            .take(5)
-            .collect::<Vec<(&Slot, &Selection)>>()
+        five_first_slots
     );
 
     Ok(cycle_draws)

--- a/massa-pos-worker/src/draw.rs
+++ b/massa-pos-worker/src/draw.rs
@@ -58,6 +58,7 @@ pub(crate) fn perform_draws(
     };
 
     let mut five_first_slots: Vec<(Slot, Selection)> = Vec::new();
+    let mut count = 0;
     loop {
         // draw block creator
         let producer = if cur_slot.period > 0 {
@@ -76,7 +77,10 @@ pub(crate) fn perform_draws(
             producer,
             endorsements,
         };
-        five_first_slots.push((cur_slot, selection.clone()));
+        if count < 5 {
+            five_first_slots.push((cur_slot, selection.clone()));
+            count += 1;
+        }
         // add to draws
         cycle_draws.draws.insert(cur_slot, selection);
 

--- a/massa-protocol-worker/src/lib.rs
+++ b/massa-protocol-worker/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(ip)]
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies)]
+#![feature(let_chains)]
 
 /// protocol worker
 pub mod protocol_worker;

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -119,15 +119,12 @@ impl ProtocolWorker {
             }
             NetworkEvent::ReceivedEndorsements { node, endorsements } => {
                 massa_trace!(ENDORSEMENTS, { "node": node, "endorsements": endorsements});
-                if self
-                    .note_endorsements_from_node(endorsements, &node, true)
-                    .is_err()
-                {
+                if let Err(err) = self.note_endorsements_from_node(endorsements, &node, true) {
                     warn!(
                         "node {} sent us critically incorrect endorsements, \
                         which may be an attack attempt by the remote node or a \
-                        loss of sync between us and the remote node",
-                        node,
+                        loss of sync between us and the remote node. Err = {}",
+                        node, err
                     );
                     let _ = self.ban_node(&node).await;
                 }
@@ -254,16 +251,12 @@ impl ProtocolWorker {
                 return Ok(());
             }
         }
-        if self
-            .note_header_from_node(&header, &from_node_id)
-            .await
-            .is_err()
-        {
+        if let Err(err) = self.note_header_from_node(&header, &from_node_id).await {
             warn!(
                 "node {} sent us critically incorrect header through protocol, \
                 which may be an attack attempt by the remote node \
-                or a loss of sync between us and the remote node",
-                from_node_id,
+                or a loss of sync between us and the remote node. Err = {}",
+                from_node_id, err
             );
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -402,13 +402,10 @@ impl ProtocolWorker {
         block_id: BlockId,
         mut operations: Vec<WrappedOperation>,
     ) -> Result<(), ProtocolError> {
-        if self
-            .note_operations_from_node(operations.clone(), &from_node_id)
-            .is_err()
-        {
+        if let Err(err) = self.note_operations_from_node(operations.clone(), &from_node_id) {
             warn!(
-                "Node id {} sent us operations for block id {} but they have bad signatures.",
-                from_node_id, block_id
+                "Node id {} sent us operations for block id {} but they failed at verifications. Err = {}",
+                from_node_id, block_id, err
             );
             let _ = self.ban_node(&from_node_id).await;
             return Ok(());

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -137,11 +137,8 @@ impl ProtocolWorker {
         node_id: NodeId,
         operations: Vec<WrappedOperation>,
     ) {
-        if self
-            .note_operations_from_node(operations, &node_id)
-            .is_err()
-        {
-            warn!("node {} sent us critically incorrect operation, which may be an attack attempt by the remote node or a loss of sync between us and the remote node", node_id,);
+        if let Err(err) = self.note_operations_from_node(operations, &node_id) {
+            warn!("node {} sent us critically incorrect operation, which may be an attack attempt by the remote node or a loss of sync between us and the remote node. Err = {}", node_id, err);
             let _ = self.ban_node(&node_id).await;
         }
     }


### PR DESCRIPTION
Case : If we already received info about this step or the next one
* don't ban
* ignore
* mark as not knowing block
* print

Case : If we haven’t received the infos from the precedent step
Can happen if consensus removes the block from wishlist during the process
* ignore 
* warn
*  mark as not knowing block

Case : If block is bigger than max size
that is a problem.
* Warn 
* ban the sender

Case : If not all operations has been received when asking
* gather the ops that are good AND asked
* mark the node as not knowing the block
* print a warning

Case : If we receive a bad header asked by protocol, not block propagation
* print warning
* ban

Solutions : Add print in all this cases and remove banning as we are on testnet and so we can have data, except for “bad header asked by protocol, not block propagation” that we should keep the ban