### PR TITLE
Add colors in CLI for wallet_info

### DIFF
--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -338,7 +338,7 @@ pub enum ListOperation {
 /// Used to have a shinny json output
 /// TODO re-factor me
 #[derive(Debug, Serialize)]
-struct ExtendedWalletEntry {
+pub (crate) struct ExtendedWalletEntry {
     /// the keypair
     pub keypair: KeyPair,
     /// address and balance information
@@ -362,7 +362,7 @@ impl Display for ExtendedWalletEntry {
 /// Aggregation of the local, with some useful information as the balance, etc
 /// to be printed by the client.
 #[derive(Debug, Serialize)]
-pub struct ExtendedWallet(PreHashMap<Address, ExtendedWalletEntry>);
+pub struct ExtendedWallet(pub (crate) PreHashMap<Address, ExtendedWalletEntry>);
 
 impl ExtendedWallet {
     /// Reorganize everything into an extended wallet

--- a/massa-client/src/display.rs
+++ b/massa-client/src/display.rs
@@ -120,7 +120,37 @@ impl Output for Wallet {
 
 impl Output for ExtendedWallet {
     fn pretty_print(&self) {
-        println!("{}", self);
+        if self.0.is_empty() {
+            client_warning!("your wallet does not contain any key, use 'wallet_generate_secret_key' to generate a new key and add it to your wallet");
+        }
+        println!("{}", Style::Separator.style("====="));
+        for entry in self.0.values() {
+            if entry.show_keys {
+                println!("Secret key: {}", Style::Secret.style(&entry.keypair));
+                println!("Public key: {}", Style::Wallet.style(entry.keypair.get_public_key()));
+            }
+            println!("Address: {} (thread {}):",
+                Style::Wallet.style(entry.address_info.address),
+                Style::Protocol.style(entry.address_info.thread),
+            );
+            println!(
+                "\tBalance: {}={}, {}={}",
+                Style::Finished.style("final"),
+                Style::Coins.style(entry.address_info.final_balance),
+                Style::Pending.style("candidate"),
+                Style::Coins.style(entry.address_info.candidate_balance),
+            );
+            println!(
+                "\tRolls: {}={}, {}={}, {}={}",
+                Style::Good.style("active"),
+                Style::Protocol.style(entry.address_info.active_rolls),
+                Style::Finished.style("final"),
+                Style::Protocol.style(entry.address_info.final_rolls),
+                Style::Pending.style("candidate"),
+                Style::Protocol.style(entry.address_info.candidate_rolls),
+            );
+            println!("{}", Style::Separator.style("====="));
+        }
     }
 }
 


### PR DESCRIPTION
Implements #3661 for the REPL `wallet_info`

Adds color on the CLI output to display more effectively operations informations.

Screenshot 
![Capture d’écran du 2023-03-08 16-13-52](https://user-images.githubusercontent.com/61109829/223753000-a055fd6e-8326-4b5d-be46-451169a4b5c6.png)

Try it on your own and tell me if you want some other colors.