### PR TITLE
Benph/bs mock tcpstream as duplex

### DIFF
--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -377,10 +377,8 @@ async fn connect_to_server(
     pub_key: &PublicKey,
 ) -> Result<BootstrapClientBinder, BootstrapError> {
     // connect
-    let mut connector = establisher
-        .get_connector(bootstrap_config.connect_timeout)
-        .await?; // cancellable
-    let socket = connector.connect(*addr).await?; // cancellable
+    let mut connector = establisher.get_connector(bootstrap_config.connect_timeout)?;
+    let socket = connector.connect(*addr).await?;
     Ok(BootstrapClientBinder::new(
         socket,
         *pub_key,

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -76,7 +76,7 @@ pub mod types {
         ///
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
-        pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
+        pub fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
             // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
             let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
 

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -22,9 +22,9 @@ pub mod types {
     };
     /// duplex connection
     pub type Duplex = TcpStream;
-    /// listener
+    /// listener, used by server
     pub type Listener = DefaultListener;
-    /// connector
+    /// connector, used by client
     pub type Connector = DefaultConnector;
     /// connection establisher
     pub type Establisher = DefaultEstablisher;

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -94,7 +94,7 @@ pub mod types {
         ///
         /// # Argument
         /// * `timeout_duration`: timeout duration in milliseconds
-        pub async fn get_connector(
+        pub fn get_connector(
             &mut self,
             timeout_duration: MassaTime,
         ) -> io::Result<DefaultConnector> {

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -131,7 +131,6 @@ pub async fn start_bootstrap_server(
 
     let listener = establisher
         .get_listener(listen_addr)
-        .await
         .map_err(BootstrapError::IoError)?;
 
     // This is the primary interface between the async-listener, and the "sync" worker

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -21,7 +21,6 @@ use massa_signature::{KeyPair, PublicKey};
 use massa_time::MassaTime;
 use serial_test::serial;
 use std::str::FromStr;
-use tokio::io::duplex;
 
 lazy_static::lazy_static! {
     pub static ref BOOTSTRAP_CONFIG_KEYPAIR: (BootstrapConfig, KeyPair) = {
@@ -66,9 +65,13 @@ impl BootstrapClientBinder {
 #[serial]
 async fn test_binders() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let server = server.accept().await.unwrap();
+    // let (client, server) = duplex(1000000);
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,
@@ -165,10 +168,14 @@ async fn test_binders() {
 async fn test_binders_double_send_server_works() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
 
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let client = tokio::net::TcpStream::connect(server.local_addr().unwrap())
+        .await
+        .unwrap();
+    let server = server.accept().await.unwrap();
 
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,
@@ -250,9 +257,12 @@ async fn test_binders_double_send_server_works() {
 async fn test_binders_try_double_send_client_works() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
 
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let server = server.accept().await.unwrap();
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -115,10 +115,7 @@ impl MockEstablisher {
         })
     }
 
-    pub async fn get_connector(
-        &mut self,
-        timeout_duration: MassaTime,
-    ) -> std::io::Result<MockConnector> {
+    pub fn get_connector(&mut self, timeout_duration: MassaTime) -> std::io::Result<MockConnector> {
         // create connector stream
 
         Ok(MockConnector {

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -1,15 +1,14 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use massa_models::config::{CHANNEL_SIZE, MAX_DUPLEX_BUFFER_SIZE};
+use massa_models::config::CHANNEL_SIZE;
 use massa_time::MassaTime;
 use socket2 as _;
 use std::io;
 use std::net::SocketAddr;
-use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 
-pub type Duplex = DuplexStream;
+pub type Duplex = tokio::net::TcpStream;
 
 pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
     let (connection_listener_tx, connection_listener_rx) =
@@ -32,18 +31,24 @@ pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
 
 #[derive(Debug)]
 pub struct MockListener {
-    connection_listener_rx: crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<Duplex>)>, // (controller, mock)
+    connection_listener_rx:
+        crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<tokio::net::TcpStream>)>, // (controller, mock)
 }
 
 impl MockListener {
-    pub async fn accept(&mut self) -> std::io::Result<(Duplex, SocketAddr)> {
-        let (addr, sender) = self.connection_listener_rx.recv().map_err(|_| {
+    pub async fn accept(&mut self) -> std::io::Result<(tokio::net::TcpStream, SocketAddr)> {
+        let (_addr, sender) = self.connection_listener_rx.recv().map_err(|_| {
             io::Error::new(
                 io::ErrorKind::Other,
                 "MockListener accept channel from Establisher closed".to_string(),
             )
         })?;
-        let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
+        let duplex_controller = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+        let duplex_mock = tokio::net::TcpStream::connect(duplex_controller.local_addr().unwrap())
+            .await
+            .unwrap();
+        let duplex_controller = duplex_controller.accept().await.unwrap();
+
         sender.send(duplex_mock).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -51,27 +56,32 @@ impl MockListener {
             )
         })?;
 
-        Ok((duplex_controller, addr))
+        Ok(duplex_controller)
     }
 }
 
 #[derive(Debug)]
 pub struct MockConnector {
-    connection_connector_tx: mpsc::Sender<(Duplex, SocketAddr, oneshot::Sender<bool>)>,
+    connection_connector_tx:
+        mpsc::Sender<(tokio::net::TcpStream, SocketAddr, oneshot::Sender<bool>)>,
     timeout_duration: MassaTime,
 }
 
 impl MockConnector {
-    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<Duplex> {
-        // task the controller connection if exist.
-        let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
+    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<tokio::net::TcpStream> {
+        let duplex_mock = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let duplex_controller = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let duplex_mock = duplex_mock.accept().await.unwrap();
+
+        // // task the controller connection if exist.
+        // let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
         // to see if the connection is accepted
         let (accept_tx, accept_rx) = oneshot::channel::<bool>();
 
         // send new connection to mock
         timeout(self.timeout_duration.to_duration(), async move {
             self.connection_connector_tx
-                .send((duplex_mock, addr, accept_tx))
+                .send((duplex_mock.0, addr, accept_tx))
                 .await
                 .map_err(|_err| {
                     io::Error::new(

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -64,7 +64,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::{sync::mpsc::Receiver, time::sleep};
 
-pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(169, 202, 0, 10));
+pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0));
 
 /// generates a small random number of bytes
 fn get_some_random_bytes() -> Vec<u8> {
@@ -301,7 +301,10 @@ pub fn get_bootstrap_config(bootstrap_public_key: NodeId) -> BootstrapConfig {
         write_timeout: 1000.into(),
         read_error_timeout: 200.into(),
         write_error_timeout: 200.into(),
-        bootstrap_list: vec![(SocketAddr::new(BASE_BOOTSTRAP_IP, 16), bootstrap_public_key)],
+        bootstrap_list: vec![(
+            SocketAddr::new(BASE_BOOTSTRAP_IP, 8069),
+            bootstrap_public_key,
+        )],
         bootstrap_whitelist_path: PathBuf::from(
             "../massa-node/base_config/bootstrap_whitelist.json",
         ),


### PR DESCRIPTION
Not to be merged.

This is a pre-cursor to de-asyncing the bootstrapping system. These changes set up the mocks to use `tokio::net::TcpStream` for the duplex, routing via "localhost:{Os-chosen port}"

The purpose of this PR is for reviewers to confirm that this is (effectively) just a straight-up refactor. The thinking being is that when a TcpStream is connected on the same local host, it's effectively a `DuplexStream`, only it goes via the OS instead of managed in-mem.

For the purpose of testing, the performance implications should be irrelevant.