### PR TITLE
Remove `test`/`not(test)` `#[cfg(...)]` annotations from bootstrap establisher system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2431,6 +2431,7 @@ name = "massa_bootstrap"
 version = "0.1.0"
 dependencies = [
  "async-speed-limit",
+ "async-trait",
  "bitvec",
  "crossbeam",
  "displaydoc",

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -24,6 +24,8 @@ tokio = { version = "1.23", features = ["full"] }
 tracing = "0.1"
 substruct = { git = "https://github.com/sydhds/substruct" }
 socket2 = "0.4.7"
+crossbeam = "0.8.2"
+async-trait = "0.1.64"
 
 # custom modules
 massa_async_pool = { path = "../massa-async-pool" }
@@ -39,8 +41,6 @@ massa_serialization = { path = "../massa-serialization" }
 massa_signature = { path = "../massa-signature" }
 massa_pos_exports = { path = "../massa-pos-exports" }
 massa_time = { path = "../massa-time" }
-crossbeam = "0.8.2"
-async-trait = "0.1.64"
 
 [dev-dependencies]
 bitvec = { version = "1.0", features = ["serde"] }

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -40,6 +40,7 @@ massa_signature = { path = "../massa-signature" }
 massa_pos_exports = { path = "../massa-pos-exports" }
 massa_time = { path = "../massa-time" }
 crossbeam = "0.8.2"
+async-trait = "0.1.64"
 
 [dev-dependencies]
 bitvec = { version = "1.0", features = ["serde"] }

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -17,9 +17,10 @@ use tracing::{debug, info, warn};
 use crate::{
     client_binder::BootstrapClientBinder,
     error::BootstrapError,
+    establisher::{BSConnector, BSEstablisher},
     messages::{BootstrapClientMessage, BootstrapServerMessage},
     settings::IpType,
-    BootstrapConfig, Establisher, GlobalBootstrapState,
+    BootstrapConfig, GlobalBootstrapState,
 };
 
 /// This function will send the starting point to receive a stream of the ledger and will receive and process each part until receive a `BootstrapServerMessage::FinalStateFinished` message from the server.
@@ -371,7 +372,7 @@ async fn send_client_message(
 }
 
 async fn connect_to_server(
-    establisher: &mut Establisher,
+    establisher: &mut impl BSEstablisher,
     bootstrap_config: &BootstrapConfig,
     addr: &SocketAddr,
     pub_key: &PublicKey,
@@ -417,7 +418,7 @@ fn filter_bootstrap_list(
 pub async fn get_state(
     bootstrap_config: &BootstrapConfig,
     final_state: Arc<RwLock<FinalState>>,
-    mut establisher: Establisher,
+    mut establisher: impl BSEstablisher,
     version: Version,
     genesis_timestamp: MassaTime,
     end_timestamp: Option<MassaTime>,

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -377,10 +377,8 @@ async fn connect_to_server(
     pub_key: &PublicKey,
 ) -> Result<BootstrapClientBinder, BootstrapError> {
     // connect
-    let mut connector = establisher
-        .get_connector(bootstrap_config.connect_timeout)
-        .await?; // cancellable
-    let socket = connector.connect(*addr).await?; // cancellable
+    let mut connector = establisher.get_connector(bootstrap_config.connect_timeout)?;
+    let socket = connector.connect(*addr).await?;
     Ok(BootstrapClientBinder::new(
         socket,
         *pub_key,

--- a/massa-bootstrap/src/client_binder.rs
+++ b/massa-bootstrap/src/client_binder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::error::BootstrapError;
-use crate::establisher::types::Duplex;
+use crate::establisher::Duplex;
 use crate::messages::{
     BootstrapClientMessage, BootstrapClientMessageSerializer, BootstrapServerMessage,
     BootstrapServerMessageDeserializer,

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -1,29 +1,27 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
+use std::{io, net::SocketAddr};
 
 #[cfg(test)]
 pub mod types {
-    pub type Duplex = crate::tests::mock_establisher::Duplex;
-
     pub type Listener = crate::tests::mock_establisher::MockListener;
 
     pub type Connector = crate::tests::mock_establisher::MockConnector;
 
     pub type Establisher = crate::tests::mock_establisher::MockEstablisher;
+/// duplex connection
+pub type Duplex = tokio::net::TcpStream;
+/// duplex connection
+pub type DuplexListener = tokio::net::TcpListener;
+
 }
 
 #[cfg(not(test))]
 /// Connection types
 pub mod types {
     use massa_time::MassaTime;
-    use std::{io, net::SocketAddr};
-    use tokio::{
-        net::{TcpListener, TcpStream},
-        time::timeout,
-    };
-    /// duplex connection
-    pub type Duplex = TcpStream;
-    /// listener, used by server
-    pub type Listener = DefaultListener;
+
+    use super::{io, Duplex, DuplexListener, SocketAddr};
+
     /// connector, used by client
     pub type Connector = DefaultConnector;
     /// connection establisher
@@ -31,7 +29,7 @@ pub mod types {
 
     /// The listener we are using
     #[derive(Debug)]
-    pub struct DefaultListener(TcpListener);
+    pub struct DefaultListener(DuplexListener);
 
     impl DefaultListener {
         /// Accepts a new incoming connection from this listener.
@@ -54,7 +52,7 @@ pub mod types {
         /// # Argument
         /// * `addr`: `SocketAddr` we are trying to connect to.
         pub async fn connect(&mut self, addr: SocketAddr) -> io::Result<Duplex> {
-            match timeout(self.0.to_duration(), TcpStream::connect(addr)).await {
+            match tokio::time::timeout(self.0.to_duration(), Duplex::connect(addr)).await {
                 Ok(Ok(sock)) => Ok(sock),
                 Ok(Err(e)) => Err(e),
                 Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
@@ -96,7 +94,7 @@ pub mod types {
             // Number of connections to queue, set to the hardcoded value used by tokio
             socket.listen(1024)?;
 
-            Ok(DefaultListener(TcpListener::from_std(socket.into())?))
+            Ok(DefaultListener(DuplexListener::from_std(socket.into())?))
         }
 
         /// Get the connector with associated timeout

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -103,7 +103,7 @@ pub mod types {
         ///
         /// # Argument
         /// * `timeout_duration`: timeout duration in milliseconds
-        pub async fn get_connector(
+        pub fn get_connector(
             &mut self,
             timeout_duration: MassaTime,
         ) -> io::Result<DefaultConnector> {

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -87,9 +87,18 @@ impl BSEstablisher for DefaultEstablisher {
     /// * `addr`: `SocketAddr` we want to bind to.
     fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
         // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
-        let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
+        // This is needed to get the same behavior on all OS
+        // However, if IPv6 is disabled system-wide, you may need to bind to an IPv4 address instead.
+        let domain = match addr.is_ipv4() {
+            true => socket2::Domain::IPV4,
+            _ => socket2::Domain::IPV6,
+        };
 
-        socket.set_only_v6(false)?;
+        let socket = socket2::Socket::new(domain, socket2::Type::STREAM, None)?;
+
+        if addr.is_ipv6() {
+            socket.set_only_v6(false)?;
+        }
         socket.set_nonblocking(true)?;
         socket.bind(&addr.into())?;
 

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -6,7 +6,7 @@ use std::{io, net::SocketAddr};
 /// duplex connection
 pub type Duplex = tokio::net::TcpStream;
 
-/// duplex connection
+/// Listener used to establish a Duplex
 pub type DuplexListener = tokio::net::TcpListener;
 
 #[async_trait]

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -76,7 +76,7 @@ pub mod types {
         ///
         /// # Argument
         /// * `addr`: `SocketAddr` we want to bind to.
-        pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
+        pub fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
             // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
             // This is needed to get the same behavior on all OS
             // However, if IPv6 is disabled system-wide, you may need to bind to an IPv4 address instead.

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -22,9 +22,9 @@ pub mod types {
     };
     /// duplex connection
     pub type Duplex = TcpStream;
-    /// listener
+    /// listener, used by server
     pub type Listener = DefaultListener;
-    /// connector
+    /// connector, used by client
     pub type Connector = DefaultConnector;
     /// connection establisher
     pub type Establisher = DefaultEstablisher;

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -10,15 +10,18 @@ pub type Duplex = tokio::net::TcpStream;
 pub type DuplexListener = tokio::net::TcpListener;
 
 #[async_trait]
+/// Specifies a common interface that can be used by standard, or mockers
 pub trait BSListener {
     async fn accept(&mut self) -> io::Result<(Duplex, SocketAddr)>;
 }
 
 #[async_trait]
+/// Specifies a common interface that can be used by standard, or mockers
 pub trait BSConnector {
     async fn connect(&mut self, addr: SocketAddr) -> io::Result<Duplex>;
 }
 
+/// Specifies a common interface that can be used by standard, or mockers
 pub trait BSEstablisher {
     // TODO: this is needed for thread spawning. Once the listener is on-thread, the static
     // lifetime can be thrown away.

--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -1,16 +1,8 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 use async_trait::async_trait;
+use massa_time::MassaTime;
 use std::{io, net::SocketAddr};
 
-#[cfg(test)]
-use crate::tests::mock_establisher::{MockConnector, MockEstablisher};
-#[cfg(test)]
-pub mod types {
-
-    pub type Connector = super::MockConnector;
-
-    pub type Establisher = super::MockEstablisher;
-}
 /// duplex connection
 pub type Duplex = tokio::net::TcpStream;
 
@@ -22,104 +14,99 @@ pub trait BSListener {
     async fn accept(&mut self) -> io::Result<(Duplex, SocketAddr)>;
 }
 
-#[cfg(not(test))]
-/// Connection types
-pub mod types {
-    use massa_time::MassaTime;
+#[async_trait]
+pub trait BSConnector {
+    async fn connect(&mut self, addr: SocketAddr) -> io::Result<Duplex>;
+}
 
-    use super::{async_trait, io, Duplex, DuplexListener, SocketAddr};
+pub trait BSEstablisher {
+    // TODO: this is needed for thread spawning. Once the listener is on-thread, the static
+    // lifetime can be thrown away.
+    // TODO: use super-advanced lifetime/GAT/other shenanigans to
+    // make the listener compatable with being moved into a thread
+    type Listener: BSListener + Send + 'static;
+    type Connector: BSConnector;
+    fn get_listener(&mut self, addr: SocketAddr) -> io::Result<Self::Listener>;
+    fn get_connector(&mut self, timeout_duration: MassaTime) -> io::Result<Self::Connector>;
+}
 
-    /// connector, used by client
-    pub type Connector = DefaultConnector;
-    /// connection establisher
-    pub type Establisher = DefaultEstablisher;
+/// The listener we are using
+#[derive(Debug)]
+pub struct DefaultListener(DuplexListener);
 
-    /// The listener we are using
-    #[derive(Debug)]
-    pub struct DefaultListener(DuplexListener);
+#[async_trait]
+impl BSListener for DefaultListener {
+    /// Accepts a new incoming connection from this listener.
+    async fn accept(&mut self) -> io::Result<(Duplex, SocketAddr)> {
+        // accept
+        let (sock, mut remote_addr) = self.0.accept().await?;
+        // normalize address
+        remote_addr.set_ip(remote_addr.ip().to_canonical());
+        Ok((sock, remote_addr))
+    }
+}
+/// Initiates a connection with given timeout in milliseconds
+#[derive(Debug)]
+pub struct DefaultConnector(MassaTime);
 
-    #[async_trait]
-    impl super::BSListener for DefaultListener {
-        /// Accepts a new incoming connection from this listener.
-        async fn accept(&mut self) -> io::Result<(Duplex, SocketAddr)> {
-            // accept
-            let (sock, mut remote_addr) = self.0.accept().await?;
-            // normalize address
-            remote_addr.set_ip(remote_addr.ip().to_canonical());
-            Ok((sock, remote_addr))
+#[async_trait]
+impl BSConnector for DefaultConnector {
+    /// Tries to connect to address
+    ///
+    /// # Argument
+    /// * `addr`: `SocketAddr` we are trying to connect to.
+    async fn connect(&mut self, addr: SocketAddr) -> io::Result<Duplex> {
+        match tokio::time::timeout(self.0.to_duration(), Duplex::connect(addr)).await {
+            Ok(Ok(sock)) => Ok(sock),
+            Ok(Err(e)) => Err(e),
+            Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
         }
     }
+}
 
-    /// Initiates a connection with given timeout in milliseconds
-    #[derive(Debug)]
-    pub struct DefaultConnector(MassaTime);
+/// Establishes a connection
+#[derive(Debug)]
+pub struct DefaultEstablisher;
 
-    impl DefaultConnector {
-        /// Tries to connect to address
-        ///
-        /// # Argument
-        /// * `addr`: `SocketAddr` we are trying to connect to.
-        pub async fn connect(&mut self, addr: SocketAddr) -> io::Result<Duplex> {
-            match tokio::time::timeout(self.0.to_duration(), Duplex::connect(addr)).await {
-                Ok(Ok(sock)) => Ok(sock),
-                Ok(Err(e)) => Err(e),
-                Err(e) => Err(io::Error::new(io::ErrorKind::TimedOut, e)),
-            }
-        }
+impl DefaultEstablisher {
+    /// Creates an Establisher.
+    pub fn new() -> Self {
+        DefaultEstablisher {}
+    }
+}
+
+impl BSEstablisher for DefaultEstablisher {
+    type Connector = DefaultConnector;
+    type Listener = DefaultListener;
+    /// Gets the associated listener
+    ///
+    /// # Argument
+    /// * `addr`: `SocketAddr` we want to bind to.
+    fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
+        // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
+        let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
+
+        socket.set_only_v6(false)?;
+        socket.set_nonblocking(true)?;
+        socket.bind(&addr.into())?;
+
+        // Number of connections to queue, set to the hardcoded value used by tokio
+        socket.listen(1024)?;
+
+        Ok(DefaultListener(DuplexListener::from_std(socket.into())?))
     }
 
-    /// Establishes a connection
-    #[derive(Debug)]
-    pub struct DefaultEstablisher;
-
-    impl DefaultEstablisher {
-        /// Creates an Establisher.
-        pub fn new() -> Self {
-            DefaultEstablisher {}
-        }
-
-        /// Gets the associated listener
-        ///
-        /// # Argument
-        /// * `addr`: `SocketAddr` we want to bind to.
-        pub fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
-            // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
-            // This is needed to get the same behavior on all OS
-            // However, if IPv6 is disabled system-wide, you may need to bind to an IPv4 address instead.
-            let domain = match addr.is_ipv4() {
-                true => socket2::Domain::IPV4,
-                _ => socket2::Domain::IPV6,
-            };
-
-            let socket = socket2::Socket::new(domain, socket2::Type::STREAM, None)?;
-
-            if addr.is_ipv6() {
-                socket.set_only_v6(false)?;
-            }
-            socket.set_nonblocking(true)?;
-            socket.bind(&addr.into())?;
-
-            // Number of connections to queue, set to the hardcoded value used by tokio
-            socket.listen(1024)?;
-
-            Ok(DefaultListener(DuplexListener::from_std(socket.into())?))
-        }
-
-        /// Get the connector with associated timeout
-        ///
-        /// # Argument
-        /// * `timeout_duration`: timeout duration in milliseconds
-        pub fn get_connector(
-            &mut self,
-            timeout_duration: MassaTime,
-        ) -> io::Result<DefaultConnector> {
-            Ok(DefaultConnector(timeout_duration))
-        }
+    /// Get the connector with associated timeout
+    ///
+    /// # Argument
+    /// * `timeout_duration`: timeout duration in milliseconds
+    fn get_connector(&mut self, timeout_duration: MassaTime) -> io::Result<DefaultConnector> {
+        Ok(DefaultConnector(timeout_duration))
     }
+}
 
-    impl Default for DefaultEstablisher {
-        fn default() -> Self {
-            Self::new()
-        }
+impl Default for DefaultEstablisher {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(ip)]
 #![feature(let_chains)]
 
-pub use establisher::types::Establisher;
 use massa_consensus_exports::bootstrapable_graph::BootstrapableGraph;
 use massa_final_state::FinalState;
 use massa_network_exports::BootstrapPeers;
@@ -30,7 +29,7 @@ mod server_binder;
 mod settings;
 mod tools;
 pub use client::get_state;
-pub use establisher::types;
+pub use establisher::DefaultEstablisher;
 pub use messages::{
     BootstrapClientMessage, BootstrapClientMessageDeserializer, BootstrapClientMessageSerializer,
     BootstrapServerMessage, BootstrapServerMessageDeserializer, BootstrapServerMessageSerializer,

--- a/massa-bootstrap/src/lib.rs
+++ b/massa-bootstrap/src/lib.rs
@@ -39,7 +39,7 @@ pub use settings::IpType;
 pub use settings::{BootstrapConfig, BootstrapServerMessageDeserializerArgs};
 
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;
 
 /// a collection of the bootstrap state snapshots of all relevant modules
 pub struct GlobalBootstrapState {

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -133,7 +133,6 @@ pub async fn start_bootstrap_server(
 
     let listener = establisher
         .get_listener(listen_addr)
-        .await
         .map_err(BootstrapError::IoError)?;
 
     // This is the primary interface between the async-listener, and the "sync" worker

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -164,6 +164,8 @@ pub async fn start_bootstrap_server(
     let listen_rt_handle = bs_server_runtime.handle().clone();
     let listen_handle = thread::Builder::new()
         .name("bs_listener".to_string())
+        // FIXME: The interface being used shouldn't have `: Send + 'static` as a constraint on the listener assosciated type.
+        // GAT lifetime is likely to remedy this, however.
         .spawn(move || {
             let res =
                 listen_rt_handle.block_on(BootstrapServer::run_listener(listener, listener_tx));

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -55,9 +55,9 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     error::BootstrapError,
+    establisher::{BSListener, Duplex},
     messages::{BootstrapClientMessage, BootstrapServerMessage},
     server_binder::BootstrapServerBinder,
-    types::{Duplex, Listener},
     BootstrapConfig, Establisher,
 };
 
@@ -248,7 +248,7 @@ impl BootstrapServer<'_> {
     /// Err(..) Error accepting a connection
     /// TODO: Integrate the listener into the bootstrap-main-loop
     async fn run_listener(
-        mut listener: Listener,
+        mut listener: impl BSListener,
         listener_tx: crossbeam::channel::Sender<BsConn>,
     ) -> Result<Result<(), BsConn>, Box<BootstrapError>> {
         loop {

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -55,10 +55,10 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     error::BootstrapError,
-    establisher::{BSListener, Duplex},
+    establisher::{BSEstablisher, BSListener, Duplex},
     messages::{BootstrapClientMessage, BootstrapServerMessage},
     server_binder::BootstrapServerBinder,
-    BootstrapConfig, Establisher,
+    BootstrapConfig,
 };
 
 /// Abstraction layer over data produced by the listener, and transported
@@ -103,7 +103,7 @@ pub async fn start_bootstrap_server(
     network_command_sender: NetworkCommandSender,
     final_state: Arc<RwLock<FinalState>>,
     config: BootstrapConfig,
-    mut establisher: Establisher,
+    mut establisher: impl BSEstablisher,
     keypair: KeyPair,
     version: Version,
 ) -> Result<Option<BootstrapManager>, Box<BootstrapError>> {

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 use crate::error::BootstrapError;
-use crate::establisher::types::Duplex;
+use crate::establisher::Duplex;
 use crate::messages::{
     BootstrapClientMessage, BootstrapClientMessageDeserializer, BootstrapServerMessage,
     BootstrapServerMessageSerializer,

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -21,7 +21,6 @@ use massa_signature::{KeyPair, PublicKey};
 use massa_time::MassaTime;
 use serial_test::serial;
 use std::str::FromStr;
-use tokio::io::duplex;
 
 lazy_static::lazy_static! {
     pub static ref BOOTSTRAP_CONFIG_KEYPAIR: (BootstrapConfig, KeyPair) = {
@@ -66,9 +65,13 @@ impl BootstrapClientBinder {
 #[serial]
 async fn test_binders() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let server = server.accept().await.unwrap();
+    // let (client, server) = duplex(1000000);
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,
@@ -165,10 +168,14 @@ async fn test_binders() {
 async fn test_binders_double_send_server_works() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
 
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let client = tokio::net::TcpStream::connect(server.local_addr().unwrap())
+        .await
+        .unwrap();
+    let server = server.accept().await.unwrap();
 
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,
@@ -250,9 +257,12 @@ async fn test_binders_double_send_server_works() {
 async fn test_binders_try_double_send_client_works() {
     let (bootstrap_config, server_keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
 
-    let (client, server) = duplex(1000000);
+    let server = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+    let addr = server.local_addr().unwrap();
+    let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let server = server.accept().await.unwrap();
     let mut server = BootstrapServerBinder::new(
-        server,
+        server.0,
         server_keypair.clone(),
         BootstrapSrvBindCfg {
             max_bytes_read_write: f64::INFINITY,

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -1,6 +1,6 @@
+use crate::establisher::Duplex;
 use crate::messages::{BootstrapClientMessage, BootstrapServerMessage};
 use crate::settings::{BootstrapClientConfig, BootstrapSrvBindCfg};
-use crate::types::Duplex;
 use crate::BootstrapConfig;
 use crate::{
     client_binder::BootstrapClientBinder, server_binder::BootstrapServerBinder,

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -1,5 +1,4 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
-
 use async_trait::async_trait;
 use massa_models::config::CHANNEL_SIZE;
 use massa_time::MassaTime;

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -73,9 +73,7 @@ impl BSConnector for MockConnector {
         let duplex_controller = Duplex::connect(addr).await.unwrap();
         let duplex_mock = duplex_mock.accept().await.unwrap();
 
-        // // task the controller connection if exist.
-        // let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
-        // to see if the connection is accepted
+        // Used to see if the connection is accepted
         let (accept_tx, accept_rx) = oneshot::channel::<bool>();
 
         // send new connection to mock

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 
-pub type Duplex = tokio::net::TcpStream;
+use crate::establisher::{Duplex, DuplexListener};
 
 pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
     let (connection_listener_tx, connection_listener_rx) =
@@ -31,8 +31,7 @@ pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
 
 #[derive(Debug)]
 pub struct MockListener {
-    connection_listener_rx:
-        crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<tokio::net::TcpStream>)>, // (controller, mock)
+    connection_listener_rx: crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<Duplex>)>, // (controller, mock)
 }
 
 impl MockListener {
@@ -43,8 +42,8 @@ impl MockListener {
                 "MockListener accept channel from Establisher closed".to_string(),
             )
         })?;
-        let duplex_controller = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
-        let duplex_mock = tokio::net::TcpStream::connect(duplex_controller.local_addr().unwrap())
+        let duplex_controller = DuplexListener::bind("localhost:0").await.unwrap();
+        let duplex_mock = Duplex::connect(duplex_controller.local_addr().unwrap())
             .await
             .unwrap();
         let duplex_controller = duplex_controller.accept().await.unwrap();
@@ -62,15 +61,14 @@ impl MockListener {
 
 #[derive(Debug)]
 pub struct MockConnector {
-    connection_connector_tx:
-        mpsc::Sender<(tokio::net::TcpStream, SocketAddr, oneshot::Sender<bool>)>,
+    connection_connector_tx: mpsc::Sender<(Duplex, SocketAddr, oneshot::Sender<bool>)>,
     timeout_duration: MassaTime,
 }
 
 impl MockConnector {
-    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<tokio::net::TcpStream> {
-        let duplex_mock = tokio::net::TcpListener::bind(addr).await.unwrap();
-        let duplex_controller = tokio::net::TcpStream::connect(addr).await.unwrap();
+    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<Duplex> {
+        let duplex_mock = DuplexListener::bind(addr).await.unwrap();
+        let duplex_controller = Duplex::connect(addr).await.unwrap();
         let duplex_mock = duplex_mock.accept().await.unwrap();
 
         // // task the controller connection if exist.

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -115,10 +115,7 @@ impl MockEstablisher {
         })
     }
 
-    pub async fn get_connector(
-        &mut self,
-        timeout_duration: MassaTime,
-    ) -> std::io::Result<MockConnector> {
+    pub fn get_connector(&mut self, timeout_duration: MassaTime) -> std::io::Result<MockConnector> {
         // create connector stream
 
         Ok(MockConnector {

--- a/massa-bootstrap/src/tests/mock_establisher.rs
+++ b/massa-bootstrap/src/tests/mock_establisher.rs
@@ -1,15 +1,14 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use massa_models::config::{CHANNEL_SIZE, MAX_DUPLEX_BUFFER_SIZE};
+use massa_models::config::CHANNEL_SIZE;
 use massa_time::MassaTime;
 use socket2 as _;
 use std::io;
 use std::net::SocketAddr;
-use tokio::io::DuplexStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
 
-pub type Duplex = DuplexStream;
+pub type Duplex = tokio::net::TcpStream;
 
 pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
     let (connection_listener_tx, connection_listener_rx) =
@@ -32,18 +31,24 @@ pub fn new() -> (MockEstablisher, MockEstablisherInterface) {
 
 #[derive(Debug)]
 pub struct MockListener {
-    connection_listener_rx: crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<Duplex>)>, // (controller, mock)
+    connection_listener_rx:
+        crossbeam::channel::Receiver<(SocketAddr, oneshot::Sender<tokio::net::TcpStream>)>, // (controller, mock)
 }
 
 impl MockListener {
-    pub async fn accept(&mut self) -> std::io::Result<(Duplex, SocketAddr)> {
-        let (addr, sender) = self.connection_listener_rx.recv().map_err(|_| {
+    pub async fn accept(&mut self) -> std::io::Result<(tokio::net::TcpStream, SocketAddr)> {
+        let (_addr, sender) = self.connection_listener_rx.recv().map_err(|_| {
             io::Error::new(
                 io::ErrorKind::Other,
                 "MockListener accept channel from Establisher closed".to_string(),
             )
         })?;
-        let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
+        let duplex_controller = tokio::net::TcpListener::bind("localhost:0").await.unwrap();
+        let duplex_mock = tokio::net::TcpStream::connect(duplex_controller.local_addr().unwrap())
+            .await
+            .unwrap();
+        let duplex_controller = duplex_controller.accept().await.unwrap();
+
         sender.send(duplex_mock).map_err(|_| {
             io::Error::new(
                 io::ErrorKind::Other,
@@ -51,27 +56,32 @@ impl MockListener {
             )
         })?;
 
-        Ok((duplex_controller, addr))
+        Ok(duplex_controller)
     }
 }
 
 #[derive(Debug)]
 pub struct MockConnector {
-    connection_connector_tx: mpsc::Sender<(Duplex, SocketAddr, oneshot::Sender<bool>)>,
+    connection_connector_tx:
+        mpsc::Sender<(tokio::net::TcpStream, SocketAddr, oneshot::Sender<bool>)>,
     timeout_duration: MassaTime,
 }
 
 impl MockConnector {
-    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<Duplex> {
-        // task the controller connection if exist.
-        let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
+    pub async fn connect(&mut self, addr: SocketAddr) -> std::io::Result<tokio::net::TcpStream> {
+        let duplex_mock = tokio::net::TcpListener::bind(addr).await.unwrap();
+        let duplex_controller = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let duplex_mock = duplex_mock.accept().await.unwrap();
+
+        // // task the controller connection if exist.
+        // let (duplex_controller, duplex_mock) = tokio::io::duplex(MAX_DUPLEX_BUFFER_SIZE);
         // to see if the connection is accepted
         let (accept_tx, accept_rx) = oneshot::channel::<bool>();
 
         // send new connection to mock
         timeout(self.timeout_duration.to_duration(), async move {
             self.connection_connector_tx
-                .send((duplex_mock, addr, accept_tx))
+                .send((duplex_mock.0, addr, accept_tx))
                 .await
                 .map_err(|_err| {
                     io::Error::new(

--- a/massa-bootstrap/src/tests/mod.rs
+++ b/massa-bootstrap/src/tests/mod.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
 mod binders;
-pub mod mock_establisher;
+pub(crate) mod mock_establisher;
 mod scenarios;
-pub mod tools;
+pub(crate) mod tools;

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -64,7 +64,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::{sync::mpsc::Receiver, time::sleep};
 
-pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(169, 202, 0, 10));
+pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0));
 
 /// generates a small random number of bytes
 fn get_some_random_bytes() -> Vec<u8> {
@@ -301,7 +301,10 @@ pub fn get_bootstrap_config(bootstrap_public_key: NodeId) -> BootstrapConfig {
         write_timeout: 1000.into(),
         read_error_timeout: 200.into(),
         write_error_timeout: 200.into(),
-        bootstrap_list: vec![(SocketAddr::new(BASE_BOOTSTRAP_IP, 16), bootstrap_public_key)],
+        bootstrap_list: vec![(
+            SocketAddr::new(BASE_BOOTSTRAP_IP, 8069),
+            bootstrap_public_key,
+        )],
         bootstrap_whitelist_path: PathBuf::from(
             "../massa-node/base_config/bootstrap_whitelist.json",
         ),

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
-use super::mock_establisher::Duplex;
+use crate::establisher::Duplex;
 use crate::settings::{BootstrapConfig, IpType};
 use bitvec::vec::BitVec;
 use massa_async_pool::test_exports::{create_async_pool, get_random_message};

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -64,6 +64,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::{sync::mpsc::Receiver, time::sleep};
 
+// Use loop-back address. use port 0 to auto-assign a port
 pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 /// generates a small random number of bytes

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -274,19 +274,9 @@ pub fn get_dummy_block_id(s: &str) -> BlockId {
     BlockId(Hash::compute_from(s.as_bytes()))
 }
 
-pub fn get_random_public_key() -> PublicKey {
-    let priv_key = KeyPair::generate();
-    priv_key.get_public_key()
-}
-
 pub fn get_random_address() -> Address {
     let priv_key = KeyPair::generate();
     Address::from_public_key(&priv_key.get_public_key())
-}
-
-pub fn get_dummy_signature(s: &str) -> Signature {
-    let priv_key = KeyPair::generate();
-    priv_key.sign(&Hash::compute_from(s.as_bytes())).unwrap()
 }
 
 pub fn get_bootstrap_config(bootstrap_public_key: NodeId) -> BootstrapConfig {

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -50,7 +50,7 @@ use massa_models::{
 use massa_network_exports::{BootstrapPeers, NetworkCommand};
 use massa_pos_exports::{CycleInfo, DeferredCredits, PoSChanges, PoSFinalState, ProductionStats};
 use massa_serialization::{DeserializeError, Deserializer, Serializer};
-use massa_signature::{KeyPair, PublicKey, Signature};
+use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use rand::Rng;
 use std::collections::{HashMap, VecDeque};

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -64,7 +64,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::{sync::mpsc::Receiver, time::sleep};
 
-pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 0));
+pub const BASE_BOOTSTRAP_IP: IpAddr = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
 /// generates a small random number of bytes
 fn get_some_random_bytes() -> Vec<u8> {

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -236,7 +236,7 @@ async fn launch(
         res = get_state(
             &bootstrap_config,
             final_state.clone(),
-            massa_bootstrap::types::Establisher::default(),
+            massa_bootstrap::DefaultEstablisher::default(),
             *VERSION,
             *GENESIS_TIMESTAMP,
             *END_TIMESTAMP,
@@ -508,7 +508,7 @@ async fn launch(
         network_command_sender.clone(),
         final_state.clone(),
         bootstrap_config,
-        massa_bootstrap::Establisher::new(),
+        massa_bootstrap::DefaultEstablisher::new(),
         private_key,
         *VERSION,
     )


### PR DESCRIPTION
This PR is a spin-off of the work being done to de-async the bootstrap server.

All functions are unchanged, so it should be (pretty close) to a straight up refactor.

The removal has several advantages:

- rust-analyzer won't be confused anymore about whether to go to the `Mock` or the `Default` definition of the types
- Allows one to be explicit about having a setup be mocked or not, regardless of the build-context.
- The mock communication duplex-type is the same as deployed type.

Problems:
- the `'static` constraint in this code. This will not always be needed (listener will soon not need to be moved into a thread-spawn), but should be looked into none-the-less
```rust
pub trait BSEstablisher {
    // TODO: this is needed for thread spawning. Once the listener is on-thread, the static
    // lifetime can be thrown away.
    // TODO: use super-advanced lifetime/GAT/other shenanigans to
    // make the listener compatable with being moved into a thread
    type Listener: BSListener + Send + 'static;
    type Connector: BSConnector;
    fn get_listener(&mut self, addr: SocketAddr) -> io::Result<Self::Listener>;
    fn get_connector(&mut self, timeout_duration: MassaTime) -> io::Result<Self::Connector>;
}
```
- non-test code would have to account for the mocking stuff. The optimizer should be able to handle that, though.
- [x] non-test code doesn't exclude test-code (can be fixed)

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification