### PR TITLE
Remove un-necessary serialization of message ID in messages

### DIFF
--- a/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
@@ -154,7 +154,6 @@ impl PeerManagementMessage {
             }
             PeerManagementMessage::ListPeers(peers) => {
                 let mut bytes = vec![];
-                let _ = id_serializer.serialize(&1, &mut bytes);
                 let nb_peers = peers.len() as u64;
                 bytes.extend_from_slice(&nb_peers.to_le_bytes());
                 for (peer_id, listeners) in peers {

--- a/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
@@ -3,7 +3,6 @@ use std::{
     net::{IpAddr, SocketAddr},
 };
 
-use massa_serialization::{Serializer, U64VarIntSerializer};
 use peernet::{
     error::{PeerNetError, PeerNetResult},
     peer_id::PeerId,
@@ -128,7 +127,6 @@ impl PeerManagementMessage {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let id_serializer = U64VarIntSerializer::new();
         match self {
             PeerManagementMessage::NewPeerConnected((peer_id, listeners)) => {
                 let mut bytes = vec![];

--- a/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
@@ -132,7 +132,6 @@ impl PeerManagementMessage {
         match self {
             PeerManagementMessage::NewPeerConnected((peer_id, listeners)) => {
                 let mut bytes = vec![];
-                let _ = id_serializer.serialize(&0, &mut bytes);
                 bytes.extend_from_slice(&peer_id.to_bytes());
                 bytes.extend((listeners.len() as u64).to_be_bytes());
                 for listener in listeners {


### PR DESCRIPTION
Apparently the serialization of the message ID was left over, making the tests fail.

Test are failling as usual now (never succeeds to join)