### PR TITLE
Bind to IPv6 addr.

### DIFF
--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -3,7 +3,8 @@ history_file_path = "config/.massa_history"
 timeout = 1000
 
 [default_node]
-ip = "::1"
+# The IP of your node. Works both with IPv4 (like 127.0.0.1) and IPv6 (like ::1) addresses, if the node is bound to the correct protocol.
+ip = "127.0.0.1"
 private_port = 33034
 public_port = 33035
 

--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -3,7 +3,7 @@ history_file_path = "config/.massa_history"
 timeout = 1000
 
 [default_node]
-ip = "127.0.0.1"
+ip = "::1"
 private_port = 33034
 public_port = 33035
 

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -7,12 +7,12 @@
 [api]
     # max number of future periods considered during requests
     draw_lookahead_period_count = 10
-    # port on which the node API listens for admin and node management requests. Dangerous if publicly exposed
-    bind_private = "[::1]:33034"
-    # port on which the node API listens for public requests. Can be exposed to the Internet
-    bind_public = "[::]:33035"
-    # port on which the node API(V2) listens for HTTP requests and WebSockets subscriptions. Can be exposed to the Internet
-    bind_api = "[::]:33036"
+    # port on which the node API listens for admin and node management requests. Dangerous if publicly exposed. Bind to "[::1]:port" if you want to access the node from IPv6.
+    bind_private = "127.0.0.1:33034"
+    # port on which the node API listens for public requests. Can be exposed to the Internet. Bind to "[::]:port" if you want to access the node from IPv6.
+    bind_public = "0.0.0.0:33035"
+    # port on which the node API(V2) listens for HTTP requests and WebSockets subscriptions. Can be exposed to the Internet. Bind to "[::]:port" if you want to access the node from IPv6.
+    bind_api = "0.0.0.0:33036"
     # max number of arguments per RPC call
     max_arguments = 128
     # path to the openrpc specification file used in `rpc.discover` method

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -8,7 +8,7 @@
     # max number of future periods considered during requests
     draw_lookahead_period_count = 10
     # port on which the node API listens for admin and node management requests. Dangerous if publicly exposed
-    bind_private = "[::]:33034"
+    bind_private = "[::1]:33034"
     # port on which the node API listens for public requests. Can be exposed to the Internet
     bind_public = "[::]:33035"
     # port on which the node API(V2) listens for HTTP requests and WebSockets subscriptions. Can be exposed to the Internet

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -8,11 +8,11 @@
     # max number of future periods considered during requests
     draw_lookahead_period_count = 10
     # port on which the node API listens for admin and node management requests. Dangerous if publicly exposed
-    bind_private = "127.0.0.1:33034"
+    bind_private = "[::]:33034"
     # port on which the node API listens for public requests. Can be exposed to the Internet
-    bind_public = "0.0.0.0:33035"
+    bind_public = "[::]:33035"
     # port on which the node API(V2) listens for HTTP requests and WebSockets subscriptions. Can be exposed to the Internet
-    bind_api = "0.0.0.0:33036"
+    bind_api = "[::]:33036"
     # max number of arguments per RPC call
     max_arguments = 128
     # path to the openrpc specification file used in `rpc.discover` method


### PR DESCRIPTION
* [X] document all added functions
* [X] try in sandbox /simulation/labnet
* [X] unit tests on the added/changed features
  * [X] make tests compile
  * [X] make tests pass 
* [X] add logs allowing easy debugging in case the changes caused problems
* [X] if the API has changed, update the API specification

Only binding on IPv6 addresses (bind_private = "[::]:33034", bind_public = "[::]:33035" and bind_api = "[::]:33036") still works with IPv4 only interfaces.

Cf issue #2607 