### PR TITLE
Change name execute SC on client.

### DIFF
--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -218,7 +218,7 @@ pub enum Command {
         props(args = "SenderAddress PathToBytecode MaxGas Fee",),
         message = "create and send an operation containing byte code"
     )]
-    send_smart_contract,
+    execute_smart_contract,
 
     #[strum(
         ascii_case_insensitive,
@@ -232,7 +232,7 @@ pub enum Command {
         props(args = "PathToBytecode MaxGas Address",),
         message = "execute byte code, address is optional. Nothing is really executed on chain"
     )]
-    read_only_smart_contract,
+    read_only_execute_smart_contract,
 
     #[strum(
         ascii_case_insensitive,
@@ -818,7 +818,7 @@ impl Command {
                 }
                 Ok(Box::new(()))
             }
-            Command::send_smart_contract => {
+            Command::execute_smart_contract => {
                 if parameters.len() != 4 {
                     bail!("wrong number of parameters");
                 }
@@ -931,7 +931,7 @@ impl Command {
                     bail!("Missing public key")
                 }
             }
-            Command::read_only_smart_contract => {
+            Command::read_only_execute_smart_contract => {
                 if parameters.len() != 2 && parameters.len() != 3 {
                     bail!("wrong number of parameters");
                 }


### PR DESCRIPTION
This explicit the fact that the CLI is only for executing bytecode and not deploy smart contracts deployer because we don't allow the usage of a operation datastore.

The update will be done in massa-docs also