### PR TITLE
Improve documentation

### DIFF
--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -642,7 +642,7 @@ impl ExecutionContext {
     }
 
     /// Cancels an asynchronous message, reimbursing `msg.coins` to the sender
-    ///x
+    ///
     /// # Arguments
     /// * `msg`: the asynchronous message to cancel
     pub fn cancel_async_message(&mut self, msg: &AsyncMessage) {

--- a/massa-models/src/block.rs
+++ b/massa-models/src/block.rs
@@ -206,13 +206,13 @@ impl Serializer<Block> for BlockSerializer {
     }
 }
 
-///
+/// Parameters for the deserializer of a block
 pub struct BlockDeserializerArgs {
-    ///
+    /// Number of threads in Massa
     pub thread_count: u8,
-    ///
+    /// Maximum of operations in a block
     pub max_operations_per_block: u32,
-    ///
+    /// Number of endorsements in a block
     pub endorsement_count: u32,
 }
 


### PR DESCRIPTION
Fix #3707.

The `x` added in `cancel_async_message` was a typo and the documentation is already done for this function (only one line but the method has only 3 lines)