### PR TITLE
Keep old testnet final ledger.

### DIFF
--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -426,13 +426,6 @@ pub async fn get_state(
         // init final state
         {
             let mut final_state_guard = final_state.write();
-            // load ledger from initial ledger file
-            final_state_guard
-                .ledger
-                .load_initial_ledger()
-                .map_err(|err| {
-                    BootstrapError::GeneralError(format!("could not load initial ledger: {}", err))
-                })?;
             // create the initial cycle of PoS cycle_history
             final_state_guard.pos_state.create_initial_cycle();
         }

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -135,9 +135,12 @@ async fn launch(
 
     // Remove current disk ledger if there is one
     // NOTE: this is temporary, since we cannot currently handle bootstrap from remaining ledger
-    if SETTINGS.ledger.disk_ledger_path.exists() {
+    let now = MassaTime::now(0).expect("could not get now time");
+    if *GENESIS_TIMESTAMP > now && SETTINGS.ledger.disk_ledger_path.exists() {
         std::fs::remove_dir_all(SETTINGS.ledger.disk_ledger_path.clone())
             .expect("disk ledger delete failed");
+    } else {
+        info!("Loading old ledger for next episode");
     }
 
     // Create final ledger


### PR DESCRIPTION
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

Need to be tested, don't think it's a good thing to keep it for testnet 17.