### PR TITLE
Fix tests pool failing

### DIFF
--- a/massa-execution-exports/src/controller_traits.rs
+++ b/massa-execution-exports/src/controller_traits.rs
@@ -53,12 +53,12 @@ pub trait ExecutionController: Send + Sync {
 
     /// Get the execution status of operation that have been executed both speculatively or finaly
     ///
-    /// # Return value
-    /// * `(speculative_statuses, final_statuses)`
-    /// * for each hashmap:
-    /// *     key: the operation id
-    /// *     value: true: operation executed successfully,
-    /// *            false: operation failed
+    ///  Return value
+    ///  `(speculative_statuses, final_statuses)`
+    ///  for each hashmap:
+    ///      key: the operation id
+    ///      value: true: operation executed successfully,
+    ///             false: operation failed
     fn get_op_exec_status(&self) -> (HashMap<OperationId, bool>, HashMap<OperationId, bool>);
 
     /// Get a copy of a single datastore entry with its final and active values

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -504,11 +504,13 @@ mod tests {
     #[test]
     #[serial]
     fn test_operation_execution_status() {
+        let vesting = get_initials_vesting(false);
         // setup the period duration and the maximum gas for asynchronous messages execution
         let exec_cfg = ExecutionConfig {
             t0: 100.into(),
             max_async_gas: 100_000,
             cursor_delay: 0.into(),
+            initial_vesting_path: vesting.path().to_path_buf(),
             ..ExecutionConfig::default()
         };
         // get a sample final state

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -31,6 +31,7 @@ fn test_add_operation() {
         let op_gen = OpGenerator::default().expirery(2);
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.add_operations(storage);
+        std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 10);
     });
 }
@@ -46,6 +47,7 @@ fn test_add_irrelevant_operation() {
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.notify_final_cs_periods(&vec![51; thread_count.into()]);
         operation_pool.add_operations(storage);
+        std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 0);
     });
 }
@@ -70,6 +72,7 @@ fn test_pool() {
                 let mut storage = storage_base.clone_without_refs();
                 storage.store_operations(vec![op.clone()]);
                 pool.add_operations(storage);
+                std::thread::sleep(Duration::from_millis(100));
 
                 //TODO: compare
                 // assert_eq!(storage.get_op_refs(), &Set::<OperationId>::default());
@@ -191,12 +194,16 @@ fn test_pool() {
                 let mut storage = storage_base.clone_without_refs();
                 storage.store_operations(vec![op.clone()]);
                 pool.add_operations(storage);
+                std::thread::sleep(Duration::from_millis(100));
                 //TODO: compare
                 //assert_eq!(storage.get_op_refs(), &Set::<OperationId>::default());
                 let op_thread = op
                     .content_creator_address
                     .get_thread(pool_config.thread_count);
-                let (ids, _) = pool.get_block_operations(&Slot::new(expire_period - 1, op_thread));
+                let (ids, _) = pool.get_block_operations(&Slot::new(
+                    expire_period - pool_config.operation_validity_periods - 1,
+                    op_thread,
+                ));
                 assert!(ids.is_empty());
             }
             pool_manager.stop();

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -31,7 +31,7 @@ fn test_add_operation() {
         let op_gen = OpGenerator::default().expirery(2);
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.add_operations(storage);
-        // Wait for pool to add the operations
+        // Allow some time for the pool to add the operations
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 10);
     });
@@ -48,7 +48,7 @@ fn test_add_irrelevant_operation() {
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.notify_final_cs_periods(&vec![51; thread_count.into()]);
         operation_pool.add_operations(storage);
-        // Wait for pool to add the operations
+        // Allow some time for the pool to add the operations
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 0);
     });
@@ -95,7 +95,7 @@ fn test_pool() {
             }
 
             pool.add_operations(storage);
-            // Wait for pool to add the operations
+            // Allow some time for the pool to add the operations
             std::thread::sleep(Duration::from_millis(200));
 
             // sort from bigger fee to smaller and truncate
@@ -205,7 +205,7 @@ fn test_pool() {
                 let mut storage = storage_base.clone_without_refs();
                 storage.store_operations(vec![op.clone()]);
                 pool.add_operations(storage);
-                // Wait for pool to add the operations
+                // Allow some time for the pool to add the operations
                 std::thread::sleep(Duration::from_millis(100));
                 //TODO: compare
                 //assert_eq!(storage.get_op_refs(), &Set::<OperationId>::default());

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -21,7 +21,7 @@ use crate::tests::tools::OpGenerator;
 
 use super::tools::{create_some_operations, operation_pool_test, pool_test};
 use massa_execution_exports::test_exports::MockExecutionControllerMessage;
-use massa_models::{amount::Amount, slot::Slot, operation::OperationId};
+use massa_models::{amount::Amount, operation::OperationId, slot::Slot};
 use massa_pool_exports::PoolConfig;
 use std::time::Duration;
 
@@ -134,20 +134,24 @@ fn test_pool() {
                     let target_slot = Slot::new(period, thread);
                     let (ids, storage) = pool.get_block_operations(&target_slot);
 
-                    assert_eq!(ids
-                        .iter()
-                        .map(|id| (
-                            *id,
-                            storage
-                                .read_operations()
-                                .get(id)
-                                .unwrap()
-                                .serialized_data
-                                .clone()
-                        )).collect::<Vec<(OperationId, Vec<u8>)>>(), thread_tx_lists[target_slot.thread as usize]
+                    assert_eq!(
+                        ids.iter()
+                            .map(|id| (
+                                *id,
+                                storage
+                                    .read_operations()
+                                    .get(id)
+                                    .unwrap()
+                                    .serialized_data
+                                    .clone()
+                            ))
+                            .collect::<Vec<(OperationId, Vec<u8>)>>(),
+                        thread_tx_lists[target_slot.thread as usize]
                             .iter()
                             .filter(|(_, r)| r.contains(&target_slot.period))
-                            .map(|(op, _)| (op.id, op.serialized_data.clone())).collect::<Vec<(OperationId, Vec<u8>)>>());
+                            .map(|(op, _)| (op.id, op.serialized_data.clone()))
+                            .collect::<Vec<(OperationId, Vec<u8>)>>()
+                    );
                 }
             }
 
@@ -167,22 +171,25 @@ fn test_pool() {
                     let target_slot = Slot::new(period, thread);
                     let max_count = 4;
                     let (ids, storage) = pool.get_block_operations(&target_slot);
-                    assert_eq!(ids
-                        .iter()
-                        .map(|id| (
-                            *id,
-                            storage
-                                .read_operations()
-                                .get(id)
-                                .unwrap()
-                                .serialized_data
-                                .clone()
-                        )).collect::<Vec<(OperationId, Vec<u8>)>>(), 
+                    assert_eq!(
+                        ids.iter()
+                            .map(|id| (
+                                *id,
+                                storage
+                                    .read_operations()
+                                    .get(id)
+                                    .unwrap()
+                                    .serialized_data
+                                    .clone()
+                            ))
+                            .collect::<Vec<(OperationId, Vec<u8>)>>(),
                         thread_tx_lists[target_slot.thread as usize]
                             .iter()
                             .filter(|(_, r)| r.contains(&target_slot.period))
                             .take(max_count)
-                            .map(|(op, _)| (op.id, op.serialized_data.clone())).collect::<Vec<(OperationId, Vec<u8>)>>());
+                            .map(|(op, _)| (op.id, op.serialized_data.clone()))
+                            .collect::<Vec<(OperationId, Vec<u8>)>>()
+                    );
                 }
             }
 

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -21,7 +21,7 @@ use crate::tests::tools::OpGenerator;
 
 use super::tools::{create_some_operations, operation_pool_test, pool_test};
 use massa_execution_exports::test_exports::MockExecutionControllerMessage;
-use massa_models::{amount::Amount, slot::Slot};
+use massa_models::{amount::Amount, slot::Slot, operation::OperationId};
 use massa_pool_exports::PoolConfig;
 use std::time::Duration;
 
@@ -31,6 +31,7 @@ fn test_add_operation() {
         let op_gen = OpGenerator::default().expirery(2);
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.add_operations(storage);
+        // Wait for pool to add the operations
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 10);
     });
@@ -47,6 +48,7 @@ fn test_add_irrelevant_operation() {
         storage.store_operations(create_some_operations(10, &op_gen));
         operation_pool.notify_final_cs_periods(&vec![51; thread_count.into()]);
         operation_pool.add_operations(storage);
+        // Wait for pool to add the operations
         std::thread::sleep(Duration::from_millis(100));
         assert_eq!(operation_pool.storage.get_op_refs().len(), 0);
     });
