### PR TITLE
Remove useless transfer balance.

### DIFF
--- a/docs/technical-doc/openrpc.json
+++ b/docs/technical-doc/openrpc.json
@@ -1376,7 +1376,6 @@
                 "title": "ExecuteSC",
                 "description": "Execute Smart Contract",
                 "required": [
-                    "coins",
                     "data",
                     "gas_price",
                     "max_gas"
@@ -1393,10 +1392,6 @@
                     "max_gas": {
                         "description": "Maximum amount of gas that the execution of the contract is allowed to cost.",
                         "type": "number"
-                    },
-                    "coins": {
-                        "description": "Represent an Amount in coins that are spent by consensus and are available in the execution context of the contract",
-                        "type": "string"
                     },
                     "gas_price": {
                         "description": "Represent an Amount in coins, price per unit of gas that the caller is willing to pay for the execution.",

--- a/docs/technical-doc/vm-block-feed.rst
+++ b/docs/technical-doc/vm-block-feed.rst
@@ -13,9 +13,9 @@ Summary
 The general idea is that the Smart Contract Engine (SCE) takes an initial SCE ledger loaded from file and iteratively updates it by executing all Slots in order from (0,0) up to the current latest slot.
 At each one of those slots, there might be a block (either final or in the active Blockclique) containing a certain number of ExecuteSC operations, or a miss (lack of block in the slot). ExecuteSC operations within a block are tentatively executed in the order they appear in the block.
 
-Each one of those ExecuteSC operations has already spent `max_gas * gas_price + coins` from the CSS ledger so that the block creator is certain to get the gas fees (they cannot be spent in-between).
-When an ExecuteSC operation is executed on the SCE side, it immediately credits the block producer with `max_gas * gas_price` in the SCE ledger, then it credits the target address with `coins` in the SCE ledger, then it executes the byte-code inside the ExecuteSC operation.
-If byte-code execution fails (invalid byte-code or execution error), everything is reverted except the `max_gas * gas_price` credit to the block producer and `coins` are sent back to the sender on the SCE side.
+Each one of those ExecuteSC operations has already spent `max_gas * gas_price` from the CSS ledger so that the block creator is certain to get the gas fees (they cannot be spent in-between).
+When an ExecuteSC operation is executed on the SCE side, it immediately credits the block producer with `max_gas * gas_price` in the ledger then it executes the byte-code inside the ExecuteSC operation.
+If byte-code execution fails (invalid byte-code or execution error), everything is reverted except the `max_gas * gas_price` credit to the block producer.
 
 This scheme works in theory but requires heavy optimizations in practice because not everything can be recomputed from genesis at every slot or Blockclique change, especially since old blocks are forgotten. Such optimizations include keeping only a final ledger on the SCE side and a list of changes caused by active blocks that can be applied to the final ledger on-the-fly.
 

--- a/docs/technical-doc/vm-ledger-interaction.rst
+++ b/docs/technical-doc/vm-ledger-interaction.rst
@@ -117,11 +117,10 @@ The detailed algorithm is the following:
 * if there is a block B at slot S:
   * Note that the block would have been rejected before if the sum of the `max_gas` of its operations exceeded `config.max_block_gas`
   * for every `ExecuteSC` operation Op of the block B :
-    * Note that Consensus has already debited `Op.max_gas*Op.gas_price+Op.coins` from Op's sender's CSS balance or rejected the block B if there wasn't enough balance to do so
+    * Note that Consensus has already debited `Op.max_gas*Op.gas_price` from Op's sender's CSS balance or rejected the block B if there wasn't enough balance to do so
     * prepare the context for execution:
-      * make `context.ledger_step` credit Op's sender with `Op.coins` in the SCE ledger 
       * make `context.ledger_step` credit the producer of the block B with `Op.max_gas * Op.gas_price` in the SCE ledger
-    * save a snapshot (named `ledger_changes_backup`) of the `context.ledger_step.caused_changes` that will be used to rollback the step's effects on the SCE ledger backt to this point in case bytecode execution fails. This is done because on bytecode execution failure (whether it fails completely or midway) we want to credit the block producer with fees (it's not their fault !) and Op's sender with `Op.coins` (otherwise those coins will be lost !) but revert all the effects of a bytecode execution that failed midway
+    * save a snapshot (named `ledger_changes_backup`) of the `context.ledger_step.caused_changes` that will be used to rollback the step's effects on the SCE ledger backt to this point in case bytecode execution fails. This is done because on bytecode execution failure (whether it fails completely or midway) we want to credit the block producer with fees (it's not their fault !) but revert all the effects of a bytecode execution that failed midway
     * parse and run (call `main()`) the bytecode of operation Op
       * in case of failure (e.g. invalid bytecode), revert `context.ledger_step.caused_changes = ledger_changes_backup`
 * push back the SCE ledger changes caused by the slot `StepHistoryItem { step, block_id (optional), ledger_changes: context.ledger_step.caused_changes  }` into `step_history`

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -226,9 +226,7 @@ pub enum Command {
 
     #[strum(
         ascii_case_insensitive,
-        props(
-            args = "SenderAddress TargetAddress FunctionName Parameter MaxGas GasPrice Coins Fee",
-        ),
+        props(args = "SenderAddress TargetAddress FunctionName Parameter MaxGas GasPrice Fee",),
         message = "create and send an operation to call a function of a smart contract"
     )]
     call_smart_contract,
