### PR TITLE
Provide alloc-free byte-slyce with DBPinnableSlice as Deref

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1128,16 +1128,17 @@ impl ExecutionState {
         address: &Address,
         key: &[u8],
     ) -> (Option<Vec<u8>>, Option<Vec<u8>>) {
-        let final_entry = self.final_state.read().ledger.get_data_entry(address, key);
+        let binding = self.final_state.read();
+        let final_entry = binding.ledger.get_data_entry(address, key);
         let search_result = self
             .active_history
             .read()
             .fetch_active_history_data_entry(address, key);
         (
-            final_entry.clone(),
+            final_entry.as_ref().map(|res| res.deref().to_vec()),
             match search_result {
                 HistorySearchResult::Present(active_entry) => Some(active_entry),
-                HistorySearchResult::NoInfo => final_entry,
+                HistorySearchResult::NoInfo => final_entry.map(|res| res.deref().to_vec()),
                 HistorySearchResult::Absent => None,
             },
         )

--- a/massa-execution-worker/src/speculative_ledger.rs
+++ b/massa-execution-worker/src/speculative_ledger.rs
@@ -120,7 +120,12 @@ impl SpeculativeLedger {
         self.added_changes.get_bytecode_or_else(addr, || {
             match self.active_history.read().fetch_bytecode(addr) {
                 HistorySearchResult::Present(bytecode) => Some(bytecode),
-                HistorySearchResult::NoInfo => self.final_state.read().ledger.get_bytecode(addr),
+                HistorySearchResult::NoInfo => self
+                    .final_state
+                    .read()
+                    .ledger
+                    .get_bytecode(addr)
+                    .map(|res| res.deref().to_vec()),
                 HistorySearchResult::Absent => None,
             }
         })
@@ -430,9 +435,12 @@ impl SpeculativeLedger {
                 .fetch_active_history_data_entry(addr, key)
             {
                 HistorySearchResult::Present(entry) => Some(entry),
-                HistorySearchResult::NoInfo => {
-                    self.final_state.read().ledger.get_data_entry(addr, key)
-                }
+                HistorySearchResult::NoInfo => self
+                    .final_state
+                    .read()
+                    .ledger
+                    .get_data_entry(addr, key)
+                    .map(|res| res.deref().to_vec()),
                 HistorySearchResult::Absent => None,
             }
         })

--- a/massa-ledger-exports/src/controller.rs
+++ b/massa-ledger-exports/src/controller.rs
@@ -2,8 +2,8 @@ use massa_hash::Hash;
 use massa_models::{
     address::Address, amount::Amount, error::ModelsError, slot::Slot, streaming_step::StreamingStep,
 };
-use std::collections::BTreeSet;
 use std::fmt::Debug;
+use std::{collections::BTreeSet, ops::Deref};
 
 use crate::{LedgerChanges, LedgerError};
 
@@ -24,7 +24,7 @@ pub trait LedgerController: Send + Sync + Debug {
     ///
     /// # Returns
     /// A copy of the found bytecode, or None if the ledger entry was not found
-    fn get_bytecode(&self, addr: &Address) -> Option<Vec<u8>>;
+    fn get_bytecode(&self, addr: &Address) -> Option<Box<dyn Deref<Target = [u8]> + '_>>;
 
     /// Checks if a ledger entry exists
     ///
@@ -40,7 +40,11 @@ pub trait LedgerController: Send + Sync + Debug {
     ///
     /// # Returns
     /// A copy of the datastore value, or `None` if the ledger entry or datastore entry was not found
-    fn get_data_entry(&self, addr: &Address, key: &[u8]) -> Option<Vec<u8>>;
+    fn get_data_entry(
+        &self,
+        addr: &Address,
+        key: &[u8],
+    ) -> Option<Box<dyn Deref<Target = [u8]> + '_>>;
 
     /// Get every key of the datastore for a given address.
     ///

--- a/massa-ledger-worker/src/ledger_db.rs
+++ b/massa-ledger-worker/src/ledger_db.rs
@@ -20,8 +20,8 @@ use massa_serialization::{Deserializer, Serializer, U64VarIntSerializer};
 use nom::multi::many0;
 use nom::sequence::tuple;
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, Direction, IteratorMode, Options, ReadOptions,
-    WriteBatch, DB,
+    ColumnFamily, ColumnFamilyDescriptor, DBPinnableSlice, Direction, IteratorMode, Options,
+    ReadOptions, WriteBatch, DB,
 };
 use std::ops::Bound;
 use std::path::PathBuf;
@@ -216,10 +216,14 @@ impl LedgerDB {
     ///
     /// # Returns
     /// An Option of the sub-entry value as bytes
-    pub fn get_sub_entry(&self, addr: &Address, ty: LedgerSubEntry) -> Option<Vec<u8>> {
+    pub(crate) fn get_sub_entry(
+        &self,
+        addr: &Address,
+        ty: LedgerSubEntry,
+    ) -> Option<DBPinnableSlice> {
         let handle = self.db.cf_handle(LEDGER_CF).expect(CF_ERROR);
         self.db
-            .get_cf(handle, ty.derive_key(addr))
+            .get_pinned_cf(handle, ty.derive_key(addr))
             .expect(CRUD_ERROR)
     }
 

--- a/massa-ledger-worker/src/test_exports/bootstrap.rs
+++ b/massa-ledger-worker/src/test_exports/bootstrap.rs
@@ -53,7 +53,13 @@ pub fn assert_eq_ledger(v1: &dyn LedgerController, v2: &dyn LedgerController) {
                 *addr,
                 LedgerEntry {
                     balance: *balance,
-                    bytecode: v1.get_bytecode(addr).unwrap_or_default(),
+                    bytecode: {
+                        let ref this = v1;
+                        let pinned = this
+                            .sorted_ledger
+                            .get_sub_entry(addr, LedgerSubEntry::Bytecode);
+                    }
+                    .unwrap_or_default(),
                     datastore: v1.get_entire_datastore(addr),
                 },
             )
@@ -67,7 +73,13 @@ pub fn assert_eq_ledger(v1: &dyn LedgerController, v2: &dyn LedgerController) {
                 *addr,
                 LedgerEntry {
                     balance: *balance,
-                    bytecode: v2.get_bytecode(addr).unwrap_or_default(),
+                    bytecode: {
+                        let ref this = v2;
+                        let pinned = this
+                            .sorted_ledger
+                            .get_sub_entry(addr, LedgerSubEntry::Bytecode);
+                    }
+                    .unwrap_or_default(),
                     datastore: v2.get_entire_datastore(addr),
                 },
             )


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

This adds more refactors to the upstream refactor branch. It assumes that passing up the deref trait object implicitly attaches the appropriate `Drop` impls as well (need to check that).

The intended advantages is to reduce the allocations needed.

Possible disadvantages include the increased use of dynamic dispatch.