@@ -62,17 +64,15 @@ fn test_pool() {
             // generate (id, transactions, range of validity) by threads
             let mut thread_tx_lists = vec![Vec::new(); pool_config.thread_count as usize];
 
+            let mut storage = storage_base.clone_without_refs();
             for i in 0..18 {
-                let expire_period: u64 = 40 + i;
+                let expire_period: u64 = 10 + i;
                 let op = OpGenerator::default()
                     .expirery(expire_period)
                     .fee(Amount::from_raw(40 + i))
                     .generate(); //get_transaction(expire_period, fee);
 
-                let mut storage = storage_base.clone_without_refs();
                 storage.store_operations(vec![op.clone()]);
-                pool.add_operations(storage);
-                std::thread::sleep(Duration::from_millis(100));
 
                 //TODO: compare
                 // assert_eq!(storage.get_op_refs(), &Set::<OperationId>::default());
@@ -93,8 +93,19 @@ fn test_pool() {
 
                 thread_tx_lists[op_thread as usize].push((op, start_period..=expire_period));
             }
+
+            pool.add_operations(storage);
+            // Wait for pool to add the operations
+            std::thread::sleep(Duration::from_millis(200));
+
+            // sort from bigger fee to smaller and truncate
+            for lst in thread_tx_lists.iter_mut() {
+                lst.reverse();
+                lst.truncate(pool_config.max_operation_pool_size_per_thread);
+            }
+
             std::thread::spawn(move || loop {
-                match execution_receiver.recv_timeout(Duration::from_millis(100)) {
+                match execution_receiver.recv_timeout(Duration::from_millis(2000)) {
                     // forward on the operations
                     Ok(MockExecutionControllerMessage::UnexecutedOpsAmong {
                         ops,
@@ -117,20 +128,13 @@ fn test_pool() {
                 }
             });
 
-            // sort from bigger fee to smaller and truncate
-            for lst in thread_tx_lists.iter_mut() {
-                lst.reverse();
-                lst.truncate(pool_config.max_operation_pool_size_per_thread);
-            }
-
             // checks ops are the expected ones for thread 0 and 1 and various periods
             for thread in 0u8..pool_config.thread_count {
                 for period in 0u64..70 {
                     let target_slot = Slot::new(period, thread);
-                    let max_count = 3;
                     let (ids, storage) = pool.get_block_operations(&target_slot);
 
-                    assert!(ids
+                    assert_eq!(ids
                         .iter()
                         .map(|id| (
                             *id,
@@ -140,12 +144,10 @@ fn test_pool() {
                                 .unwrap()
                                 .serialized_data
                                 .clone()
-                        ))
-                        .eq(thread_tx_lists[target_slot.thread as usize]
+                        )).collect::<Vec<(OperationId, Vec<u8>)>>(), thread_tx_lists[target_slot.thread as usize]
                             .iter()
                             .filter(|(_, r)| r.contains(&target_slot.period))
-                            .take(max_count)
-                            .map(|(op, _)| (op.id, op.serialized_data.clone()))));
+                            .map(|(op, _)| (op.id, op.serialized_data.clone())).collect::<Vec<(OperationId, Vec<u8>)>>());
                 }
             }
 
@@ -153,6 +155,8 @@ fn test_pool() {
             // we don't keep them as expected ops
             let final_period = 45u64;
             pool.notify_final_cs_periods(&vec![final_period; pool_config.thread_count as usize]);
+            // Wait for pool to manage the above command
+            std::thread::sleep(Duration::from_millis(200));
             for lst in thread_tx_lists.iter_mut() {
                 lst.retain(|(op, _)| op.content.expire_period > final_period);
             }
@@ -163,7 +167,7 @@ fn test_pool() {
                     let target_slot = Slot::new(period, thread);
                     let max_count = 4;
                     let (ids, storage) = pool.get_block_operations(&target_slot);
-                    assert!(ids
+                    assert_eq!(ids
                         .iter()
                         .map(|id| (
                             *id,
@@ -173,12 +177,12 @@ fn test_pool() {
                                 .unwrap()
                                 .serialized_data
                                 .clone()
-                        ))
-                        .eq(thread_tx_lists[target_slot.thread as usize]
+                        )).collect::<Vec<(OperationId, Vec<u8>)>>(), 
+                        thread_tx_lists[target_slot.thread as usize]
                             .iter()
                             .filter(|(_, r)| r.contains(&target_slot.period))
                             .take(max_count)
-                            .map(|(op, _)| (op.id, op.serialized_data.clone()))));
+                            .map(|(op, _)| (op.id, op.serialized_data.clone())).collect::<Vec<(OperationId, Vec<u8>)>>());
                 }
             }
 
@@ -194,6 +198,7 @@ fn test_pool() {
                 let mut storage = storage_base.clone_without_refs();
                 storage.store_operations(vec![op.clone()]);
                 pool.add_operations(storage);
+                // Wait for pool to add the operations
                 std::thread::sleep(Duration::from_millis(100));
                 //TODO: compare
                 //assert_eq!(storage.get_op_refs(), &Set::<OperationId>::default());

--- a/massa-pool-worker/src/tests/scenario.rs
+++ b/massa-pool-worker/src/tests/scenario.rs
@@ -61,6 +61,7 @@ fn test_simple_get_operations() {
             storage.store_operations(create_some_operations(10, &op_gen));
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
+            // Wait for pool to add the operations
             std::thread::sleep(Duration::from_millis(100));
 
             // Start mock execution thread.
@@ -167,6 +168,7 @@ fn test_get_operations_overflow() {
             storage.store_operations(operations);
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
+            // Wait for pool to add the operations
             std::thread::sleep(Duration::from_millis(100));
 
             // start mock execution thread

--- a/massa-pool-worker/src/tests/scenario.rs
+++ b/massa-pool-worker/src/tests/scenario.rs
@@ -61,7 +61,7 @@ fn test_simple_get_operations() {
             storage.store_operations(create_some_operations(10, &op_gen));
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
-            // Wait for pool to add the operations
+            // Allow some time for the pool to add the operations
             std::thread::sleep(Duration::from_millis(100));
 
             // Start mock execution thread.
@@ -168,7 +168,7 @@ fn test_get_operations_overflow() {
             storage.store_operations(operations);
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
-            // Wait for pool to add the operations
+            // Allow some time for the pool to add the operations
             std::thread::sleep(Duration::from_millis(100));
 
             // start mock execution thread

--- a/massa-pool-worker/src/tests/scenario.rs
+++ b/massa-pool-worker/src/tests/scenario.rs
@@ -61,6 +61,7 @@ fn test_simple_get_operations() {
             storage.store_operations(create_some_operations(10, &op_gen));
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
+            std::thread::sleep(Duration::from_millis(100));
 
             // Start mock execution thread.
             // Provides the data for `pool_controller.get_block_operations`
@@ -92,7 +93,7 @@ pub fn launch_basic_get_block_operation_execution_mock(
     creator_address: Address,
     balance_vec: Vec<(Option<Amount>, Option<Amount>)>,
 ) {
-    let receive = |er: &Receiver<ControllerMsg>| er.recv_timeout(Duration::from_millis(10));
+    let receive = |er: &Receiver<ControllerMsg>| er.recv_timeout(Duration::from_millis(100));
     std::thread::spawn(move || {
         match receive(&recvr) {
             Ok(ControllerMsg::UnexecutedOpsAmong { response_tx, .. }) => {
@@ -166,6 +167,7 @@ fn test_get_operations_overflow() {
             storage.store_operations(operations);
             let unexecuted_ops = storage.get_op_refs().clone();
             pool_controller.add_operations(storage);
+            std::thread::sleep(Duration::from_millis(100));
 
             // start mock execution thread
             launch_basic_get_block_operation_execution_mock(

--- a/massa-serialization/src/lib.rs
+++ b/massa-serialization/src/lib.rs
@@ -373,8 +373,8 @@ impl Deserializer<bool> for BoolDeserializer {
         context("Failed bool deserialization", |input: &'a [u8]| {
             Ok((&buffer[1..], {
                 match buffer.first() {
-                    Some(&b'1') => Ok(true),
-                    Some(&b'0') => Ok(false),
+                    Some(1) => Ok(true),
+                    Some(0) => Ok(false),
                     _ => Err(nom::Err::Error(ParseError::from_error_kind(
                         input,
                         nom::error::ErrorKind::Fail,


### PR DESCRIPTION
* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

The tests were failing because `add_operations` is managed in an other thread and so the tests don't wait that the ops are inserted before trying to fetch them. So sometimes it was fast enough sometimes not. With the new sleep it's always fast enough.

The `test_pool` failed after this change because it was wrong by design. Fixed it.

Fix #3509 and #3584