### PR TITLE
Add lazy error handling in `get_block_slot_timestamp`

### DIFF
--- a/massa-models/src/timeslots.rs
+++ b/massa-models/src/timeslots.rs
@@ -39,17 +39,17 @@ pub fn get_block_slot_timestamp(
 ) -> Result<MassaTime, ModelsError> {
     let base: MassaTime = t0
         .checked_div_u64(thread_count as u64)
-        .or(Err(ModelsError::TimeOverflowError))?
+        .map_err(|_| ModelsError::TimeOverflowError)?
         .checked_mul(slot.thread as u64)
-        .or(Err(ModelsError::TimeOverflowError))?;
+        .map_err(|_| ModelsError::TimeOverflowError)?;
     let shift: MassaTime = t0
         .checked_mul(slot.period)
-        .or(Err(ModelsError::TimeOverflowError))?;
+        .map_err(|_| ModelsError::TimeOverflowError)?;
     genesis_timestamp
         .checked_add(base)
-        .or(Err(ModelsError::TimeOverflowError))?
+        .map_err(|_| ModelsError::TimeOverflowError)?
         .checked_add(shift)
-        .or(Err(ModelsError::TimeOverflowError))
+        .map_err(|_| ModelsError::TimeOverflowError)
 }
 
 /// Returns the thread and block period index of the latest block slot at a given timestamp (inclusive), if any happened


### PR DESCRIPTION
* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification