### PR TITLE
Fix max op not taken in account

### DIFF
--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -92,7 +92,7 @@ pub const ENDORSEMENT_COUNT: u32 = 16;
 /// Threshold for fitness.
 pub const DELTA_F0: u64 = 64 * (ENDORSEMENT_COUNT as u64 + 1);
 /// Maximum number of operations per block
-pub const MAX_OPERATIONS_PER_BLOCK: u32 = 5000;
+pub const MAX_OPERATIONS_PER_BLOCK: u32 = 10000;
 /// Maximum block size in bytes
 pub const MAX_BLOCK_SIZE: u32 = 1_000_000;
 /// Maximum capacity of the asynchronous messages pool

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -357,6 +357,7 @@ async fn launch(
         roll_price: ROLL_PRICE,
         max_block_endorsement_count: ENDORSEMENT_COUNT,
         operation_validity_periods: OPERATION_VALIDITY_PERIODS,
+        max_operations_per_block: MAX_OPERATIONS_PER_BLOCK,
         max_operation_pool_size_per_thread: SETTINGS.pool.max_pool_size_per_thread,
         max_endorsements_pool_size_per_thread: SETTINGS.pool.max_pool_size_per_thread,
         channels_size: POOL_CONTROLLER_CHANNEL_SIZE,

--- a/massa-pool-exports/src/config.rs
+++ b/massa-pool-exports/src/config.rs
@@ -16,6 +16,8 @@ pub struct PoolConfig {
     pub roll_price: Amount,
     /// operation validity periods
     pub operation_validity_periods: u64,
+    /// max operations per block
+    pub max_operations_per_block: u32,
     /// max operation pool size per thread (in number of operations)
     pub max_operation_pool_size_per_thread: usize,
     /// max endorsement pool size per thread (in number of endorsements)

--- a/massa-pool-exports/src/test_exports/config.rs
+++ b/massa-pool-exports/src/test_exports/config.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use massa_models::config::{
-    ENDORSEMENT_COUNT, MAX_BLOCK_SIZE, MAX_GAS_PER_BLOCK, OPERATION_VALIDITY_PERIODS, ROLL_PRICE,
-    THREAD_COUNT,
+    ENDORSEMENT_COUNT, MAX_BLOCK_SIZE, MAX_GAS_PER_BLOCK, MAX_OPERATIONS_PER_BLOCK,
+    OPERATION_VALIDITY_PERIODS, ROLL_PRICE, THREAD_COUNT,
 };
 
 use crate::PoolConfig;
@@ -17,6 +17,7 @@ impl Default for PoolConfig {
             max_block_size: MAX_BLOCK_SIZE,
             max_operation_pool_size_per_thread: 1000,
             max_endorsements_pool_size_per_thread: 1000,
+            max_operations_per_block: MAX_OPERATIONS_PER_BLOCK,
             max_block_endorsement_count: ENDORSEMENT_COUNT,
             channels_size: 1024,
             broadcast_enabled: false,

--- a/massa-pool-worker/src/operation_pool.rs
+++ b/massa-pool-worker/src/operation_pool.rs
@@ -194,6 +194,8 @@ impl OperationPool {
         let mut remaining_space = self.config.max_block_size as usize;
         // init remaining gas
         let mut remaining_gas = self.config.max_block_gas;
+        // init remaining number of operations
+        let mut remaining_ops = self.config.max_operations_per_block;
         // cache of balances
         let mut balance_cache: PreHashMap<Address, Amount> = Default::default();
 
@@ -217,6 +219,11 @@ impl OperationPool {
             // exclude ops that require too much gas
             if op_info.max_gas > remaining_gas {
                 continue;
+            }
+
+            // if we have reached the maximum number of operations, stop
+            if remaining_ops == 0 {
+                break;
             }
 
             // check if the op was already executed
@@ -261,6 +268,9 @@ impl OperationPool {
 
             // update remaining block gas
             remaining_gas -= op_info.max_gas;
+
+            // update remaining number of operations
+            remaining_ops -= 1;
 
             // update balance cache
             *creator_balance = creator_balance.saturating_sub(op_info.max_spending);

--- a/massa-pool-worker/src/operation_pool.rs
+++ b/massa-pool-worker/src/operation_pool.rs
@@ -201,6 +201,10 @@ impl OperationPool {
 
         // iterate over pool operations in the right thread, from best to worst
         for cursor in self.sorted_ops_per_thread[slot.thread as usize].iter() {
+            // if we have reached the maximum number of operations, stop
+            if remaining_ops == 0 {
+                break;
+            }
             let op_info = self
                 .operations
                 .get(&cursor.get_id())
@@ -219,11 +223,6 @@ impl OperationPool {
             // exclude ops that require too much gas
             if op_info.max_gas > remaining_gas {
                 continue;
-            }
-
-            // if we have reached the maximum number of operations, stop
-            if remaining_ops == 0 {
-                break;
             }
 
             // check if the op was already executed


### PR DESCRIPTION
Currently someone can create a block with more than 5000 operations (it happens when the last blocks are not produced on the same thread) as there is no limit on the number of ops but on maximum size of a block (in bytes) or maximum gas.

But in the workflow, of block propagation when we receive a list of operation from a block we assume we can have only 5k operations (to avoid deserializing a too big message and OOM). So the block producers of these blocks were disconnected from their peers and their blocks not propagated.