### PR TITLE
2608 need ipv6 bootstrap address

### DIFF
--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -443,18 +443,38 @@ pub async fn get_state(
     // We filter the bootstrap list to keep only the ip addresses we are compatible with
     match &bootstrap_config.bootstrap_protocol {
         Some(s) if s.as_str() == "ipv4" => {
+            let prev_bootstrap_list_len = filtered_bootstrap_list.len();
+
             filtered_bootstrap_list = filtered_bootstrap_list
                 .clone()
                 .into_iter()
                 .filter(|&(addr, _)| addr.is_ipv4())
-                .collect()
+                .collect();
+
+            let new_bootstrap_list_len = filtered_bootstrap_list.len();
+
+            debug!(
+                "Filtered out {} IPv6 bootstrap addresses out of a total of {} bootstrap servers.",
+                prev_bootstrap_list_len as i32 - new_bootstrap_list_len as i32,
+                prev_bootstrap_list_len
+            );
         }
         Some(s) if s.as_str() == "ipv6" => {
+            let prev_bootstrap_list_len = filtered_bootstrap_list.len();
+
             filtered_bootstrap_list = filtered_bootstrap_list
                 .clone()
                 .into_iter()
                 .filter(|&(addr, _)| addr.is_ipv6())
-                .collect()
+                .collect();
+
+            let new_bootstrap_list_len = filtered_bootstrap_list.len();
+
+            debug!(
+                "Filtered out {} IPv4 bootstrap addresses out of a total of {} bootstrap servers.",
+                prev_bootstrap_list_len as i32 - new_bootstrap_list_len as i32,
+                prev_bootstrap_list_len
+            );
         }
         _ => {}
     };

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 
 use massa_final_state::FinalState;
 use massa_logging::massa_trace;
-use massa_models::{streaming_step::StreamingStep, version::Version, node::NodeId};
+use massa_models::{node::NodeId, streaming_step::StreamingStep, version::Version};
 use massa_signature::PublicKey;
 use massa_time::MassaTime;
 use parking_lot::RwLock;
@@ -438,8 +438,7 @@ pub async fn get_state(
         return Ok(GlobalBootstrapState::new(final_state));
     }
 
-    let mut filtered_bootstrap_list =
-        bootstrap_config.bootstrap_list.clone();
+    let mut filtered_bootstrap_list = bootstrap_config.bootstrap_list.clone();
 
     // We filter the bootstrap list to keep only the ip addresses we are compatible with
     match &bootstrap_config.bootstrap_protocol {

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -483,7 +483,6 @@ pub async fn get_state(
 
     // we remove the duplicated node ids (if a bootstrap server appears both with its IPv4 and IPv6 address)
     let shuffled_hashmap: HashMap<NodeId, SocketAddr> = filtered_bootstrap_list
-        .clone()
         .into_iter()
         .map(|(addr, node_id)| (node_id, addr))
         .collect();

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -37,6 +37,7 @@ pub use messages::{
 };
 pub use server::{start_bootstrap_server, BootstrapManager};
 pub use settings::BootstrapConfig;
+pub use settings::IpType;
 
 #[cfg(test)]
 pub mod tests;

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -10,7 +10,7 @@ use std::{net::SocketAddr, path::PathBuf};
 pub struct BootstrapConfig {
     /// Ip address of our bootstrap nodes and their public key.
     pub bootstrap_list: Vec<(SocketAddr, PublicKey)>,
-    /// Ip address of our bootstrap nodes and their public key.
+    /// IP version filter for bootstrap list, targeting "ipv4", "ipv6" or "both".
     pub bootstrap_protocol: Option<String>,
     /// Path to the bootstrap whitelist file. This whitelist define IPs that can bootstrap on your node.
     pub bootstrap_whitelist_path: PathBuf,

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -5,13 +5,24 @@ use massa_time::MassaTime;
 use serde::Deserialize;
 use std::{net::SocketAddr, path::PathBuf};
 
+/// Bootstrap IP protocol version setting.
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub enum IpType {
+    /// Bootstrap with both IPv4 and IPv6 protocols (default).
+    Both,
+    /// Bootstrap only with IPv4.
+    IPv4,
+    /// Bootstrap only with IPv6.
+    IPv6,
+}
+
 /// Bootstrap configuration.
 #[derive(Debug, Deserialize, Clone)]
 pub struct BootstrapConfig {
     /// Ip address of our bootstrap nodes and their public key.
     pub bootstrap_list: Vec<(SocketAddr, NodeId)>,
-    /// IP version filter for bootstrap list, targeting "ipv4", "ipv6" or "both".
-    pub bootstrap_protocol: Option<String>,
+    /// IP version filter for bootstrap list, targeting IpType::IPv4, IpType::IPv6 or IpType::Both. Defaults to IpType::Both.
+    pub bootstrap_protocol: IpType,
     /// Path to the bootstrap whitelist file. This whitelist define IPs that can bootstrap on your node.
     pub bootstrap_whitelist_path: PathBuf,
     /// Path to the bootstrap blacklist file. This whitelist define IPs that will not be able to bootstrap on your node. This list is optional.

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -10,6 +10,8 @@ use std::{net::SocketAddr, path::PathBuf};
 pub struct BootstrapConfig {
     /// Ip address of our bootstrap nodes and their public key.
     pub bootstrap_list: Vec<(SocketAddr, PublicKey)>,
+    /// Ip address of our bootstrap nodes and their public key.
+    pub bootstrap_protocol: Option<String>,
     /// Path to the bootstrap whitelist file. This whitelist define IPs that can bootstrap on your node.
     pub bootstrap_whitelist_path: PathBuf,
     /// Path to the bootstrap blacklist file. This whitelist define IPs that will not be able to bootstrap on your node. This list is optional.

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -275,6 +275,7 @@ pub fn get_dummy_signature(s: &str) -> Signature {
 pub fn get_bootstrap_config(bootstrap_public_key: PublicKey) -> BootstrapConfig {
     BootstrapConfig {
         bind: Some("0.0.0.0:31244".parse().unwrap()),
+        bootstrap_protocol: Some(String::from("both")),
         connect_timeout: 200.into(),
         retry_delay: 200.into(),
         max_ping: MassaTime::from_millis(500),

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use super::mock_establisher::Duplex;
-use crate::settings::BootstrapConfig;
+use crate::settings::{BootstrapConfig, IpType};
 use bitvec::vec::BitVec;
 use massa_async_pool::test_exports::{create_async_pool, get_random_message};
 use massa_async_pool::{AsyncPoolChanges, Change};
@@ -276,7 +276,7 @@ pub fn get_dummy_signature(s: &str) -> Signature {
 pub fn get_bootstrap_config(bootstrap_public_key: NodeId) -> BootstrapConfig {
     BootstrapConfig {
         bind: Some("0.0.0.0:31244".parse().unwrap()),
-        bootstrap_protocol: Some(String::from("both")),
+        bootstrap_protocol: IpType::Both,
         connect_timeout: 200.into(),
         retry_delay: 200.into(),
         max_ping: MassaTime::from_millis(500),

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -208,10 +208,10 @@
         ["[2001:41d0:1004:67::]:31245", "N12UbyLJDS7zimGWf3LTHe8hYY67RdLke1iDRZqJbQQLHQSKPW8j"],
         ["[2001:41d0:a:7f7d::]:31245", "N12vxrYTQzS5TRzxLfFNYxn6PyEsphKWkdqx2mVfEuvJ9sPF43uq"],
         ["[2001:41d0:602:db1::]:31245", "N1gEdBVEbRFbBxBtrjcTDDK9JPbJFDay27uiJRE3vmbFAFDKNh7"],
-        ["[2001:41d0:602:21e4::]:31245", "N13Ykon8Zo73PTKMruLViMMtE2rEG646JQ4sCcee2DnopmVM3P5"]
+        ["[2001:41d0:602:21e4::]:31245", "N13Ykon8Zo73PTKMruLViMMtE2rEG646JQ4sCcee2DnopmVM3P5"],
     ]
-    # [optional] force the bootstrap protocol to use: "ipv4", "ipv6". Defaults to using both protocols.
-    bootstrap_protocol = "both"
+    # force the bootstrap protocol to use: "IPv4", "IPv6", or "Both". Defaults to using both protocols.
+    bootstrap_protocol = "Both"
     # path to the bootstrap whitelist file. This whitelist define IPs that can bootstrap on your node.
     bootstrap_whitelist_path = "base_config/bootstrap_whitelist.json"
     # path to the bootstrap blacklist file. This whitelist define IPs that will not be able to bootstrap on your node. This list is optional.

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -204,13 +204,19 @@
         ["198.27.74.5:31245", "P1qxuqNnx9kyAMYxUfsYiv2gQd5viiBX126SzzexEdbbWd2vQKu"],
         ["198.27.74.52:31245", "P1hdgsVsd4zkNp8cF1rdqqG6JPRQasAmx12QgJaJHBHFU1fRHEH"],
         ["54.36.174.177:31245", "P1gEdBVEbRFbBxBtrjcTDDK9JPbJFDay27uiJRE3vmbFAFDKNh7"],
-        ["51.75.60.228:31245", "P13Ykon8Zo73PTKMruLViMMtE2rEG646JQ4sCcee2DnopmVM3P5"]
+        ["51.75.60.228:31245", "P13Ykon8Zo73PTKMruLViMMtE2rEG646JQ4sCcee2DnopmVM3P5"],
+        ["[2001:41d0:1004:67::]:31245", "P12UbyLJDS7zimGWf3LTHe8hYY67RdLke1iDRZqJbQQLHQSKPW8j"],
+        ["[2001:41d0:a:7f7d::]:31245", "P12vxrYTQzS5TRzxLfFNYxn6PyEsphKWkdqx2mVfEuvJ9sPF43uq"],
+        ["[2001:41d0:602:db1::]:31245", "P1gEdBVEbRFbBxBtrjcTDDK9JPbJFDay27uiJRE3vmbFAFDKNh7"],
+        ["[2001:41d0:602:21e4::]:31245", "P13Ykon8Zo73PTKMruLViMMtE2rEG646JQ4sCcee2DnopmVM3P5"]
     ]
+    # [optional] force the bootstrap protocol to use: "ipv4", "ipv6". Defaults to using both protocols.
+    bootstrap_protocol = "both"
     # path to the bootstrap whitelist file. This whitelist define IPs that can bootstrap on your node.
     bootstrap_whitelist_path = "base_config/bootstrap_whitelist.json"
     # path to the bootstrap blacklist file. This whitelist define IPs that will not be able to bootstrap on your node. This list is optional.
     bootstrap_blacklist_path = "base_config/bootstrap_blacklist.json"
-    # [optionnal] port on which to listen for incoming bootstrap requests
+    # [optional] port on which to listen for incoming bootstrap requests
     bind = "[::]:31245"
     # timeout to establish a bootstrap connection
     connect_timeout = 15000

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -172,7 +172,7 @@ async fn launch(
 
     let bootstrap_config: BootstrapConfig = BootstrapConfig {
         bootstrap_list: SETTINGS.bootstrap.bootstrap_list.clone(),
-        bootstrap_protocol: SETTINGS.bootstrap.bootstrap_protocol.clone(),
+        bootstrap_protocol: SETTINGS.bootstrap.bootstrap_protocol,
         bootstrap_whitelist_path: SETTINGS.bootstrap.bootstrap_whitelist_path.clone(),
         bootstrap_blacklist_path: SETTINGS.bootstrap.bootstrap_blacklist_path.clone(),
         bind: SETTINGS.bootstrap.bind,

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -172,6 +172,7 @@ async fn launch(
 
     let bootstrap_config: BootstrapConfig = BootstrapConfig {
         bootstrap_list: SETTINGS.bootstrap.bootstrap_list.clone(),
+        bootstrap_protocol: SETTINGS.bootstrap.bootstrap_protocol.clone(),
         bootstrap_whitelist_path: SETTINGS.bootstrap.bootstrap_whitelist_path.clone(),
         bootstrap_blacklist_path: SETTINGS.bootstrap.bootstrap_blacklist_path.clone(),
         bind: SETTINGS.bootstrap.bind,

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -76,6 +76,7 @@ pub struct NetworkSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct BootstrapSettings {
     pub bootstrap_list: Vec<(SocketAddr, PublicKey)>,
+    pub bootstrap_protocol: Option<String>,
     pub bootstrap_whitelist_path: PathBuf,
     pub bootstrap_blacklist_path: PathBuf,
     pub bind: Option<SocketAddr>,

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -4,6 +4,7 @@
 use std::path::PathBuf;
 
 use enum_map::EnumMap;
+use massa_bootstrap::IpType;
 use massa_models::{config::build_massa_settings, node::NodeId};
 use massa_time::MassaTime;
 use serde::Deserialize;
@@ -75,7 +76,7 @@ pub struct NetworkSettings {
 #[derive(Debug, Deserialize, Clone)]
 pub struct BootstrapSettings {
     pub bootstrap_list: Vec<(SocketAddr, NodeId)>,
-    pub bootstrap_protocol: Option<String>,
+    pub bootstrap_protocol: IpType,
     pub bootstrap_whitelist_path: PathBuf,
     pub bootstrap_blacklist_path: PathBuf,
     pub bind: Option<SocketAddr>,

--- a/massa-node/src/tests/config.toml
+++ b/massa-node/src/tests/config.toml
@@ -70,8 +70,10 @@
         ["149.202.86.103:31245", "5GcSNukkKePWpNSjx9STyoEZniJAN4U4EUzdsQyqhuP3WYf6nj"],
         ["149.202.89.125:31245", "5wDwi2GYPniGLzpDfKjXJrmHV3p1rLRmm4bQ9TUWNVkpYmd4Zm"],
         ["158.69.120.215:31245", "5QbsTjSoKzYc8uBbwPCap392CoMQfZ2jviyq492LZPpijctb9c"],
-        ["158.69.23.120:31245", "8139kbee951YJdwK99odM7e6V3eW7XShCfX5E2ovG3b9qxqqrq"]
+        ["158.69.23.120:31245", "8139kbee951YJdwK99odM7e6V3eW7XShCfX5E2ovG3b9qxqqrq"],,
+        ["[dba7:c8ca:cfda:ffad:23ee:feb7:569e:a0bf]:31245", "6DbsTjSoKzYc8uBbwPCap392CoMQfZ2jviyq492LZPpijctb9c"]
     ]
+    bootstrap_protocol = "both"
     bind = "[::]:31245"
     connect_timeout = 15000
     retry_delay = 5000

--- a/massa-node/src/tests/config.toml
+++ b/massa-node/src/tests/config.toml
@@ -70,10 +70,10 @@
         ["149.202.86.103:31245", "5GcSNukkKePWpNSjx9STyoEZniJAN4U4EUzdsQyqhuP3WYf6nj"],
         ["149.202.89.125:31245", "5wDwi2GYPniGLzpDfKjXJrmHV3p1rLRmm4bQ9TUWNVkpYmd4Zm"],
         ["158.69.120.215:31245", "5QbsTjSoKzYc8uBbwPCap392CoMQfZ2jviyq492LZPpijctb9c"],
-        ["158.69.23.120:31245", "8139kbee951YJdwK99odM7e6V3eW7XShCfX5E2ovG3b9qxqqrq"],,
+        ["158.69.23.120:31245", "8139kbee951YJdwK99odM7e6V3eW7XShCfX5E2ovG3b9qxqqrq"],
         ["[dba7:c8ca:cfda:ffad:23ee:feb7:569e:a0bf]:31245", "6DbsTjSoKzYc8uBbwPCap392CoMQfZ2jviyq492LZPpijctb9c"]
     ]
-    bootstrap_protocol = "both"
+    bootstrap_protocol = "Both"
     bind = "[::]:31245"
     connect_timeout = 15000
     retry_delay = 5000


### PR DESCRIPTION
* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

From #2608:

* [x] Let our bootstrap servers expose both an IPv4 and IPv6 address
* [x] Then, we can put both addresses in the bootstrap ip list
* [x] Finally, filter the bootstrap ip list based on the available interfaces of the node