### PR TITLE
Fix bind ipv4 only network (#3653)

### DIFF
--- a/massa-bootstrap/src/establisher.rs
+++ b/massa-bootstrap/src/establisher.rs
@@ -78,9 +78,18 @@ pub mod types {
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
             // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
-            let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
+            // This is needed to get the same behavior on all OS
+            // However, if IPv6 is disabled system-wide, you may need to bind to an IPv4 address instead.
+            let domain = match addr.is_ipv4() {
+                true => socket2::Domain::IPV4,
+                _ => socket2::Domain::IPV6,
+            };
 
-            socket.set_only_v6(false)?;
+            let socket = socket2::Socket::new(domain, socket2::Type::STREAM, None)?;
+
+            if addr.is_ipv6() {
+                socket.set_only_v6(false)?;
+            }
             socket.set_nonblocking(true)?;
             socket.bind(&addr.into())?;
 

--- a/massa-network-exports/src/establisher.rs
+++ b/massa-network-exports/src/establisher.rs
@@ -84,9 +84,18 @@ mod types {
         /// * `addr`: `SocketAddr` we want to bind to.
         pub async fn get_listener(&mut self, addr: SocketAddr) -> io::Result<DefaultListener> {
             // Create a socket2 TCP listener to manually set the IPV6_V6ONLY flag
-            let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
+            // This is needed to get the same behavior on all OS
+            // However, if IPv6 is disabled system-wide, you may need to bind to an IPv4 address instead.
+            let domain = match addr.is_ipv4() {
+                true => socket2::Domain::IPV4,
+                _ => socket2::Domain::IPV6,
+            };
 
-            socket.set_only_v6(false)?;
+            let socket = socket2::Socket::new(domain, socket2::Type::STREAM, None)?;
+
+            if addr.is_ipv6() {
+                socket.set_only_v6(false)?;
+            }
             socket.set_nonblocking(true)?;
             socket.bind(&addr.into())?;
 

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -138,7 +138,7 @@
     max_endorsements_propagation_time = 48000
 
 [network]
-    # port on which to listen for protocol communication
+    # port on which to listen for protocol communication. You may need to change this to "0.0.0.0:port" if IPv6 is disabled system-wide.
     bind = "[::]:31244"
     # port used by protocol
     protocol_port = 31244
@@ -218,7 +218,7 @@
     bootstrap_whitelist_path = "base_config/bootstrap_whitelist.json"
     # path to the bootstrap blacklist file. This whitelist define IPs that will not be able to bootstrap on your node. This list is optional.
     bootstrap_blacklist_path = "base_config/bootstrap_blacklist.json"
-    # [optional] port on which to listen for incoming bootstrap requests
+    # [optional] port on which to listen for incoming bootstrap requests. You may need to change this to "0.0.0.0:port" if IPv6 is disabled system-wide.
     bind = "[::]:31245"
     # timeout to establish a bootstrap connection
     connect_timeout = 15000


### PR DESCRIPTION
* initial fix

* Do not set ipv6 flag if ipv4 only

* fmt

* Added documentation and comments

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification