### PR TITLE
Fix/vesting test review requests

### DIFF
--- a/massa-versioning-worker/src/lib.rs
+++ b/massa-versioning-worker/src/lib.rs
@@ -45,5 +45,5 @@ pub mod versioning_factory;
 pub mod versioning_ser_der;
 
 /// Test utils
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub mod test_helpers;

--- a/massa-versioning-worker/src/versioning.rs
+++ b/massa-versioning-worker/src/versioning.rs
@@ -1003,7 +1003,7 @@ mod test {
             MipStoreRaw::try_from([(vi_1.clone(), vs_1.clone()), (vi_2.clone(), vs_2_2.clone())])
                 .unwrap();
 
-        vs_raw_1.update_with(&vs_raw_2);
+        vs_raw_1.update_with(&vs_raw_2).unwrap();
 
         // Expect state 1 (for vi_1) no change, state 2 (for vi_2) updated to "LockedIn"
         assert_eq!(vs_raw_1.0.get(&vi_1).unwrap().inner, vs_1.inner);


### PR DESCRIPTION
Clears clippy lint and allows the running of tests without the "testing" feature. handy for some IDE setups (in the case of mine, at least)