### PR TITLE
Fix bootstrap server deserialize error

### DIFF
--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -116,7 +116,7 @@ pub const DEFERRED_CREDITS_BOOTSTRAP_PART_SIZE: u64 = 100;
 /// Maximum executed ops per slot in a bootstrap batch
 pub const EXECUTED_OPS_BOOTSTRAP_PART_SIZE: u64 = 10;
 /// Maximum number of consensus blocks in a bootstrap batch
-pub const CONSENSUS_BOOTSTRAP_PART_SIZE: u64 = 50;
+pub const CONSENSUS_BOOTSTRAP_PART_SIZE: u64 = (THREAD_COUNT as u64) * 2;
 /// Maximum size of proof-of-stake rolls
 pub const MAX_ROLLS_COUNT_LENGTH: u64 = 10_000;
 /// Maximum size of proof-of-stake production stats


### PR DESCRIPTION
Fix #3572. 
The bootstrap part is retrieved using the `list_required_blocks` and so it retrieves the last two periods of the network which is 64 blocks and now the max is 50 which may cause #3572.

I'm not fully sure of this if you can confirm @Eitu33 