@@ -824,14 +822,13 @@ impl Command {
                 Ok(Box::new(()))
             }
             Command::send_smart_contract => {
-                if parameters.len() != 6 {
+                if parameters.len() != 5 {
                     bail!("wrong number of parameters");
                 }
                 let addr = parameters[0].parse::<Address>()?;
                 let path = parameters[1].parse::<PathBuf>()?;
                 let max_gas = parameters[2].parse::<u64>()?;
                 let gas_price = parameters[3].parse::<Amount>()?;
-                let coins = parameters[4].parse::<Amount>()?;
                 let fee = parameters[5].parse::<Amount>()?;
 
                 if !json {
@@ -878,7 +875,6 @@ impl Command {
                     OperationType::ExecuteSC {
                         data,
                         max_gas,
-                        coins,
                         gas_price,
                         datastore,
                     },

--- a/massa-consensus-worker/src/tests/tools.rs
+++ b/massa-consensus-worker/src/tests/tools.rs
@@ -385,13 +385,11 @@ pub fn _create_executesc(
     fee: u64,
     data: Vec<u8>,
     max_gas: u64,
-    coins: u64,
     gas_price: u64,
 ) -> WrappedOperation {
     let op = OperationType::ExecuteSC {
         data,
         max_gas,
-        coins: Amount::from_str(&coins.to_string()).unwrap(),
         gas_price: Amount::from_str(&gas_price.to_string()).unwrap(),
         datastore: BTreeMap::new(),
     };

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -573,22 +573,6 @@ impl ExecutionState {
                 coins: *coins,
                 owned_addresses: vec![sender_addr],
             }];
-
-            // Debit the sender's balance with the coins to transfer
-            if let Err(err) = context.transfer_coins(Some(sender_addr), None, *coins, false) {
-                return Err(ExecutionError::RuntimeError(format!(
-                    "failed to debit operation sender {} with {} operation coins: {}",
-                    sender_addr, *coins, err
-                )));
-            }
-
-            // Credit the operation sender with `coins` coins.
-            if let Err(err) = context.transfer_coins(None, Some(sender_addr), *coins, false) {
-                return Err(ExecutionError::RuntimeError(format!(
-                    "failed to credit operation sender {} with {} operation coins: {}",
-                    sender_addr, *coins, err
-                )));
-            }
         };
 
         // run the VM on the bytecode contained in the operation

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -549,13 +549,8 @@ impl ExecutionState {
         sender_addr: Address,
     ) -> Result<(), ExecutionError> {
         // process ExecuteSC operations only
-        let (bytecode, max_gas, coins) = match &operation {
-            OperationType::ExecuteSC {
-                data,
-                max_gas,
-                coins,
-                ..
-            } => (data, max_gas, coins),
+        let (bytecode, max_gas) = match &operation {
+            OperationType::ExecuteSC { data, max_gas, .. } => (data, max_gas),
             _ => panic!("unexpected operation type"),
         };
 
@@ -565,12 +560,11 @@ impl ExecutionState {
 
             // Set the call stack to a single element:
             // * the execution will happen in the context of the address of the operation's sender
-            // * the context will signal that `coins` were credited to the balance of the sender during that call
             // * the context will give the operation's sender write access to its own ledger entry
             // This needs to be defined before anything can fail, so that the emitted event contains the right stack
             context.stack = vec![ExecutionStackElement {
                 address: sender_addr,
-                coins: *coins,
+                coins: Amount::zero(),
                 owned_addresses: vec![sender_addr],
             }];
         };

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -668,7 +668,6 @@ fn create_execute_sc_operation(
     let op = OperationType::ExecuteSC {
         data: data.to_vec(),
         max_gas: 100_000,
-        coins: Amount::from_str("10").unwrap(),
         gas_price: Amount::from_mantissa_scale(1, 0),
         datastore: BTreeMap::new(),
     };

--- a/massa-pool-worker/src/tests/tools.rs
+++ b/massa-pool-worker/src/tests/tools.rs
@@ -130,12 +130,10 @@ pub fn _create_executesc(
     let keypair = KeyPair::generate();
 
     let data = vec![42; 7];
-    let coins = 0_u64;
 
     let op = OperationType::ExecuteSC {
         data,
         max_gas,
-        coins: Amount::from_str(&coins.to_string()).unwrap(),
         gas_price: Amount::from_str(&gas_price.to_string()).unwrap(),
         datastore: BTreeMap::new(),
     };


### PR DESCRIPTION
This transfer was useful when 2 balances were in place to transfer from sequential to parallel before sending to SCs. Now it perform only a ping pong so we can remove it.