### PR TITLE
Bootstrap server binding read-message in a single `read_exact`

### DIFF
--- a/massa-bootstrap/src/server_binder.rs
+++ b/massa-bootstrap/src/server_binder.rs
@@ -269,7 +269,7 @@ impl BootstrapServerBinder {
             self.prev_message = Some(Hash::compute_from(&hashed_bytes));
         } else {
             // no previous message: hash message only
-            self.prev_message = Some(Hash::compute_from(&msg_bytes));
+            self.prev_message = Some(Hash::compute_from(msg_bytes));
         }
 
         // deserialize message
@@ -278,7 +278,7 @@ impl BootstrapServerBinder {
             self.max_datastore_key_length,
             self.max_consensus_block_ids,
         )
-        .deserialize::<DeserializeError>(&msg_bytes)
+        .deserialize::<DeserializeError>(msg_bytes)
         .map_err(|err| BootstrapError::GeneralError(format!("{}", err)))?;
 
         Ok(msg)


### PR DESCRIPTION
This allows the bootstrap server to perform a complete read in one go, without incremental consumption of the stream (...internally, read_exact is an incremental read, but sorting that out is another issue. This statement assumes read_exact functions non-incrementally)

This allows state-changes in the server to be complete: The server consumes a message completely, or not at all.

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification