### PR TITLE
Fix deadlock in get_blocks

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -588,30 +588,33 @@ impl MassaRpcServer for API<Public> {
         let blocks = ids
             .into_iter()
             .filter_map(|id| {
-                if let Some(wrapped_block) = storage.read_blocks().get(&id).cloned() {
-                    if let Some(graph_status) = consensus_controller
-                        .get_block_statuses(&[id])
-                        .into_iter()
-                        .next()
-                    {
-                        let is_final = graph_status == BlockGraphStatus::Final;
-                        let is_in_blockclique =
-                            graph_status == BlockGraphStatus::ActiveInBlockclique;
-                        let is_candidate = graph_status == BlockGraphStatus::ActiveInBlockclique
-                            || graph_status == BlockGraphStatus::ActiveInAlternativeCliques;
-                        let is_discarded = graph_status == BlockGraphStatus::Discarded;
+                let content = if let Some(wrapped_block) = storage.read_blocks().get(&id) {
+                    wrapped_block.content.clone()
+                } else {
+                    return None;
+                };
 
-                        return Some(BlockInfo {
-                            id,
-                            content: Some(BlockInfoContent {
-                                is_final,
-                                is_in_blockclique,
-                                is_candidate,
-                                is_discarded,
-                                block: wrapped_block.content,
-                            }),
-                        });
-                    }
+                if let Some(graph_status) = consensus_controller
+                    .get_block_statuses(&[id])
+                    .into_iter()
+                    .next()
+                {
+                    let is_final = graph_status == BlockGraphStatus::Final;
+                    let is_in_blockclique = graph_status == BlockGraphStatus::ActiveInBlockclique;
+                    let is_candidate = graph_status == BlockGraphStatus::ActiveInBlockclique
+                        || graph_status == BlockGraphStatus::ActiveInAlternativeCliques;
+                    let is_discarded = graph_status == BlockGraphStatus::Discarded;
+
+                    return Some(BlockInfo {
+                        id,
+                        content: Some(BlockInfoContent {
+                            is_final,
+                            is_in_blockclique,
+                            is_candidate,
+                            is_discarded,
+                            block: content,
+                        }),
+                    });
                 }
 
                 None


### PR DESCRIPTION
This PR fix #3399 

A read reference in the storage was kept for too long because of : https://internals.rust-lang.org/t/lifetime-in-match-if-let-and-while-let/14304/6 which cause the `prune()` function of the consensus to never release his write lock to `shared_state` because was blocked on waiting the lock access to the block to delete. But this lock was never release because he lives until the end of the `if let` and in this we are calling `get_block_statuses` which requires a read lock to `shared_state` that he can achieve because of the write lock on the consensus thread.

Here is an schema to explain the text above : 
<img width="744" alt="Screenshot 2023-01-17 at 15 57 45" src="https://user-images.githubusercontent.com/32803821/212937302-ee6379c6-6032-4f47-ad4a-9d443c11cdf0.png">

I just made the `if` before the code that fetch in the `shared_state`.
I tested this on my node on the testnet the endpoint still work. Need to test on testnet0 to be sure it's fully fixed.