### PR TITLE
improve op propag

### DIFF
--- a/massa-protocol-worker/src/node_info.rs
+++ b/massa-protocol-worker/src/node_info.rs
@@ -6,8 +6,9 @@
 //! Same as for wanted/known blocks, we remember here in cache which node asked
 //! for operations and which operations he seem to already know.
 
+use massa_models::operation::OperationPrefixId;
 use massa_models::prehash::{CapacityAllocator, PreHashMap};
-use massa_models::{block::BlockId, endorsement::EndorsementId, operation::OperationId};
+use massa_models::{block::BlockId, endorsement::EndorsementId};
 use massa_protocol_exports::ProtocolConfig;
 use tokio::time::Instant;
 
@@ -24,8 +25,8 @@ pub(crate) struct NodeInfo {
     pub asked_blocks: PreHashMap<BlockId, Instant>,
     /// Instant when the node was added
     pub connection_instant: Instant,
-    /// all known operations
-    known_operations: LinearHashCacheSet<OperationId>,
+    /// all known operations (prefix-based)
+    known_operations: LinearHashCacheSet<OperationPrefixId>,
     /// all known endorsements
     known_endorsements: LinearHashCacheSet<EndorsementId>,
 }
@@ -97,11 +98,11 @@ impl NodeInfo {
         self.known_endorsements.contains(endorsement_id)
     }
 
-    pub fn insert_known_ops<I: IntoIterator<Item = OperationId>>(&mut self, ops: I) {
+    pub fn insert_known_ops<I: IntoIterator<Item = OperationPrefixId>>(&mut self, ops: I) {
         self.known_operations.try_extend(ops);
     }
 
-    pub fn knows_op(&self, op: &OperationId) -> bool {
+    pub fn knows_op(&self, op: &OperationPrefixId) -> bool {
         self.known_operations.contains(op)
     }
 }

--- a/massa-protocol-worker/src/protocol_network.rs
+++ b/massa-protocol-worker/src/protocol_network.rs
@@ -306,7 +306,7 @@ impl ProtocolWorker {
 
         // add to known ops
         if let Some(node_info) = self.active_nodes.get_mut(&from_node_id) {
-            node_info.insert_known_ops(operation_ids.iter().copied());
+            node_info.insert_known_ops(operation_ids.iter().map(|id| id.prefix()));
         }
 
         let info = if let Some(info) = self.block_wishlist.get_mut(&block_id) {

--- a/massa-protocol-worker/src/protocol_worker.rs
+++ b/massa-protocol-worker/src/protocol_worker.rs
@@ -352,11 +352,12 @@ impl ProtocolWorker {
         for (node, node_info) in self.active_nodes.iter_mut() {
             let new_ops: Vec<OperationId> = operation_ids
                 .iter()
-                .filter(|id| !node_info.knows_op(id))
+                .filter(|id| !node_info.knows_op(&id.prefix()))
                 .copied()
                 .collect();
-            node_info.insert_known_ops(new_ops.iter().copied());
             if !new_ops.is_empty() {
+                node_info.insert_known_ops(new_ops.iter().map(|id| id.prefix()));
+                
                 let res = self
                     .network_command_sender
                     .announce_operations(*node, new_ops.iter().map(|id| id.into_prefix()).collect())
@@ -952,7 +953,7 @@ impl ProtocolWorker {
 
         // add to known ops
         if let Some(node_info) = self.active_nodes.get_mut(source_node_id) {
-            node_info.insert_known_ops(received_ids);
+            node_info.insert_known_ops(received_ids.iter().map(|id| id.prefix()));
         }
 
         if !new_operations.is_empty() {

--- a/massa-protocol-worker/src/worker_operations_impl.rs
+++ b/massa-protocol-worker/src/worker_operations_impl.rs
@@ -64,6 +64,11 @@ impl ProtocolWorker {
         mut op_batch: OperationPrefixIds,
         node_id: NodeId,
     ) -> Result<(), ProtocolError> {
+        // mark sender as knowing the ops
+        if let Some(node_info) = self.active_nodes.get_mut(&node_id) {
+            node_info.insert_known_ops(op_batch.iter().copied());
+        }
+
         // filter out the operations that we already know about
         op_batch.retain(|prefix| !self.checked_operations.contains_prefix(prefix));
 


### PR DESCRIPTION
In this PR, we make sure that when someone announces us an operation, we mark the sender node as knowing the op.