### PR TITLE
Use saturating sub as appropriate for thread-count

### DIFF
--- a/massa-api-exports/src/config.rs
+++ b/massa-api-exports/src/config.rs
@@ -2,6 +2,7 @@
 
 use massa_time::MassaTime;
 use std::net::SocketAddr;
+use std::num::NonZeroU8;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -59,7 +60,7 @@ pub struct APIConfig {
     /// max parameter size
     pub max_parameter_size: u32,
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// `genesis_timestamp`
     pub genesis_timestamp: MassaTime,
     /// t0

--- a/massa-async-pool/src/changes.rs
+++ b/massa-async-pool/src/changes.rs
@@ -1,4 +1,4 @@
-use std::ops::Bound::Included;
+use std::{num::NonZeroU8, ops::Bound::Included};
 
 use massa_serialization::{
     Deserializer, SerializeError, Serializer, U64VarIntDeserializer, U64VarIntSerializer,
@@ -134,7 +134,7 @@ pub struct AsyncPoolChangesDeserializer {
 
 impl AsyncPoolChangesDeserializer {
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         max_async_pool_changes: u64,
         max_async_message_data: u64,
         max_key_length: u32,
@@ -183,7 +183,7 @@ impl Deserializer<AsyncPoolChanges> for AsyncPoolChangesDeserializer {
     /// let changes: AsyncPoolChanges = AsyncPoolChanges(vec![Change::Add(message.compute_id(), message.clone()), Change::Delete(message.compute_id())]);
     /// let mut serialized = Vec::new();
     /// let serializer = AsyncPoolChangesSerializer::new();
-    /// let deserializer = AsyncPoolChangesDeserializer::new(32, 100000, 100000, 100000);
+    /// let deserializer = AsyncPoolChangesDeserializer::new(32.try_into().unwrap(), 100000, 100000, 100000);
     /// serializer.serialize(&changes, &mut serialized).unwrap();
     /// let (rest, changes_deser) = deserializer.deserialize::<DeserializeError>(&serialized).unwrap();
     /// assert!(rest.is_empty());

--- a/massa-async-pool/src/config.rs
+++ b/massa-async-pool/src/config.rs
@@ -2,6 +2,8 @@
 
 //! This file defines a configuration structure containing all settings for the asynchronous message pool system
 
+use std::num::NonZeroU8;
+
 /// Asynchronous pool configuration
 #[derive(Debug, Clone)]
 pub struct AsyncPoolConfig {
@@ -12,5 +14,5 @@ pub struct AsyncPoolConfig {
     /// max async message data (for bootstrap limits)
     pub max_async_message_data: u64,
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
 }

--- a/massa-async-pool/src/pool.rs
+++ b/massa-async-pool/src/pool.rs
@@ -21,8 +21,8 @@ use nom::{
     sequence::tuple,
     IResult, Parser,
 };
-use std::collections::BTreeMap;
 use std::ops::Bound::{Excluded, Included, Unbounded};
+use std::{collections::BTreeMap, num::NonZeroU8};
 
 const ASYNC_POOL_HASH_INITIAL_BYTES: &[u8; 32] = &[0; HASH_SIZE_BYTES];
 
@@ -302,7 +302,7 @@ pub struct AsyncPoolDeserializer {
 impl AsyncPoolDeserializer {
     /// Creates a new `AsyncPool` deserializer
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         max_async_pool_length: u64,
         max_async_message_data: u64,
         max_key_length: u32,
@@ -359,7 +359,7 @@ fn test_take_batch() {
     use std::str::FromStr;
 
     let config = AsyncPoolConfig {
-        thread_count: 2,
+        thread_count: 2.try_into().unwrap(),
         max_length: 10,
         max_async_message_data: 1_000_000,
         bootstrap_part_size: 100,

--- a/massa-async-pool/src/test_exports/bootstrap.rs
+++ b/massa-async-pool/src/test_exports/bootstrap.rs
@@ -27,7 +27,10 @@ fn get_random_address() -> Address {
 pub fn get_random_message(fee: Option<Amount>) -> AsyncMessage {
     let mut rng = rand::thread_rng();
     AsyncMessage::new_with_hash(
-        Slot::new(rng.gen_range(0..100_000), rng.gen_range(0..THREAD_COUNT)),
+        Slot::new(
+            rng.gen_range(0..100_000),
+            rng.gen_range(0..THREAD_COUNT.get()),
+        ),
         0,
         get_random_address(),
         get_random_address(),

--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -18,6 +18,7 @@ use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use std::convert::TryInto;
 use std::net::SocketAddr;
+use std::num::NonZeroU8;
 use std::thread;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -29,7 +30,7 @@ use tracing::error;
 pub struct BootstrapServerBinder {
     max_bootstrap_message_size: u32,
     max_consensus_block_ids: u64,
-    thread_count: u8,
+    thread_count: NonZeroU8,
     max_datastore_key_length: u8,
     randomness_size_bytes: usize,
     size_field_len: usize,

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -4,7 +4,7 @@ use massa_models::block::BlockDeserializerArgs;
 use massa_models::node::NodeId;
 use massa_time::MassaTime;
 use serde::Deserialize;
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, num::NonZeroU8, path::PathBuf};
 
 use substruct::SubStruct;
 
@@ -64,7 +64,7 @@ pub struct BootstrapConfig {
     /// max bootstrap message size in bytes
     pub max_bootstrap_message_size: u32,
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// period per cycle
     pub periods_per_cycle: u64,
     /// max datastore key length
@@ -130,7 +130,7 @@ pub struct BootstrapConfig {
 pub struct BootstrapSrvBindCfg {
     pub max_bytes_read_write: f64,
     pub max_bootstrap_message_size: u32,
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     pub max_datastore_key_length: u8,
     pub randomness_size_bytes: usize,
     pub consensus_bootstrap_part_size: u64,
@@ -148,7 +148,7 @@ pub struct BootstrapClientConfig {
     pub max_advertise_length: u32,
     pub max_bootstrap_blocks_length: u32,
     pub max_operations_per_block: u32,
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     pub randomness_size_bytes: usize,
     pub max_bootstrap_error_length: u64,
     pub max_bootstrap_final_state_parts_size: u64,
@@ -172,7 +172,7 @@ pub struct BootstrapClientConfig {
 #[derive(SubStruct)]
 #[parent(type = "BootstrapClientConfig")]
 pub struct BootstrapServerMessageDeserializerArgs {
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     pub endorsement_count: u32,
     pub max_advertise_length: u32,
     pub max_bootstrap_blocks_length: u32,

--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -60,7 +60,7 @@ lazy_static::lazy_static! {
 #[tokio::test]
 #[serial]
 async fn test_bootstrap_server() {
-    let thread_count = 2;
+    let thread_count = 2.try_into().unwrap();
     let periods_per_cycle = 2;
     let (bootstrap_config, keypair): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
     let rolls_path = PathBuf::from_str("../massa-node/base_config/initial_rolls.json").unwrap();

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -389,7 +389,7 @@ pub fn get_boot_state() -> BootstrapableGraph {
                     // associated slot
                     // all header endorsements are supposed to point towards this one
                     slot: Slot::new(1, 0),
-                    parents: vec![get_dummy_block_id("p1"); THREAD_COUNT.get() as usize],
+                    parents: vec![get_dummy_block_id("p1"); THREAD_COUNT.get().into()],
                     operation_merkle_root: Hash::compute_from("op_hash".as_bytes()),
                     endorsements: vec![
                         Endorsement::new_verifiable(
@@ -428,7 +428,7 @@ pub fn get_boot_state() -> BootstrapableGraph {
     // TODO: We currently lost information. Need to use shared storage
     let block1 = ExportActiveBlock {
         block,
-        parents: vec![(get_dummy_block_id("b1"), 4777); THREAD_COUNT.get() as usize],
+        parents: vec![(get_dummy_block_id("b1"), 4777); THREAD_COUNT.get().into()],
         is_final: true,
     };
 

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -389,7 +389,7 @@ pub fn get_boot_state() -> BootstrapableGraph {
                     // associated slot
                     // all header endorsements are supposed to point towards this one
                     slot: Slot::new(1, 0),
-                    parents: vec![get_dummy_block_id("p1"); THREAD_COUNT as usize],
+                    parents: vec![get_dummy_block_id("p1"); THREAD_COUNT.get() as usize],
                     operation_merkle_root: Hash::compute_from("op_hash".as_bytes()),
                     endorsements: vec![
                         Endorsement::new_verifiable(
@@ -428,7 +428,7 @@ pub fn get_boot_state() -> BootstrapableGraph {
     // TODO: We currently lost information. Need to use shared storage
     let block1 = ExportActiveBlock {
         block,
-        parents: vec![(get_dummy_block_id("b1"), 4777); THREAD_COUNT as usize],
+        parents: vec![(get_dummy_block_id("b1"), 4777); THREAD_COUNT.get() as usize],
         is_final: true,
     };
 

--- a/massa-consensus-exports/src/bootstrapable_graph.rs
+++ b/massa-consensus-exports/src/bootstrapable_graph.rs
@@ -106,7 +106,7 @@ impl Deserializer<BootstrapableGraph> for BootstrapableGraphDeserializer {
     /// let mut buffer = Vec::new();
     /// BootstrapableGraphSerializer::new().serialize(&bootstrapable_graph, &mut buffer).unwrap();
     /// let args = BlockDeserializerArgs {
-    /// thread_count: 32,max_operations_per_block: 16,endorsement_count: 10,};
+    /// thread_count: 32.try_into().unwrap(),max_operations_per_block: 16,endorsement_count: 10,};
     /// let (rest, bootstrapable_graph_deserialized) = BootstrapableGraphDeserializer::new(args, 10).deserialize::<DeserializeError>(&buffer).unwrap();
     /// let mut buffer2 = Vec::new();
     /// BootstrapableGraphSerializer::new().serialize(&bootstrapable_graph_deserialized, &mut buffer2).unwrap();

--- a/massa-consensus-exports/src/export_active_block.rs
+++ b/massa-consensus-exports/src/export_active_block.rs
@@ -73,7 +73,7 @@ impl ExportActiveBlock {
             creator_address: self.block.content_creator_address,
             block_id: self.block.id,
             parents: self.parents.clone(),
-            children: vec![PreHashMap::default(); thread_count.get() as usize], // will be computed once the full graph is available
+            children: vec![PreHashMap::default(); thread_count.get().into()], // will be computed once the full graph is available
             descendants: Default::default(), // will be computed once the full graph is available
             is_final: self.is_final,
             slot: self.block.content.header.content.slot,

--- a/massa-consensus-exports/src/settings.rs
+++ b/massa-consensus-exports/src/settings.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use serde::{Deserialize, Serialize};
@@ -9,7 +11,7 @@ pub struct ConsensusConfig {
     /// Delta time between two period
     pub t0: MassaTime,
     /// Number of threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// Keypair to sign genesis blocks.
     pub genesis_key: KeyPair,
     /// Maximum number of blocks allowed in discarded blocks.

--- a/massa-consensus-worker/src/state/mod.rs
+++ b/massa-consensus-worker/src/state/mod.rs
@@ -223,7 +223,8 @@ impl ConsensusState {
         &self,
         slot: Slot,
     ) -> Result<Vec<(BlockId, u64)>, ConsensusError> {
-        let mut latest: Vec<Option<(BlockId, u64)>> = vec![None; self.config.thread_count as usize];
+        let mut latest: Vec<Option<(BlockId, u64)>> =
+            vec![None; self.config.thread_count.get() as usize];
         for id in self.active_index.iter() {
             let (block, _storage) = self.try_get_full_active_block(id)?;
             if let Some((_, p)) = latest[block.slot.thread as usize] && block.slot.period < p {
@@ -256,7 +257,7 @@ impl ConsensusState {
         end_slot: Option<Slot>,
     ) -> Result<Vec<(BlockId, u64)>, ConsensusError> {
         let mut earliest: Vec<Option<(BlockId, u64)>> =
-            vec![None; self.config.thread_count as usize];
+            vec![None; self.config.thread_count.get() as usize];
         for id in block_ids {
             let (block, _storage) = self.try_get_full_active_block(id)?;
             if let Some(slot) = end_slot && block.slot > slot {

--- a/massa-consensus-worker/src/state/mod.rs
+++ b/massa-consensus-worker/src/state/mod.rs
@@ -224,7 +224,7 @@ impl ConsensusState {
         slot: Slot,
     ) -> Result<Vec<(BlockId, u64)>, ConsensusError> {
         let mut latest: Vec<Option<(BlockId, u64)>> =
-            vec![None; self.config.thread_count.get() as usize];
+            vec![None; self.config.thread_count.get().into()];
         for id in self.active_index.iter() {
             let (block, _storage) = self.try_get_full_active_block(id)?;
             if let Some((_, p)) = latest[block.slot.thread as usize] && block.slot.period < p {
@@ -257,7 +257,7 @@ impl ConsensusState {
         end_slot: Option<Slot>,
     ) -> Result<Vec<(BlockId, u64)>, ConsensusError> {
         let mut earliest: Vec<Option<(BlockId, u64)>> =
-            vec![None; self.config.thread_count.get() as usize];
+            vec![None; self.config.thread_count.get().into()];
         for id in block_ids {
             let (block, _storage) = self.try_get_full_active_block(id)?;
             if let Some(slot) = end_slot && block.slot > slot {

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -508,7 +508,7 @@ impl ConsensusState {
                     parents: parents_hash_period.clone(),
                     descendants: PreHashSet::<BlockId>::default(),
                     block_id: add_block_id,
-                    children: vec![Default::default(); self.config.thread_count.get() as usize],
+                    children: vec![Default::default(); self.config.thread_count.get().into()],
                     is_final: false,
                     slot: add_block_slot,
                     fitness,

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -508,7 +508,7 @@ impl ConsensusState {
                     parents: parents_hash_period.clone(),
                     descendants: PreHashSet::<BlockId>::default(),
                     block_id: add_block_id,
-                    children: vec![Default::default(); self.config.thread_count as usize],
+                    children: vec![Default::default(); self.config.thread_count.get() as usize],
                     is_final: false,
                     slot: add_block_slot,
                     fitness,

--- a/massa-consensus-worker/src/state/verifications.rs
+++ b/massa-consensus-worker/src/state/verifications.rs
@@ -183,7 +183,7 @@ impl ConsensusState {
 
         // check the topological consistency of the parents
         {
-            let mut gp_max_slots = vec![0u64; self.config.thread_count.get() as usize];
+            let mut gp_max_slots = vec![0u64; self.config.thread_count.get().into()];
             for parent_i in 0..self.config.thread_count.get() {
                 let (parent_h, parent_period) = parents[parent_i as usize];
                 let parent = match read_shared_state.block_statuses.get(&parent_h) {

--- a/massa-consensus-worker/src/worker/init.rs
+++ b/massa-consensus-worker/src/worker/init.rs
@@ -92,8 +92,8 @@ impl ConsensusWorker {
 
         // load genesis blocks
         let mut block_statuses = PreHashMap::default();
-        let mut genesis_block_ids = Vec::with_capacity(config.thread_count as usize);
-        for thread in 0u8..config.thread_count {
+        let mut genesis_block_ids = Vec::with_capacity(config.thread_count.get() as usize);
+        for thread in 0u8..config.thread_count.get() {
             let block = create_genesis_block(&config, thread).map_err(|err| {
                 ConsensusError::GenesisCreationError(format!("genesis error {}", err))
             })?;
@@ -106,7 +106,7 @@ impl ConsensusWorker {
                     a_block: Box::new(ActiveBlock {
                         creator_address: block.content_creator_address,
                         parents: Vec::new(),
-                        children: vec![PreHashMap::default(); config.thread_count as usize],
+                        children: vec![PreHashMap::default(); config.thread_count.get() as usize],
                         descendants: Default::default(),
                         is_final: true,
                         block_id: block.id,
@@ -151,7 +151,7 @@ impl ConsensusWorker {
         // add genesis blocks to stats
         let genesis_addr = Address::from_public_key(&config.genesis_key.get_public_key());
         let mut final_block_stats = VecDeque::new();
-        for thread in 0..config.thread_count {
+        for thread in 0..config.thread_count.get() {
             final_block_stats.push_back((
                 get_block_slot_timestamp(
                     config.thread_count,
@@ -281,7 +281,7 @@ impl ConsensusWorker {
 
                 if !a_block.is_final {
                     // note: parents of final blocks will be missing, that's ok, but it shouldn't be the case for non-finals
-                    if n_claimed_parents != self.config.thread_count as usize {
+                    if n_claimed_parents != self.config.thread_count.get() as usize {
                         return Err(ConsensusError::MissingBlock(
                             "block storage could not claim refs to all parent blocks".into(),
                         ));

--- a/massa-consensus-worker/src/worker/init.rs
+++ b/massa-consensus-worker/src/worker/init.rs
@@ -106,7 +106,7 @@ impl ConsensusWorker {
                     a_block: Box::new(ActiveBlock {
                         creator_address: block.content_creator_address,
                         parents: Vec::new(),
-                        children: vec![PreHashMap::default(); config.thread_count.get() as usize],
+                        children: vec![PreHashMap::default(); config.thread_count.get().into()],
                         descendants: Default::default(),
                         is_final: true,
                         block_id: block.id,

--- a/massa-executed-ops/src/config.rs
+++ b/massa-executed-ops/src/config.rs
@@ -1,9 +1,11 @@
 //! Copyright (c) 2022 MASSA LABS <info@massa.net>
 
+use std::num::NonZeroU8;
+
 #[derive(Debug, Clone)]
 pub struct ExecutedOpsConfig {
     /// Number of threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// Maximum size of a bootstrap part
     pub bootstrap_part_size: u64,
 }

--- a/massa-executed-ops/src/executed_ops.rs
+++ b/massa-executed-ops/src/executed_ops.rs
@@ -23,6 +23,7 @@ use nom::{
 };
 use std::{
     collections::{BTreeMap, HashMap},
+    num::NonZeroU8,
     ops::Bound::{Excluded, Included, Unbounded},
 };
 
@@ -184,7 +185,7 @@ fn test_executed_ops_xor_computing() {
 
     // initialize the executed ops config
     let config = ExecutedOpsConfig {
-        thread_count: 2,
+        thread_count: 2.try_into().unwrap(),
         bootstrap_part_size: 10,
     };
 
@@ -302,7 +303,7 @@ pub struct ExecutedOpsDeserializer {
 impl ExecutedOpsDeserializer {
     /// Create a new deserializer for `ExecutedOps`
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         max_executed_ops_length: u64,
         max_operations_per_block: u64,
     ) -> ExecutedOpsDeserializer {
@@ -310,7 +311,7 @@ impl ExecutedOpsDeserializer {
             operation_id_deserializer: OperationIdDeserializer::new(),
             slot_deserializer: SlotDeserializer::new(
                 (Included(u64::MIN), Included(u64::MAX)),
-                (Included(0), Excluded(thread_count)),
+                (Included(0), Excluded(thread_count.get())),
             ),
             ops_length_deserializer: U64VarIntDeserializer::new(
                 Included(u64::MIN),

--- a/massa-executed-ops/src/ops_changes.rs
+++ b/massa-executed-ops/src/ops_changes.rs
@@ -15,7 +15,10 @@ use nom::{
     sequence::tuple,
     IResult, Parser,
 };
-use std::ops::Bound::{Excluded, Included};
+use std::{
+    num::NonZeroU8,
+    ops::Bound::{Excluded, Included},
+};
 
 /// Speculative changes for ExecutedOps
 pub type ExecutedOpsChanges = PreHashMap<OperationId, (bool, Slot)>;
@@ -74,7 +77,10 @@ pub struct ExecutedOpsChangesDeserializer {
 
 impl ExecutedOpsChangesDeserializer {
     /// Create a new deserializer for `ExecutedOps`
-    pub fn new(thread_count: u8, max_ops_changes_length: u64) -> ExecutedOpsChangesDeserializer {
+    pub fn new(
+        thread_count: NonZeroU8,
+        max_ops_changes_length: u64,
+    ) -> ExecutedOpsChangesDeserializer {
         ExecutedOpsChangesDeserializer {
             u64_deserializer: U64VarIntDeserializer::new(
                 Included(u64::MIN),
@@ -84,7 +90,7 @@ impl ExecutedOpsChangesDeserializer {
             op_execution_deserializer: BoolDeserializer::new(),
             slot_deserializer: SlotDeserializer::new(
                 (Included(u64::MIN), Included(u64::MAX)),
-                (Included(0), Excluded(thread_count)),
+                (Included(0), Excluded(thread_count.get())),
             ),
         }
     }

--- a/massa-execution-exports/src/settings.rs
+++ b/massa-execution-exports/src/settings.rs
@@ -6,7 +6,7 @@ use massa_models::amount::Amount;
 use massa_sc_runtime::GasCosts;
 use massa_time::MassaTime;
 use num::rational::Ratio;
-use std::path::PathBuf;
+use std::{num::NonZeroU8, path::PathBuf};
 
 /// Storage cost constants
 #[derive(Debug, Clone, Copy)]
@@ -31,7 +31,7 @@ pub struct ExecutionConfig {
     /// maximum gas per block
     pub max_gas_per_block: u64,
     /// number of threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// price of a roll inside the network
     pub roll_price: Amount,
     /// extra lag to add on the execution cursor to improve performance

--- a/massa-execution-worker/src/active_history.rs
+++ b/massa-execution-worker/src/active_history.rs
@@ -6,7 +6,10 @@ use massa_models::{
     address::Address, amount::Amount, bytecode::Bytecode, operation::OperationId,
     prehash::PreHashMap, slot::Slot,
 };
-use std::collections::{HashMap, VecDeque};
+use std::{
+    collections::{HashMap, VecDeque},
+    num::NonZeroU8,
+};
 
 #[derive(Default)]
 /// History of the outputs of recently executed slots.
@@ -35,7 +38,7 @@ pub enum SlotIndexPosition {
 
 impl ActiveHistory {
     /// Remove `slot` and the slots after it from history
-    pub fn truncate_from(&mut self, slot: &Slot, thread_count: u8) {
+    pub fn truncate_from(&mut self, slot: &Slot, thread_count: NonZeroU8) {
         match self.get_slot_index(slot, thread_count) {
             SlotIndexPosition::Past => self.0.clear(),
             SlotIndexPosition::Found(index) => self.0.truncate(index),
@@ -181,7 +184,7 @@ impl ActiveHistory {
     }
 
     /// Gets the index of a slot in history
-    pub fn get_slot_index(&self, slot: &Slot, thread_count: u8) -> SlotIndexPosition {
+    pub fn get_slot_index(&self, slot: &Slot, thread_count: NonZeroU8) -> SlotIndexPosition {
         let first_slot = match self.0.front() {
             Some(itm) => &itm.slot,
             None => return SlotIndexPosition::NoHistory,
@@ -217,7 +220,7 @@ impl ActiveHistory {
         &self,
         cycle: u64,
         periods_per_cycle: u64,
-        thread_count: u8,
+        thread_count: NonZeroU8,
     ) -> (std::ops::Range<usize>, bool, bool) {
         // Get first and last slots indices of cycle in history. We consider overflows as "Future"
         let first_index = Slot::new_first_of_cycle(cycle, periods_per_cycle).map_or_else(

--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -36,6 +36,7 @@ use parking_lot::RwLock;
 use rand::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
 use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroU8;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -912,7 +913,7 @@ impl ExecutionContext {
     pub fn get_address_future_deferred_credits(
         &self,
         address: &Address,
-        thread_count: u8,
+        thread_count: NonZeroU8,
     ) -> BTreeMap<Slot, Amount> {
         let min_slot = self
             .slot

--- a/massa-execution-worker/src/interface_impl.rs
+++ b/massa-execution-worker/src/interface_impl.rs
@@ -694,10 +694,10 @@ impl Interface for InterfaceImpl {
         data: &[u8],
         filter: Option<(&str, Option<&[u8]>)>,
     ) -> Result<()> {
-        if validity_start.1 >= self.config.thread_count {
+        if validity_start.1 >= self.config.thread_count.get() {
             bail!("validity start thread exceeds the configuration thread count")
         }
-        if validity_end.1 >= self.config.thread_count {
+        if validity_end.1 >= self.config.thread_count.get() {
             bail!("validity end thread exceeds the configuration thread count")
         }
         let mut execution_context = context_guard!(self);

--- a/massa-execution-worker/src/slot_sequencer.rs
+++ b/massa-execution-worker/src/slot_sequencer.rs
@@ -72,7 +72,9 @@ impl SlotSequencer {
     pub fn new(config: ExecutionConfig, final_cursor: Slot) -> Self {
         SlotSequencer {
             sequence: Default::default(),
-            latest_css_final_slots: (0..config.thread_count).map(|t| Slot::new(0, t)).collect(),
+            latest_css_final_slots: (0..config.thread_count.get())
+                .map(|t| Slot::new(0, t))
+                .collect(),
             latest_sce_final_slot: final_cursor,
             latest_executed_final_slot: final_cursor,
             latest_executed_candidate_slot: final_cursor,
@@ -731,7 +733,7 @@ impl SlotSequencer {
                 .saturating_add(
                     self.config
                         .t0
-                        .checked_div_u64(self.config.thread_count as u64)
+                        .checked_div_u64(self.config.thread_count.get() as u64)
                         .unwrap(),
                 );
         }

--- a/massa-execution-worker/src/speculative_roll_state.rs
+++ b/massa-execution-worker/src/speculative_roll_state.rs
@@ -11,6 +11,7 @@ use massa_pos_exports::{DeferredCredits, PoSChanges, ProductionStats};
 use num::rational::Ratio;
 use parking_lot::RwLock;
 use std::collections::{BTreeMap, HashMap};
+use std::num::NonZeroU8;
 use std::sync::Arc;
 
 /// Speculative state of the rolls
@@ -104,7 +105,7 @@ impl SpeculativeRollState {
         slot: Slot,
         roll_count: u64,
         periods_per_cycle: u64,
-        thread_count: u8,
+        thread_count: NonZeroU8,
         roll_price: Amount,
     ) -> Result<(), ExecutionError> {
         // fetch the roll count from: current changes > active history > final state
@@ -186,7 +187,7 @@ impl SpeculativeRollState {
         &mut self,
         slot: &Slot,
         periods_per_cycle: u64,
-        thread_count: u8,
+        thread_count: NonZeroU8,
         roll_price: Amount,
         max_miss_ratio: Ratio<u64>,
     ) {
@@ -423,7 +424,7 @@ impl SpeculativeRollState {
         &self,
         cycle: u64,
         periods_per_cycle: u64,
-        thread_count: u8,
+        thread_count: NonZeroU8,
         cur_slot: &Slot,
     ) -> (PreHashMap<Address, ProductionStats>, bool) {
         let mut accumulated_stats: PreHashMap<Address, ProductionStats> = Default::default();

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -130,7 +130,7 @@ mod tests {
         let genesis_keypair = KeyPair::generate();
         let mut finalized_blocks: HashMap<Slot, BlockId> = HashMap::new();
         let mut block_storage: PreHashMap<BlockId, Storage> = PreHashMap::default();
-        for thread in 0..config.thread_count {
+        for thread in 0..config.thread_count.get() {
             let slot = Slot::new(0, thread);
             let final_block = create_block(genesis_keypair.clone(), vec![], slot).unwrap();
             finalized_blocks.insert(slot, final_block.id);
@@ -1253,7 +1253,7 @@ mod tests {
         let mut exec_cfg = ExecutionConfig {
             t0: 100.into(),
             periods_per_cycle: 2,
-            thread_count: 2,
+            thread_count: 2.try_into().unwrap(),
             cursor_delay: 0.into(),
             initial_vesting_path: vesting.path().to_path_buf(),
             ..Default::default()

--- a/massa-factory-exports/src/config.rs
+++ b/massa-factory-exports/src/config.rs
@@ -2,13 +2,15 @@
 
 //! This file defines the factory settings
 
+use std::num::NonZeroU8;
+
 use massa_time::MassaTime;
 
 /// Structure defining the settings of the factory
 #[derive(Debug, Clone)]
 pub struct FactoryConfig {
     /// number of threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
 
     /// genesis timestamp
     pub genesis_timestamp: MassaTime,

--- a/massa-factory-worker/src/tests/tools.rs
+++ b/massa-factory-worker/src/tests/tools.rs
@@ -66,7 +66,7 @@ impl TestFactory {
         let mut accounts = PreHashMap::default();
 
         let mut genesis_blocks = vec![];
-        for i in 0..factory_config.thread_count {
+        for i in 0..factory_config.thread_count.get() {
             let block = create_empty_block(producer_keypair, &Slot::new(0, i));
             genesis_blocks.push((block.id, 0));
             storage.store_block(block);

--- a/massa-final-state/src/config.rs
+++ b/massa-final-state/src/config.rs
@@ -6,7 +6,7 @@ use massa_async_pool::AsyncPoolConfig;
 use massa_executed_ops::ExecutedOpsConfig;
 use massa_ledger_exports::LedgerConfig;
 use massa_pos_exports::PoSConfig;
-use std::path::PathBuf;
+use std::{num::NonZeroU8, path::PathBuf};
 
 /// Ledger configuration
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ pub struct FinalStateConfig {
     /// final changes history length
     pub final_history_length: usize,
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// periods per cycle
     pub periods_per_cycle: u64,
     /// initial PoS seed string

--- a/massa-final-state/src/final_state.rs
+++ b/massa-final-state/src/final_state.rs
@@ -59,7 +59,7 @@ impl FinalState {
         .map_err(|err| FinalStateError::PosError(format!("PoS final state init error: {}", err)))?;
 
         // attach at the output of the latest initial final slot, that is the last genesis slot
-        let slot = Slot::new(0, config.thread_count.saturating_sub(1));
+        let slot = Slot::new(0, config.thread_count.get() - 1);
 
         // create the async pool
         let async_pool = AsyncPool::new(config.async_pool_config.clone());
@@ -84,7 +84,7 @@ impl FinalState {
     ///
     /// USED ONLY FOR BOOTSTRAP
     pub fn reset(&mut self) {
-        self.slot = Slot::new(0, self.config.thread_count.saturating_sub(1));
+        self.slot = Slot::new(0, self.config.thread_count.get() - 1);
         self.ledger.reset();
         self.async_pool.reset();
         self.pos_state.reset();

--- a/massa-final-state/src/state_changes.rs
+++ b/massa-final-state/src/state_changes.rs
@@ -2,6 +2,8 @@
 
 //! This file provides structures representing changes to the final state
 
+use std::num::NonZeroU8;
+
 use massa_async_pool::{
     AsyncPoolChanges, AsyncPoolChangesDeserializer, AsyncPoolChangesSerializer,
 };
@@ -127,7 +129,7 @@ impl StateChangesDeserializer {
     /// Creates a `StateChangesDeserializer`
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         max_async_pool_changes: u64,
         max_async_message_data: u64,
         max_ledger_changes_count: u64,
@@ -210,7 +212,7 @@ impl Deserializer<StateChanges> for StateChangesDeserializer {
     /// state_changes.ledger_changes = ledger_changes;
     /// let mut serialized = Vec::new();
     /// StateChangesSerializer::new().serialize(&state_changes, &mut serialized).unwrap();
-    /// let (rest, state_changes_deser) = StateChangesDeserializer::new(32, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255).deserialize::<DeserializeError>(&serialized).unwrap();
+    /// let (rest, state_changes_deser) = StateChangesDeserializer::new(32.try_into().unwrap(), 255, 255, 255, 255, 255, 255, 255, 255, 255, 255).deserialize::<DeserializeError>(&serialized).unwrap();
     /// assert!(rest.is_empty());
     /// assert_eq!(state_changes_deser.ledger_changes, state_changes.ledger_changes);
     /// assert_eq!(state_changes_deser.async_pool_changes, state_changes.async_pool_changes);

--- a/massa-final-state/src/test_exports/config.rs
+++ b/massa-final-state/src/test_exports/config.rs
@@ -52,7 +52,7 @@ impl Default for FinalStateConfig {
                 credits_bootstrap_part_size: DEFERRED_CREDITS_BOOTSTRAP_PART_SIZE,
             },
             final_history_length: 10,
-            thread_count: 2,
+            thread_count: 2.try_into().unwrap(),
             periods_per_cycle: 100,
             initial_rolls_path: PathBuf::new(),
             initial_seed_string: "".to_string(),

--- a/massa-ledger-exports/src/config.rs
+++ b/massa-ledger-exports/src/config.rs
@@ -2,13 +2,13 @@
 
 //! This file defines a configuration structure containing all settings for the ledger system
 
-use std::path::PathBuf;
+use std::{num::NonZeroU8, path::PathBuf};
 
 /// Ledger configuration
 #[derive(Debug, Clone)]
 pub struct LedgerConfig {
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// initial SCE ledger file
     pub initial_ledger_path: PathBuf,
     /// disk ledger db directory

--- a/massa-models/src/address.rs
+++ b/massa-models/src/address.rs
@@ -13,6 +13,7 @@ use nom::error::{context, ContextError, ParseError};
 use nom::sequence::preceded;
 use nom::{IResult, Parser};
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU8;
 use std::ops::Bound::Included;
 use std::str::FromStr;
 
@@ -211,9 +212,9 @@ impl PreHashed for Address {}
 
 impl Address {
     /// Gets the associated thread. Depends on the `thread_count`
-    pub fn get_thread(&self, thread_count: u8) -> u8 {
+    pub fn get_thread(&self, thread_count: NonZeroU8) -> u8 {
         (self.hash_bytes()[0])
-            .checked_shr(8 - thread_count.trailing_zeros())
+            .checked_shr(8 - thread_count.get().trailing_zeros())
             .unwrap_or(0)
     }
 

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -39,6 +39,7 @@ use serde::{Deserialize, Serialize};
 // use std::collections::HashSet;
 // use std::convert::TryInto;
 use std::fmt::Formatter;
+use std::num::NonZeroU8;
 // use std::ops::Bound::{Excluded, Included};
 // use std::str::FromStr;
 use crate::block_header::{BlockHeader, BlockHeaderDeserializer, SecuredHeader};
@@ -151,7 +152,7 @@ impl Serializer<Block> for BlockSerializer {
     /// use massa_signature::KeyPair;
     /// use massa_serialization::{Serializer, Deserializer, DeserializeError};
     /// let keypair = KeyPair::generate();
-    /// let parents = (0..THREAD_COUNT)
+    /// let parents = (0..THREAD_COUNT.get())
     ///     .map(|i| BlockId(Hash::compute_from(&[i])))
     ///     .collect();
     ///
@@ -209,7 +210,7 @@ impl Serializer<Block> for BlockSerializer {
 ///
 pub struct BlockDeserializerArgs {
     ///
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     ///
     pub max_operations_per_block: u32,
     ///
@@ -246,7 +247,7 @@ impl Deserializer<Block> for BlockDeserializer {
     /// use massa_signature::KeyPair;
     /// use massa_serialization::{Serializer, Deserializer, DeserializeError};
     /// let keypair = KeyPair::generate();
-    /// let parents: Vec<BlockId> = (0..THREAD_COUNT)
+    /// let parents: Vec<BlockId> = (0..THREAD_COUNT.get())
     ///     .map(|i| BlockId(Hash::compute_from(&[i])))
     ///     .collect();
     ///
@@ -418,7 +419,7 @@ mod test {
     fn test_block_serialization() {
         let keypair =
             KeyPair::from_str("S1bXjyPwrssNmG4oUG5SEqaUhQkVArQi7rzQDWpCprTSmEgZDGG").unwrap();
-        let parents = (0..THREAD_COUNT)
+        let parents = (0..THREAD_COUNT.get())
             .map(|_i| {
                 BlockId(
                     Hash::from_bs58_check("bq1NsaCBAfseMKSjNBYLhpK7M5eeef2m277MYS2P2k424GaDf")
@@ -661,7 +662,7 @@ mod test {
     #[serial]
     fn test_invalid_genesis_block_serialization_with_parents() {
         let keypair = KeyPair::generate();
-        let parents = (0..THREAD_COUNT)
+        let parents = (0..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i])))
             .collect();
 
@@ -758,7 +759,7 @@ mod test {
     fn test_invalid_block_serialization_obo_high_parent_count() {
         let keypair = KeyPair::generate();
         // Non genesis block must have THREAD_COUNT parents
-        let parents = (0..=THREAD_COUNT)
+        let parents = (0..=THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i])))
             .collect();
 
@@ -812,7 +813,7 @@ mod test {
         let endorsed = BlockId(
             Hash::from_bs58_check("bq1NsaCBAfseMKSjNBYLhpK7M5eeef2m277MYS2P2k424GaDf").unwrap(),
         );
-        let fillers = (1..THREAD_COUNT).map(|i| BlockId(Hash::compute_from(&[i])));
+        let fillers = (1..THREAD_COUNT.get()).map(|i| BlockId(Hash::compute_from(&[i])));
         let parents = std::iter::once(endorsed).chain(fillers).collect();
 
         let endorsements = (0..ENDORSEMENT_COUNT)
@@ -879,7 +880,7 @@ mod test {
     fn test_invalid_block_serialization_obo_low_parent_count() {
         let keypair = KeyPair::generate();
         // Non genesis block must have THREAD_COUNT parents
-        let parents = (1..THREAD_COUNT)
+        let parents = (1..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i])))
             .collect();
 
@@ -929,7 +930,7 @@ mod test {
     fn test_invalid_block_serialization_obo_high_endo_count() {
         let keypair = KeyPair::generate();
         // Non genesis block must have THREAD_COUNT parents
-        let parents = (0..THREAD_COUNT)
+        let parents = (0..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i])))
             .collect();
 
@@ -993,7 +994,7 @@ mod test {
     fn test_invalid_endorsement_idx() {
         let keypair =
             KeyPair::from_str("S1bXjyPwrssNmG4oUG5SEqaUhQkVArQi7rzQDWpCprTSmEgZDGG").unwrap();
-        let parents = (0..THREAD_COUNT)
+        let parents = (0..THREAD_COUNT.get())
             .map(|_i| {
                 BlockId(
                     Hash::from_bs58_check("bq1NsaCBAfseMKSjNBYLhpK7M5eeef2m277MYS2P2k424GaDf")
@@ -1061,7 +1062,7 @@ mod test {
     fn test_invalid_dupe_endo_idx() {
         let keypair =
             KeyPair::from_str("S1bXjyPwrssNmG4oUG5SEqaUhQkVArQi7rzQDWpCprTSmEgZDGG").unwrap();
-        let parents = (0..THREAD_COUNT)
+        let parents = (0..THREAD_COUNT.get())
             .map(|_i| {
                 BlockId(
                     Hash::from_bs58_check("bq1NsaCBAfseMKSjNBYLhpK7M5eeef2m277MYS2P2k424GaDf")

--- a/massa-models/src/config/compact_config.rs
+++ b/massa-models/src/config/compact_config.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::amount::Amount;
 use massa_time::MassaTime;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
+use std::{fmt::Display, num::NonZeroU8};
 
 /// Compact representation of key values of consensus algorithm used in API
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
@@ -12,7 +12,7 @@ pub struct CompactConfig {
     /// TESTNET: time when the blockclique is ended.
     pub end_timestamp: Option<MassaTime>,
     /// Number of threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// Time between the periods in the same thread.
     pub t0: MassaTime,
     /// Threshold for fitness.

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -13,7 +13,7 @@
 //!
 //! A parallel file with the same constant definitions exist for the testing case.
 //! (`default_testing.rs`) But as for the current file you shouldn't modify it.
-use std::str::FromStr;
+use std::{num::NonZeroU8, str::FromStr};
 
 use crate::{address::ADDRESS_SIZE_BYTES, amount::Amount, version::Version};
 use massa_signature::KeyPair;
@@ -86,7 +86,9 @@ pub const T0: MassaTime = MassaTime::from_millis(16000);
 /// Proof of stake seed for the initial draw
 pub const INITIAL_DRAW_SEED: &str = "massa_genesis_seed";
 /// Number of threads
-pub const THREAD_COUNT: u8 = 32;
+/// # Safety
+/// This is guaranteed to be safe if the value is non-zero
+pub const THREAD_COUNT: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(32) };
 /// Number of endorsement
 pub const ENDORSEMENT_COUNT: u32 = 16;
 /// Threshold for fitness.
@@ -155,7 +157,8 @@ pub const MAX_FUNCTION_NAME_LENGTH: u16 = u16::MAX;
 /// Maximum size of parameters in call SC
 pub const MAX_PARAMETERS_SIZE: u32 = 10_000_000;
 /// Maximum length of `rng_seed` in thread cycle
-pub const MAX_RNG_SEED_LENGTH: u32 = PERIODS_PER_CYCLE.saturating_mul(THREAD_COUNT as u64) as u32;
+pub const MAX_RNG_SEED_LENGTH: u32 =
+    PERIODS_PER_CYCLE.saturating_mul(THREAD_COUNT.get() as u64) as u32;
 // ***********************
 // Bootstrap constants
 //
@@ -229,7 +232,7 @@ pub const VERSIONING_THRESHOLD_TRANSITION_ACCEPTED: Amount = Amount::from_mantis
 // Some checks at compile time that should not be ignored!
 #[allow(clippy::assertions_on_constants)]
 const _: () = {
-    assert!(THREAD_COUNT > 1);
+    assert!(THREAD_COUNT.get() > 1);
     assert!((T0).to_millis() >= 1);
-    assert!((T0).to_millis() % (THREAD_COUNT as u64) == 0);
+    assert!((T0).to_millis() % (THREAD_COUNT.get() as u64) == 0);
 };

--- a/massa-models/src/denunciation.rs
+++ b/massa-models/src/denunciation.rs
@@ -497,13 +497,13 @@ mod tests {
         let keypair = KeyPair::generate();
 
         let slot = Slot::new(2, 1);
-        let parents_1: Vec<BlockId> = (0..THREAD_COUNT)
+        let parents_1: Vec<BlockId> = (0..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i])))
             .collect();
-        let parents_2: Vec<BlockId> = (0..THREAD_COUNT)
+        let parents_2: Vec<BlockId> = (0..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i + 1])))
             .collect();
-        let parents_3: Vec<BlockId> = (0..THREAD_COUNT)
+        let parents_3: Vec<BlockId> = (0..THREAD_COUNT.get())
             .map(|i| BlockId(Hash::compute_from(&[i + 2])))
             .collect();
 

--- a/massa-models/src/endorsement.rs
+++ b/massa-models/src/endorsement.rs
@@ -19,6 +19,7 @@ use nom::{
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::num::NonZeroU8;
 use std::ops::Bound::{Excluded, Included};
 use std::{fmt::Display, str::FromStr};
 
@@ -154,7 +155,7 @@ impl SecureShareEndorsement {
         if let Err(e) = self.verify_signature() {
             return Err(e.into());
         }
-        if self.content.slot.thread >= crate::config::THREAD_COUNT {
+        if self.content.slot.thread >= crate::config::THREAD_COUNT.get() {
             Err("Endorsement slot on non-existant thread".into())
         } else if self.content.index >= crate::config::ENDORSEMENT_COUNT {
             Err("Endorsement index out of range".into())
@@ -238,11 +239,11 @@ pub struct EndorsementDeserializer {
 
 impl EndorsementDeserializer {
     /// Creates a new `EndorsementDeserializer`
-    pub const fn new(thread_count: u8, endorsement_count: u32) -> Self {
+    pub const fn new(thread_count: NonZeroU8, endorsement_count: u32) -> Self {
         EndorsementDeserializer {
             slot_deserializer: SlotDeserializer::new(
                 (Included(0), Included(u64::MAX)),
-                (Included(0), Excluded(thread_count)),
+                (Included(0), Excluded(thread_count.get())),
             ),
             index_deserializer: U32VarIntDeserializer::new(
                 Included(0),
@@ -267,7 +268,7 @@ impl Deserializer<Endorsement> for EndorsementDeserializer {
     /// };
     /// let mut buffer = Vec::new();
     /// EndorsementSerializer::new().serialize(&endorsement, &mut buffer).unwrap();
-    /// let (rest, deserialized) = EndorsementDeserializer::new(32, 10).deserialize::<DeserializeError>(&buffer).unwrap();
+    /// let (rest, deserialized) = EndorsementDeserializer::new(32.try_into().unwrap(), 10).deserialize::<DeserializeError>(&buffer).unwrap();
     /// assert_eq!(rest.len(), 0);
     /// assert_eq!(deserialized.slot, endorsement.slot);
     /// assert_eq!(deserialized.index, endorsement.index);
@@ -449,7 +450,7 @@ mod tests {
             .serialize(&endorsement, &mut ser_endorsement)
             .unwrap();
         let (_, res_endorsement): (&[u8], SecureShareEndorsement) =
-            SecureShareDeserializer::new(EndorsementDeserializer::new(32, 1))
+            SecureShareDeserializer::new(EndorsementDeserializer::new(32.try_into().unwrap(), 1))
                 .deserialize::<DeserializeError>(&ser_endorsement)
                 .unwrap();
         assert_eq!(res_endorsement, endorsement);

--- a/massa-models/src/secure_share.rs
+++ b/massa-models/src/secure_share.rs
@@ -346,7 +346,7 @@ where
     /// ).unwrap();
     /// let mut serialized_data = Vec::new();
     /// let serialized = SecureShareSerializer::new().serialize(&secured, &mut serialized_data).unwrap();
-    /// let deserializer = SecureShareDeserializer::new(EndorsementDeserializer::new(32, 1));
+    /// let deserializer = SecureShareDeserializer::new(EndorsementDeserializer::new(32.try_into().unwrap(), 1));
     /// let (rest, deserialized): (&[u8], SecureShare<Endorsement, BlockId>) = deserializer.deserialize::<DeserializeError>(&serialized_data).unwrap();
     /// assert!(rest.is_empty());
     /// assert_eq!(secured.id, deserialized.id);

--- a/massa-models/src/slot.rs
+++ b/massa-models/src/slot.rs
@@ -178,7 +178,7 @@ impl Slot {
             .ok_or(ModelsError::PeriodOverflowError)?;
         Ok(Slot {
             period,
-            thread: thread_count - 1,
+            thread: thread_count.saturating_sub(1),
         })
     }
 
@@ -202,7 +202,7 @@ impl Slot {
     pub const fn max(thread_count: u8) -> Slot {
         Slot {
             period: u64::MAX,
-            thread: thread_count,
+            thread: thread_count.saturating_sub(1),
         }
     }
 

--- a/massa-models/src/test_exports/tools.rs
+++ b/massa-models/src/test_exports/tools.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use massa_time::MassaTime;
 
 use crate::timeslots::{get_block_slot_timestamp, get_closest_slot_to_timestamp};
@@ -5,7 +7,7 @@ use crate::timeslots::{get_block_slot_timestamp, get_closest_slot_to_timestamp};
 /// Gets the instant of the next slot.
 pub fn get_next_slot_instant(
     genesis_timestamp: MassaTime,
-    thread_count: u8,
+    thread_count: NonZeroU8,
     t0: MassaTime,
 ) -> MassaTime {
     // get current time

--- a/massa-network-exports/src/settings.rs
+++ b/massa-network-exports/src/settings.rs
@@ -3,7 +3,10 @@
 use enum_map::EnumMap;
 use massa_time::MassaTime;
 use serde::Deserialize;
-use std::net::{IpAddr, SocketAddr};
+use std::{
+    net::{IpAddr, SocketAddr},
+    num::NonZeroU8,
+};
 
 use crate::peers::PeerType;
 
@@ -63,7 +66,7 @@ pub struct NetworkConfig {
     /// Max operations per block
     pub max_operations_per_block: u32,
     /// Thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// Endorsement count
     pub endorsement_count: u32,
     /// Max peer advertise length

--- a/massa-network-worker/src/messages.rs
+++ b/massa-network-worker/src/messages.rs
@@ -30,8 +30,8 @@ use nom::{
 };
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
 use std::ops::Bound::{Excluded, Included};
+use std::{net::IpAddr, num::NonZeroU8};
 
 /// All messages that can be sent or received.
 #[allow(clippy::large_enum_variant)]
@@ -269,7 +269,7 @@ impl MessageDeserializer {
     /// Creates a new `MessageDeserializer`.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         endorsement_count: u32,
         max_advertise_length: u32,
         max_ask_block: u32,

--- a/massa-pool-exports/src/config.rs
+++ b/massa-pool-exports/src/config.rs
@@ -1,5 +1,7 @@
 //! Copyright (c) 2022 MASSA LABS <info@massa.net>
 
+use std::num::NonZeroU8;
+
 use massa_models::amount::Amount;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone, Copy)]
 pub struct PoolConfig {
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// maximal total block operations size
     pub max_block_size: u32,
     /// maximal gas per block

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -31,9 +31,9 @@ pub struct EndorsementPool {
 impl EndorsementPool {
     pub fn init(config: PoolConfig, storage: &Storage) -> Self {
         EndorsementPool {
-            last_cs_final_periods: vec![0u64; config.thread_count as usize],
+            last_cs_final_periods: vec![0u64; config.thread_count.get() as usize],
             endorsements_indexed: Default::default(),
-            endorsements_sorted: vec![Default::default(); config.thread_count as usize],
+            endorsements_sorted: vec![Default::default(); config.thread_count.get() as usize],
             config,
             storage: storage.clone_without_refs(),
         }
@@ -56,7 +56,7 @@ impl EndorsementPool {
 
         // remove all endorsements whose periods <= last_cs_final_periods[endorsement.thread]
         let mut removed: PreHashSet<EndorsementId> = Default::default();
-        for thread in 0..self.config.thread_count {
+        for thread in 0..self.config.thread_count.get() {
             while let Some((&(inclusion_slot, index, block_id), &endo_id)) =
                 self.endorsements_sorted[thread as usize].first_key_value()
             {
@@ -120,7 +120,7 @@ impl EndorsementPool {
         }
 
         // prune excess endorsements
-        for thread in 0..self.config.thread_count {
+        for thread in 0..self.config.thread_count.get() {
             while self.endorsements_sorted[thread as usize].len()
                 > self.config.max_endorsements_pool_size_per_thread
             {

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -31,9 +31,9 @@ pub struct EndorsementPool {
 impl EndorsementPool {
     pub fn init(config: PoolConfig, storage: &Storage) -> Self {
         EndorsementPool {
-            last_cs_final_periods: vec![0u64; config.thread_count.get() as usize],
+            last_cs_final_periods: vec![0u64; config.thread_count.get().into()],
             endorsements_indexed: Default::default(),
-            endorsements_sorted: vec![Default::default(); config.thread_count.get() as usize],
+            endorsements_sorted: vec![Default::default(); config.thread_count.get().into()],
             config,
             storage: storage.clone_without_refs(),
         }

--- a/massa-pool-worker/src/operation_pool.rs
+++ b/massa-pool-worker/src/operation_pool.rs
@@ -50,9 +50,9 @@ impl OperationPool {
     ) -> Self {
         OperationPool {
             operations: Default::default(),
-            sorted_ops_per_thread: vec![Default::default(); config.thread_count as usize],
+            sorted_ops_per_thread: vec![Default::default(); config.thread_count.get() as usize],
             ops_per_expiration: Default::default(),
-            last_cs_final_periods: vec![0u64; config.thread_count as usize],
+            last_cs_final_periods: vec![0u64; config.thread_count.get() as usize],
             config,
             storage: storage.clone_without_refs(),
             execution_controller,

--- a/massa-pool-worker/src/operation_pool.rs
+++ b/massa-pool-worker/src/operation_pool.rs
@@ -50,9 +50,9 @@ impl OperationPool {
     ) -> Self {
         OperationPool {
             operations: Default::default(),
-            sorted_ops_per_thread: vec![Default::default(); config.thread_count.get() as usize],
+            sorted_ops_per_thread: vec![Default::default(); config.thread_count.get().into()],
             ops_per_expiration: Default::default(),
-            last_cs_final_periods: vec![0u64; config.thread_count.get() as usize],
+            last_cs_final_periods: vec![0u64; config.thread_count.get().into()],
             config,
             storage: storage.clone_without_refs(),
             execution_controller,

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -62,7 +62,7 @@ fn test_pool() {
         pool_config,
         |mut pool_manager, mut pool, execution_receiver, storage_base| {
             // generate (id, transactions, range of validity) by threads
-            let mut thread_tx_lists = vec![Vec::new(); pool_config.thread_count.get() as usize];
+            let mut thread_tx_lists = vec![Vec::new(); pool_config.thread_count.get().into()];
 
             let mut storage = storage_base.clone_without_refs();
             for i in 0..18 {

--- a/massa-pool-worker/src/types.rs
+++ b/massa-pool-worker/src/types.rs
@@ -4,8 +4,8 @@ use massa_models::{
     operation::{OperationId, SecureShareOperation},
 };
 use num::rational::Ratio;
-use std::cmp::Reverse;
 use std::ops::RangeInclusive;
+use std::{cmp::Reverse, num::NonZeroU8};
 
 pub type OperationCursorInner = (Reverse<Ratio<u64>>, OperationId);
 /// A cursor for pool operations, sorted by increasing quality
@@ -43,7 +43,7 @@ impl OperationInfo {
         op: &SecureShareOperation,
         operation_validity_periods: u64,
         roll_price: Amount,
-        thread_count: u8,
+        thread_count: NonZeroU8,
     ) -> Self {
         OperationInfo {
             id: op.id,

--- a/massa-pos-exports/src/config.rs
+++ b/massa-pos-exports/src/config.rs
@@ -1,12 +1,14 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
+use std::num::NonZeroU8;
+
 /// proof-of-stake final state configuration
 #[derive(Debug, Clone)]
 pub struct PoSConfig {
     /// periods per cycle
     pub periods_per_cycle: u64,
     /// thread count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// number of saved cycle
     pub cycle_history_length: usize,
     /// maximum size of a deferred credits bootstrap part

--- a/massa-pos-exports/src/cycle_info.rs
+++ b/massa-pos-exports/src/cycle_info.rs
@@ -21,8 +21,8 @@ use nom::{
 };
 use num::rational::Ratio;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::ops::Bound::Included;
+use std::{collections::BTreeMap, num::NonZeroU8};
 
 use crate::PoSChanges;
 
@@ -162,10 +162,10 @@ impl CycleInfo {
         changes: PoSChanges,
         slot: Slot,
         periods_per_cycle: u64,
-        thread_count: u8,
+        thread_count: NonZeroU8,
     ) -> bool {
         let hash_computer = CycleInfoHashComputer::new();
-        let slots_per_cycle = periods_per_cycle.saturating_mul(thread_count as u64);
+        let slots_per_cycle = periods_per_cycle.saturating_mul(thread_count.get() as u64);
         let mut hash_concat: Vec<u8> = Vec::new();
 
         // compute cycle hash and concat
@@ -261,7 +261,7 @@ fn test_cycle_info_hash_computation() {
         production_stats: production_stats.clone(),
         deferred_credits: DeferredCredits::default(),
     };
-    cycle_a.apply_changes(changes, Slot::new(0, 0), 2, 2);
+    cycle_a.apply_changes(changes, Slot::new(0, 0), 2, 2.try_into().unwrap());
 
     // update changes once
     roll_changes.clear();
@@ -280,7 +280,7 @@ fn test_cycle_info_hash_computation() {
         production_stats: production_stats.clone(),
         deferred_credits: DeferredCredits::default(),
     };
-    cycle_a.apply_changes(changes, Slot::new(0, 1), 2, 2);
+    cycle_a.apply_changes(changes, Slot::new(0, 1), 2, 2.try_into().unwrap());
 
     // update changes twice
     roll_changes.clear();
@@ -299,7 +299,7 @@ fn test_cycle_info_hash_computation() {
         production_stats,
         deferred_credits: DeferredCredits::default(),
     };
-    cycle_a.apply_changes(changes, Slot::new(1, 0), 2, 2);
+    cycle_a.apply_changes(changes, Slot::new(1, 0), 2, 2.try_into().unwrap());
 
     // create a seconde cycle from same value and match hash
     let cycle_b = CycleInfo::new_with_hash(

--- a/massa-pos-exports/src/deferred_credits.rs
+++ b/massa-pos-exports/src/deferred_credits.rs
@@ -15,8 +15,8 @@ use nom::{
     IResult, Parser,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::ops::Bound::{Excluded, Included};
+use std::{collections::BTreeMap, num::NonZeroU8};
 
 const DEFERRED_CREDITS_HASH_INITIAL_BYTES: &[u8; 32] = &[0; HASH_SIZE_BYTES];
 
@@ -184,7 +184,7 @@ pub struct DeferredCreditsDeserializer {
 
 impl DeferredCreditsDeserializer {
     /// Creates a new `DeferredCredits` deserializer
-    pub fn new(thread_count: u8, max_credits_length: u64) -> DeferredCreditsDeserializer {
+    pub fn new(thread_count: NonZeroU8, max_credits_length: u64) -> DeferredCreditsDeserializer {
         DeferredCreditsDeserializer {
             u64_deserializer: U64VarIntDeserializer::new(
                 Included(u64::MIN),
@@ -192,7 +192,7 @@ impl DeferredCreditsDeserializer {
             ),
             slot_deserializer: SlotDeserializer::new(
                 (Included(0), Included(u64::MAX)),
-                (Included(0), Excluded(thread_count)),
+                (Included(0), Excluded(thread_count.get())),
             ),
             credit_deserializer: CreditsDeserializer::new(max_credits_length),
         }

--- a/massa-pos-exports/src/pos_changes.rs
+++ b/massa-pos-exports/src/pos_changes.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use crate::{
     DeferredCredits, DeferredCreditsDeserializer, DeferredCreditsSerializer, ProductionStats,
     ProductionStatsDeserializer, ProductionStatsSerializer, RollsDeserializer,
@@ -128,7 +130,7 @@ pub struct PoSChangesDeserializer {
 impl PoSChangesDeserializer {
     /// Create a new `PoSChanges` Deserializer
     pub fn new(
-        thread_count: u8,
+        thread_count: NonZeroU8,
         max_rolls_length: u64,
         max_production_stats_length: u64,
         max_credits_length: u64,

--- a/massa-pos-exports/src/pos_final_state.rs
+++ b/massa-pos-exports/src/pos_final_state.rs
@@ -79,11 +79,11 @@ impl PoSFinalState {
         let mut rng_seed = BitVec::with_capacity(
             self.config
                 .periods_per_cycle
-                .saturating_mul(self.config.thread_count as u64)
+                .saturating_mul(self.config.thread_count.get() as u64)
                 .try_into()
                 .unwrap(),
         );
-        for _ in 0..self.config.thread_count {
+        for _ in 0..self.config.thread_count.get() {
             // assume genesis blocks have a "False" seed bit to avoid passing them around
             rng_seed.push(false);
         }
@@ -167,7 +167,7 @@ impl PoSFinalState {
         let slots_per_cycle: usize = self
             .config
             .periods_per_cycle
-            .saturating_mul(self.config.thread_count as u64)
+            .saturating_mul(self.config.thread_count.get() as u64)
             .try_into()
             .unwrap();
 

--- a/massa-pos-exports/src/settings.rs
+++ b/massa-pos-exports/src/settings.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU8;
+
 use massa_models::address::Address;
 use serde::{Deserialize, Serialize};
 
@@ -5,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct SelectorConfig {
     /// Number of running threads
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// Number of endorsement
     pub endorsement_count: u32,
     /// Maximum number of computed cycle's draws we keep in cache

--- a/massa-pos-worker/src/controller.rs
+++ b/massa-pos-worker/src/controller.rs
@@ -3,7 +3,7 @@
 //! This module implements a selector controller.
 //! See `massa-pos-exports/controller_traits.rs` for functional details.
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, num::NonZeroU8};
 
 use crate::{Command, DrawCachePtr};
 use massa_hash::Hash;
@@ -23,7 +23,7 @@ pub struct SelectorControllerImpl {
     /// todo: use a configuration structure
     pub(crate) periods_per_cycle: u64,
     /// thread count
-    pub(crate) thread_count: u8,
+    pub(crate) thread_count: NonZeroU8,
     /// Cache storing the computed selections for each cycle.
     pub(crate) cache: DrawCachePtr,
     /// MPSC to send commands to the selector thread

--- a/massa-pos-worker/src/draw.rs
+++ b/massa-pos-worker/src/draw.rs
@@ -53,7 +53,7 @@ pub(crate) fn perform_draws(
     let mut cycle_draws = CycleDraws {
         cycle,
         draws: HashMap::with_capacity(
-            (cfg.periods_per_cycle as usize) * (cfg.thread_count as usize),
+            (cfg.periods_per_cycle as usize) * (cfg.thread_count.get() as usize),
         ),
     };
 

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -1,12 +1,14 @@
 // Copyright (c) 2022 MASSA LABS <info@massa.net>
 
+use std::num::NonZeroU8;
+
 use massa_time::MassaTime;
 use serde::Deserialize;
 /// Dynamic protocol configuration mix in static settings and constants configurations.
 #[derive(Debug, Deserialize, Clone, Copy)]
 pub struct ProtocolConfig {
     /// running threads count
-    pub thread_count: u8,
+    pub thread_count: NonZeroU8,
     /// after `ask_block_timeout` milliseconds we try to ask a block to another node
     pub ask_block_timeout: MassaTime,
     /// max known blocks of current nodes we keep in memory (by node)

--- a/massa-protocol-exports/src/tests/tools.rs
+++ b/massa-protocol-exports/src/tests/tools.rs
@@ -218,7 +218,7 @@ pub fn create_protocol_config() -> ProtocolConfig {
         asked_operations_pruning_period: 500.into(),
         operation_announcement_interval: 150.into(),
         max_operations_per_message: 1024,
-        thread_count: 32,
+        thread_count: 32.try_into().unwrap(),
         max_serialized_operations_size_per_block: 1024,
         controller_channel_size: 1024,
         event_channel_size: 1024,

--- a/massa-protocol-worker/src/tests/cache_scenarios.rs
+++ b/massa-protocol-worker/src/tests/cache_scenarios.rs
@@ -37,7 +37,7 @@ async fn test_noting_block_does_not_panic_with_zero_max_node_known_blocks_size()
             let nodes = tools::create_and_connect_nodes(2, &mut network_controller).await;
 
             let address = Address::from_public_key(&nodes[0].id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             let operation = tools::create_operation_with_expire_period(&nodes[0].keypair, 1);
 

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -273,7 +273,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
             let address = Address::from_public_key(&nodes[0].id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             let endorsement = tools::create_endorsement();
             let endorsement_id = endorsement.id;
@@ -347,7 +347,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
             let address = Address::from_public_key(&nodes[0].id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             let endorsement = tools::create_endorsement();
             let endorsement_id = endorsement.id;
@@ -420,7 +420,7 @@ async fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_abou
             let nodes = tools::create_and_connect_nodes(2, &mut network_controller).await;
 
             let address = Address::from_public_key(&nodes[0].id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             let endorsement = tools::create_endorsement();
             let endorsement_id = endorsement.id;

--- a/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/in_block_operations_scenarios.rs
@@ -38,12 +38,12 @@ async fn test_protocol_does_propagate_operations_received_in_blocks() {
 
             let mut keypair = KeyPair::generate();
             let mut address = Address::from_public_key(&keypair.get_public_key());
-            let mut thread = address.get_thread(2);
+            let mut thread = address.get_thread(2.try_into().unwrap());
 
             while thread != 0 {
                 keypair = KeyPair::generate();
                 address = Address::from_public_key(&keypair.get_public_key());
-                thread = address.get_thread(2);
+                thread = address.get_thread(2.try_into().unwrap());
             }
 
             // block with ok operation
@@ -148,12 +148,12 @@ async fn test_protocol_sends_blocks_with_operations_to_consensus() {
 
             let mut keypair = KeyPair::generate();
             let mut address = Address::from_public_key(&keypair.get_public_key());
-            let mut thread = address.get_thread(2);
+            let mut thread = address.get_thread(2.try_into().unwrap());
 
             while thread != 0 {
                 keypair = KeyPair::generate();
                 address = Address::from_public_key(&keypair.get_public_key());
-                thread = address.get_thread(2);
+                thread = address.get_thread(2.try_into().unwrap());
             }
 
             // block with ok operation

--- a/massa-protocol-worker/src/tests/operations_scenarios.rs
+++ b/massa-protocol-worker/src/tests/operations_scenarios.rs
@@ -441,7 +441,7 @@ async fn test_protocol_propagates_operations_only_to_nodes_that_dont_know_about_
             let nodes = tools::create_and_connect_nodes(1, &mut network_controller).await;
 
             let address = Address::from_public_key(&nodes[0].id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             let operation = tools::create_operation_with_expire_period(&nodes[0].keypair, 1);
 
@@ -692,7 +692,7 @@ async fn test_protocol_does_not_propagates_operations_when_receiving_those_insid
             let operation = tools::create_operation_with_expire_period(&creator_node.keypair, 1);
 
             let address = Address::from_public_key(&creator_node.id.get_public_key());
-            let thread = address.get_thread(2);
+            let thread = address.get_thread(2.try_into().unwrap());
 
             // 2. Create a block coming from node creator_node, and including the operation.
             let block = tools::create_block_with_operations(


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

* [x] confirm `.get() - 1` only: no subtractions that can potentially underflow

https://github.com/massalabs/massa/pull/3489#discussion_r1142152635