### PR TITLE
Ipv4 only network - listen on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2417,6 +2417,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test 1.0.0",
+ "socket2",
  "substruct",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "nom",
  "serde",
  "serde_json",
+ "socket2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -24,6 +24,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 tokio = { version = "1.23", features = ["full"] }
 tracing = "0.1"
 substruct = { git = "https://github.com/sydhds/substruct" }
+socket2 = "0.4.7"
 
 # custom modules
 massa_async_pool = { path = "../massa-async-pool" }

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -11,6 +11,8 @@ pub mod types {
     pub type Establisher = crate::tests::mock_establisher::MockEstablisher;
 }
 
+
+
 #[cfg(not(test))]
 /// Connection types
 pub mod types {
@@ -20,6 +22,7 @@ pub mod types {
         net::{TcpListener, TcpStream},
         time::timeout,
     };
+    use socket2::Socket;
     /// duplex connection
     pub type Duplex = TcpStream;
     /// listener
@@ -77,7 +80,26 @@ pub mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
-            Ok(DefaultListener(TcpListener::bind(addr).await?))
+
+            use socket2::{Socket, Domain, Type};
+        
+            // Create a TCP listener bound to two addresses.
+            let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+    
+            socket.set_only_v6(false)?;
+    
+            socket.bind(&addr.into())?;
+            socket.set_nonblocking(true)?;
+    
+            socket.listen(128)?;
+            
+            let std_listener: std::net::TcpListener = socket.into();
+            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
+    
+
+            Ok(DefaultListener(tokio_listener))
+
+            //Ok(DefaultListener(TcpListener::bind(addr).await?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -81,17 +81,13 @@ pub mod types {
             let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
 
             socket.set_only_v6(false)?;
-
-            socket.bind(&addr.into())?;
             socket.set_nonblocking(true)?;
+            socket.bind(&addr.into())?;
 
             // Number of connections to queue, set to the hardcoded value used by tokio
             socket.listen(1024)?;
 
-            let std_listener: std::net::TcpListener = socket.into();
-            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
-
-            Ok(DefaultListener(tokio_listener))
+            Ok(DefaultListener(TcpListener::from_std(socket.into())?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -11,8 +11,6 @@ pub mod types {
     pub type Establisher = crate::tests::mock_establisher::MockEstablisher;
 }
 
-
-
 #[cfg(not(test))]
 /// Connection types
 pub mod types {
@@ -22,7 +20,6 @@ pub mod types {
         net::{TcpListener, TcpStream},
         time::timeout,
     };
-    use socket2::Socket;
     /// duplex connection
     pub type Duplex = TcpStream;
     /// listener
@@ -80,22 +77,20 @@ pub mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
+            use socket2::{Domain, Socket, Type};
 
-            use socket2::{Socket, Domain, Type};
-        
             // Create a TCP listener bound to two addresses.
             let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
-    
+
             socket.set_only_v6(false)?;
-    
+
             socket.bind(&addr.into())?;
             socket.set_nonblocking(true)?;
-    
+
             socket.listen(128)?;
-            
+
             let std_listener: std::net::TcpListener = socket.into();
             let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
-    
 
             Ok(DefaultListener(tokio_listener))
 

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -77,24 +77,21 @@ pub mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
-            use socket2::{Domain, Socket, Type};
-
-            // Create a TCP listener bound to two addresses.
-            let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+            // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
+            let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
 
             socket.set_only_v6(false)?;
 
             socket.bind(&addr.into())?;
             socket.set_nonblocking(true)?;
 
-            socket.listen(128)?;
+            // Number of connections to queue, set to the hardcoded value used by tokio
+            socket.listen(1024)?;
 
             let std_listener: std::net::TcpListener = socket.into();
             let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
 
             Ok(DefaultListener(tokio_listener))
-
-            //Ok(DefaultListener(TcpListener::bind(addr).await?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -7,6 +7,7 @@ use std::net::SocketAddr;
 use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
+use socket2 as _;
 
 pub type Duplex = DuplexStream;
 

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -2,12 +2,12 @@
 
 use massa_models::config::{CHANNEL_SIZE, MAX_DUPLEX_BUFFER_SIZE};
 use massa_time::MassaTime;
+use socket2 as _;
 use std::io;
 use std::net::SocketAddr;
 use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
-use socket2 as _;
 
 pub type Duplex = DuplexStream;
 

--- a/massa-network-exports/Cargo.toml
+++ b/massa-network-exports/Cargo.toml
@@ -12,6 +12,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.23", features = ["full"] }
 enum-map = { version = "2.4", features = ["serde"] }
+socket2 = "0.4.7"
 # custom modules
 massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }

--- a/massa-network-exports/src/establisher.rs
+++ b/massa-network-exports/src/establisher.rs
@@ -87,17 +87,13 @@ mod types {
             let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
 
             socket.set_only_v6(false)?;
-
-            socket.bind(&addr.into())?;
             socket.set_nonblocking(true)?;
+            socket.bind(&addr.into())?;
 
             // Number of connections to queue, set to the hardcoded value used by tokio
             socket.listen(1024)?;
 
-            let std_listener: std::net::TcpListener = socket.into();
-            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
-
-            Ok(DefaultListener(tokio_listener))
+            Ok(DefaultListener(TcpListener::from_std(socket.into())?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-network-exports/src/establisher.rs
+++ b/massa-network-exports/src/establisher.rs
@@ -83,19 +83,18 @@ mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
+            use socket2::{Domain, Socket, Type};
 
-            use socket2::{Socket, Domain, Type};
-        
             // Create a TCP listener bound to two addresses.
             let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
-    
+
             socket.set_only_v6(false)?;
-    
+
             socket.bind(&addr.into())?;
             socket.set_nonblocking(true)?;
-    
+
             socket.listen(128)?;
-            
+
             let std_listener: std::net::TcpListener = socket.into();
             let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
 

--- a/massa-network-exports/src/establisher.rs
+++ b/massa-network-exports/src/establisher.rs
@@ -83,7 +83,25 @@ mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
-            Ok(DefaultListener(TcpListener::bind(addr).await?))
+
+            use socket2::{Socket, Domain, Type};
+        
+            // Create a TCP listener bound to two addresses.
+            let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+    
+            socket.set_only_v6(false)?;
+    
+            socket.bind(&addr.into())?;
+            socket.set_nonblocking(true)?;
+    
+            socket.listen(128)?;
+            
+            let std_listener: std::net::TcpListener = socket.into();
+            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)?;
+
+            Ok(DefaultListener(tokio_listener))
+
+            //Ok(DefaultListener(TcpListener::bind(addr).await?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-network-exports/src/test_exports/mock_establisher.rs
+++ b/massa-network-exports/src/test_exports/mock_establisher.rs
@@ -1,12 +1,12 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use massa_time::MassaTime;
+use socket2 as _;
 use std::io;
 use std::net::SocketAddr;
 use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
-use socket2 as _;
 
 const MAX_DUPLEX_BUFFER_SIZE: usize = 1024;
 

--- a/massa-network-exports/src/test_exports/mock_establisher.rs
+++ b/massa-network-exports/src/test_exports/mock_establisher.rs
@@ -6,6 +6,7 @@ use std::net::SocketAddr;
 use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
+use socket2 as _;
 
 const MAX_DUPLEX_BUFFER_SIZE: usize = 1024;
 


### PR DESCRIPTION
* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

I was able to test that on a IPv4 only-network on windows, nodes could not bootstrap on my node before.
This PR fixes the default behaviour of windows ([::] only matches to IPv6 addresses, not IPv4, so it failed)
