### PR TITLE
Add a downtime simulator in consensus

### DIFF
--- a/massa-consensus-worker/src/state/tick.rs
+++ b/massa-consensus-worker/src/state/tick.rs
@@ -47,18 +47,22 @@ impl ConsensusState {
         // take care of block db changes
         self.block_db_changed()?;
 
+        let now = massa_time::MassaTime::now().expect("could not get now time");
+
+        use massa_models::config::constants::DOWNTIME_END_TIMESTAMP;
+        use massa_models::config::constants::DOWNTIME_START_TIMESTAMP;
+
         // Simulate downtime
-        // last_start_period should be set after the downtime_end_period (with a delay, to let people bootstrap before the network restarts).
-        // E.g. last_start_period of 563 for 30 mins after downtime_end_period
-        let downtime_start_period = 225; // Period 225 is 1 hour after genesis
-        let downtime_end_period = 450; // Period 450 is 2 hours after genesis
-        if current_slot.period >= downtime_start_period
-            && current_slot.period <= downtime_end_period
-        {
+        // last_start_period should be set to trigger after the DOWNTIME_END_TIMESTAMP
+        if now >= DOWNTIME_START_TIMESTAMP && now <= DOWNTIME_END_TIMESTAMP {
+            let (days, hours, mins, secs) = DOWNTIME_END_TIMESTAMP
+                .saturating_sub(now)
+                .days_hours_mins_secs()
+                .unwrap();
+
             panic!(
-                "We are in downtime! Current period: {}. Downtime periods: {:?}",
-                current_slot.period,
-                downtime_start_period..=downtime_end_period
+                "We are in downtime! {} days, {} hours, {} minutes, {} seconds remaining to the end of the downtime",
+                days, hours, mins, secs,
             );
         }
 

--- a/massa-consensus-worker/src/state/tick.rs
+++ b/massa-consensus-worker/src/state/tick.rs
@@ -49,6 +49,7 @@ impl ConsensusState {
 
         // Simulate downtime
         // last_start_period should be set after the downtime_end_period (with a delay, to let people bootstrap before the network restarts).
+        // E.g. last_start_period of 563 for 30 mins after downtime_end_period
         let downtime_start_period = 225; // Period 225 is 1 hour after genesis
         let downtime_end_period = 450; // Period 450 is 2 hours after genesis
         if current_slot.period >= downtime_start_period

--- a/massa-consensus-worker/src/state/tick.rs
+++ b/massa-consensus-worker/src/state/tick.rs
@@ -47,6 +47,20 @@ impl ConsensusState {
         // take care of block db changes
         self.block_db_changed()?;
 
+        // Simulate downtime
+        // last_start_period should be set after the downtime_end_period (with a delay, to let people bootstrap before the network restarts).
+        let downtime_start_period = 225; // Period 225 is 1 hour after genesis
+        let downtime_end_period = 450; // Period 450 is 2 hours after genesis
+        if current_slot.period >= downtime_start_period
+            && current_slot.period <= downtime_end_period
+        {
+            panic!(
+                "We are in downtime! Current period: {}. Downtime periods: {:?}",
+                current_slot.period,
+                downtime_start_period..=downtime_end_period
+            );
+        }
+
         Ok(())
     }
 }

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -20,6 +20,11 @@ use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use num::rational::Ratio;
 
+/// Start of the downtime simulation
+pub const DOWNTIME_START_TIMESTAMP: MassaTime = MassaTime::from_millis(1680699600000); // 05/04/2023 3PM CET
+/// End of the downtime simulation
+pub const DOWNTIME_END_TIMESTAMP: MassaTime = MassaTime::from_millis(1680703200000); // 05/04/2023 4PM CET
+
 /// Limit on the number of peers we advertise to others.
 pub const MAX_ADVERTISE_LENGTH: u32 = 10000;
 /// Maximum message length in bytes

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -114,6 +114,37 @@ async fn launch(
         }
     }
 
+    let now = MassaTime::now().expect("could not get now time");
+
+    use massa_models::config::constants::DOWNTIME_END_TIMESTAMP;
+    use massa_models::config::constants::DOWNTIME_START_TIMESTAMP;
+
+    // Simulate downtime
+    // last_start_period should be set to trigger after the DOWNTIME_END_TIMESTAMP
+    if now >= DOWNTIME_START_TIMESTAMP && now <= DOWNTIME_END_TIMESTAMP {
+        let (days, hours, mins, secs) = DOWNTIME_END_TIMESTAMP
+            .saturating_sub(now)
+            .days_hours_mins_secs()
+            .unwrap();
+
+        if let Ok(Some(end_period)) = massa_models::timeslots::get_latest_block_slot_at_timestamp(
+            THREAD_COUNT,
+            T0,
+            *GENESIS_TIMESTAMP,
+            DOWNTIME_END_TIMESTAMP,
+        ) {
+            panic!(
+                "We are in downtime! {} days, {} hours, {} minutes, {} seconds remaining to the end of the downtime. Downtime end period: {}",
+                days, hours, mins, secs, end_period.period
+            );
+        }
+
+        panic!(
+            "We are in downtime! {} days, {} hours, {} minutes, {} seconds remaining to the end of the downtime",
+            days, hours, mins, secs,
+        );
+    }
+
     // Storage shared by multiple components.
     let shared_storage: Storage = Storage::create_root();
 


### PR DESCRIPTION
1 hour after genesis, for a 1 hour duration.

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification