### PR TITLE
doc: add sc playground page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,7 @@ Contents
    smart-contracts/getting-started.rst
    smart-contracts/massa-sc-by-example.rst
    smart-contracts/types.rst
+   smart-contracts/playground.rst
 
 .. toctree::
    :maxdepth: 2

--- a/docs/smart-contracts/playground.rst
+++ b/docs/smart-contracts/playground.rst
@@ -1,0 +1,8 @@
+.. _sc-playground:
+
+Smart-contract Playground
+=========================
+
+We've built a simple interface for writing, testing, and compiling smart-contracts, written in Assembly Script. You can access it via this link:
+
+https://massa.net/testnet/sc-playground


### PR DESCRIPTION
Link to the issue: https://github.com/massalabs/massa-sc-playground/issues/19

The playground is not deployed yet, we might want merge this PR when it is deployed and running on  massa.net/testnet/sc-playground

![image](https://user-images.githubusercontent.com/11590067/196200338-047338ed-6852-4350-a679-31796bd8cc61.png)


* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification