### PR TITLE
Use bs58_check functions exclusively for debug purposes

### DIFF
--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -113,6 +113,19 @@ impl<'de> ::serde::Deserialize<'de> for Address {
 
 impl FromStr for Address {
     type Err = ModelsError;
+    /// ## Example
+    /// ```rust
+    /// # use massa_signature::{PublicKey, KeyPair, Signature};
+    /// # use massa_hash::Hash;
+    /// # use serde::{Deserialize, Serialize};
+    /// # use std::str::FromStr;
+    /// # use massa_models::address::Address;
+    /// # let keypair = KeyPair::generate();
+    /// # let address = Address::from_public_key(&keypair.get_public_key());
+    /// let ser = address.to_string();
+    /// let res_addr = Address::from_str(&ser).unwrap();
+    /// assert_eq!(address, res_addr);
+    /// ```
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut chars = s.chars();
         match chars.next() {
@@ -208,40 +221,6 @@ impl Address {
     /// ```
     pub fn from_bytes(data: &[u8; ADDRESS_SIZE_BYTES]) -> Address {
         Address(Hash::from_bytes(data))
-    }
-
-    /// ## Example
-    /// ```rust
-    /// # use massa_signature::{PublicKey, KeyPair, Signature};
-    /// # use massa_hash::Hash;
-    /// # use serde::{Deserialize, Serialize};
-    /// # use massa_models::address::Address;
-    /// # let keypair = KeyPair::generate();
-    /// # let address = Address::from_public_key(&keypair.get_public_key());
-    /// let ser = address.to_bs58_check();
-    /// let res_addr = Address::from_bs58_check(&ser).unwrap();
-    /// assert_eq!(address, res_addr);
-    /// ```
-    fn _from_bs58_check(data: &str) -> Result<Address, ModelsError> {
-        Ok(Address(
-            Hash::from_bs58_check(data).map_err(|_| ModelsError::HashError)?,
-        ))
-    }
-
-    /// ## Example
-    /// ```rust
-    /// # use massa_signature::{PublicKey, KeyPair, Signature};
-    /// # use massa_hash::Hash;
-    /// # use serde::{Deserialize, Serialize};
-    /// # use massa_models::address::Address;
-    /// # let keypair = KeyPair::generate();
-    /// # let address = Address::from_public_key(&keypair.get_public_key());
-    /// let ser = address.to_bs58_check();
-    /// let res_addr = Address::from_bs58_check(&ser).unwrap();
-    /// assert_eq!(address, res_addr);
-    /// ```
-    fn _to_bs58_check(&self) -> String {
-        self.0.to_bs58_check()
     }
 }
 

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -222,7 +222,7 @@ impl Address {
     /// let res_addr = Address::from_bs58_check(&ser).unwrap();
     /// assert_eq!(address, res_addr);
     /// ```
-    pub fn from_bs58_check(data: &str) -> Result<Address, ModelsError> {
+    fn _from_bs58_check(data: &str) -> Result<Address, ModelsError> {
         Ok(Address(
             Hash::from_bs58_check(data).map_err(|_| ModelsError::HashError)?,
         ))
@@ -240,7 +240,7 @@ impl Address {
     /// let res_addr = Address::from_bs58_check(&ser).unwrap();
     /// assert_eq!(address, res_addr);
     /// ```
-    pub fn to_bs58_check(&self) -> String {
+    fn _to_bs58_check(&self) -> String {
         self.0.to_bs58_check()
     }
 }

--- a/massa-models/src/ledger_models.rs
+++ b/massa-models/src/ledger_models.rs
@@ -383,14 +383,14 @@ impl Deserializer<LedgerChanges> for LedgerChangesDeserializer {
     /// # use massa_serialization::{Serializer, Deserializer, DeserializeError};
     /// # let ledger_changes = LedgerChanges(vec![
     /// #   (
-    /// #       Address::from_bs58_check("2oxLZc6g6EHfc5VtywyPttEeGDxWq3xjvTNziayWGDfxETZVTi".into()).unwrap(),
+    /// #       Address::from_str("A12hgh5ULW9o8fJE9muLNXhQENaUUswQbxPyDSq8ridnDGu5gRiJ").unwrap(),
     /// #       LedgerChange {
     /// #           balance_delta: Amount::from_str("1149").unwrap(),
     /// #           balance_increment: true
     /// #       },
     /// #   ),
     /// #   (
-    /// #       Address::from_bs58_check("2mvD6zEvo8gGaZbcs6AYTyWKFonZaKvKzDGRsiXhZ9zbxPD11q".into()).unwrap(),
+    /// #       Address::from_str("A12htxRWiEm8jDJpJptr6cwEhWNcCSFWstN1MLSa96DDkVM9Y42G").unwrap(),
     /// #       LedgerChange {
     /// #           balance_delta: Amount::from_str("1020").unwrap(),
     /// #           balance_increment: true


### PR DESCRIPTION
resolves https://github.com/massalabs/massa/issues/2627

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

I noticed that the Address' `from_bs58_check` and `to_bs58_check` were not used anymore so I deleted them from the code. 
I updated the examples that were using them and moved the Address' `bs58_check` examples as an example for the Address' `from_str` function.