### PR TITLE
Add colors on the get_operations command

### DIFF
--- a/massa-client/src/display.rs
+++ b/massa-client/src/display.rs
@@ -223,8 +223,42 @@ impl Output for Vec<IpAddr> {
 
 impl Output for Vec<OperationInfo> {
     fn pretty_print(&self) {
-        for operation_info in self {
-            println!("{}", operation_info);
+        for info in self {
+            println!("{}", style("==========").color256(237));
+            print!("Operation {}", Style::Id.style(info.id));
+            if info.in_pool {
+                print!(", {}", Style::Pending.style("in pool"));
+            }
+            if let Some(f) = info.is_operation_final {
+                print!(", operation is {}", if f {
+                    Style::Finished.style("final")
+                } else {
+                    Style::Pending.style("not final")
+                });
+            } else {
+                print!(", finality {}", Style::Unknown.style("unknown"));
+            }
+            println!(", {}", match info.op_exec_status {
+                Some(true) => Style::Good.style("success"),
+                Some(false) => Style::Bad.style("failed"),
+                None => Style::Unknown.style("unknown status"),
+            });
+            if info.in_blocks.is_empty() {
+                println!("{}", Style::Block.style("Not in any blocks"));
+            } else {
+                println!("In blocks:");
+                for bid in info.in_blocks.iter() {
+                    println!("\t- {}", Style::Block.style(bid));
+                }
+            }
+            println!("Signature: {}", Style::Signature.style(info.operation.signature));
+            println!("Creator pubkey: {}",
+                Style::Address.style(info.operation.content_creator_pub_key));
+            println!("Creator address: {}",
+                Style::Address.style(info.operation.content_creator_address));
+            println!("Fee: {}", Style::Coins.style(info.operation.content.fee));
+            println!("Expire period: {}", Style::Pending.style(info.operation.content.expire_period));
+            println!("Operation type: {}", Style::Id.style(&info.operation.content.op));
         }
     }
 }


### PR DESCRIPTION
Implements #3661 for the REPL `get_operations`

Adds color on the CLI output to display more effectively operations informations.

Screenshot  ![Capture d’écran du 2023-03-08 11-46-08](https://user-images.githubusercontent.com/61109829/223693302-f168678c-e2ed-41ab-84c4-2dd7cff8bbbe.png)

Try it on your own and tell me if you want some other colors.

(Same as #3658, failed an operation that closed the PR)