### PR TITLE
add command channel in PeerManagementHandler

### DIFF
--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -68,8 +68,10 @@ pub fn start_connectivity_thread(
             id_deserializer: U64VarIntDeserializer::new(Included(0), Included(u64::MAX)),
         };
 
-        let mut peernet_config =
-            PeerNetConfiguration::default(MassaHandshake::new(), message_handlers);
+        let mut peernet_config = PeerNetConfiguration::default(
+            MassaHandshake::new(peer_management_handler.peer_db.clone()),
+            message_handlers,
+        );
         peernet_config.self_keypair = config.keypair;
         peernet_config.fallback_function = Some(&fallback_function);
         //TODO: Add the rest of the config

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -52,8 +52,7 @@ pub fn start_connectivity_thread(
     let (sender_blocks_ext, receiver_blocks_ext) = unbounded();
 
     let handle = std::thread::spawn(move || {
-        let (mut peer_manager_handler, sender_peers, _sender_cmd) =
-            PeerManagementHandler::new(initial_peers);
+        let mut peer_management_handler = PeerManagementHandler::new(initial_peers);
         //TODO: Bound the channel
         // Channels network <-> handlers
         let (sender_operations, receiver_operations) = unbounded();
@@ -65,7 +64,7 @@ pub fn start_connectivity_thread(
             sender_blocks,
             sender_endorsements,
             sender_operations,
-            sender_peers,
+            sender_peers: peer_management_handler.sender.msg_sender.clone(),
             id_deserializer: U64VarIntDeserializer::new(Included(0), Included(u64::MAX)),
         };
 
@@ -109,7 +108,7 @@ pub fn start_connectivity_thread(
             select! {
                 recv(receiver) -> msg => {
                     if let Ok(ConnectivityCommand::Stop) = msg {
-                        if let Some(handle) = peer_manager_handler.thread_join.take() {
+                        if let Some(handle) = peer_management_handler.thread_join.take() {
                             handle.join().expect("Failed to join peer manager thread");
                         }
                         operation_handler.stop();
@@ -130,7 +129,7 @@ pub fn start_connectivity_thread(
                     };
                     // Get the best peers
                     {
-                        let peer_db_read = peer_manager_handler.peer_db.read();
+                        let peer_db_read = peer_management_handler.peer_db.read();
                         let best_peers = peer_db_read.index_by_newest.iter().take(nb_connection_to_try);
                         for (_timestamp, peer_id) in best_peers {
                             let peer_info = peer_db_read.peers.get(peer_id).unwrap();

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -122,7 +122,11 @@ pub fn start_connectivity_thread(
                     // Check if we need to connect to peers
                     let nb_connection_to_try = {
                         let active_connections = manager.active_connections.read();
-                        active_connections.max_out_connections - active_connections.nb_out_connections
+                        let nb_connection_to_try = active_connections.max_out_connections - active_connections.nb_out_connections;
+                        if nb_connection_to_try == 0 {
+                            continue;
+                        }
+                        nb_connection_to_try
                     };
                     // Get the best peers
                     {

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -132,15 +132,15 @@ pub fn start_connectivity_thread(
                     // Get the best peers
                     {
                         let peer_db_read = peer_management_handler.peer_db.read();
-                        let best_peers = peer_db_read.index_by_newest.iter().take(nb_connection_to_try);
-                        for (_timestamp, peer_id) in best_peers {
-                            let peer_info = peer_db_read.peers.get(peer_id).unwrap();
+                        let best_peers = peer_db_read.get_best_peers(nb_connection_to_try);
+                        for peer_id in best_peers {
+                            let peer_info = peer_db_read.peers.get(&peer_id).unwrap();
                             if peer_info.last_announce.listeners.is_empty() {
                                 continue;
                             }
                             {
                                 let active_connections = manager.active_connections.read();
-                                if active_connections.connections.contains_key(peer_id) {
+                                if active_connections.connections.contains_key(&peer_id) {
                                     continue;
                                 }
                             }

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -122,16 +122,12 @@ pub fn start_connectivity_thread(
                     // Check if we need to connect to peers
                     let nb_connection_to_try = {
                         let active_connections = manager.active_connections.read();
-                        let connection_to_try = active_connections.max_out_connections - active_connections.nb_out_connections;
-                        if connection_to_try <= 0 {
-                            continue;
-                        }
-                       connection_to_try
+                        active_connections.max_out_connections - active_connections.nb_out_connections
                     };
                     // Get the best peers
                     {
                         let peer_db_read = peer_manager_handler.peer_db.read();
-                        let best_peers = peer_db_read.index_by_newest.iter().take(nb_connection_to_try as usize);
+                        let best_peers = peer_db_read.index_by_newest.iter().take(nb_connection_to_try);
                         for (_timestamp, peer_id) in best_peers {
                             let peer_info = peer_db_read.peers.get(peer_id).unwrap();
                             if peer_info.last_announce.listeners.is_empty() {

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -52,7 +52,8 @@ pub fn start_connectivity_thread(
     let (sender_blocks_ext, receiver_blocks_ext) = unbounded();
 
     let handle = std::thread::spawn(move || {
-        let (mut peer_manager_handler, sender_peers) = PeerManagementHandler::new(initial_peers);
+        let (mut peer_manager_handler, sender_peers, _sender_cmd) =
+            PeerManagementHandler::new(initial_peers);
         //TODO: Bound the channel
         // Channels network <-> handlers
         let (sender_operations, receiver_operations) = unbounded();

--- a/massa-protocol-worker-2/src/handlers/block_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/mod.rs
@@ -83,7 +83,7 @@ impl BlockHandler {
         });
 
         let block_propagation_thread = std::thread::spawn({
-            let _active_connections = active_connections.clone();
+            let _active_connections = active_connections;
             move || {
                 let _block_message_serializer = BlockMessageSerializer::new();
                 //TODO: Real logic

--- a/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
@@ -81,7 +81,7 @@ impl OperationHandler {
         });
 
         let operation_propagation_thread = std::thread::spawn({
-            let _active_connections = active_connections.clone();
+            let _active_connections = active_connections;
             move || {
                 let _operation_message_serializer = OperationMessageSerializer::new();
                 //TODO: Real logic

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -167,8 +167,12 @@ impl PeerManagementHandler {
 
 impl PeerDB {
     fn ban_peer(&mut self, peer_id: &PeerId) {
-        self.peers.get_mut(peer_id).unwrap().state = PeerState::Banned;
-        info!("Banned peer: {:?}", peer_id);
+        if let Some(peer) = self.peers.get_mut(peer_id) {
+            peer.state = PeerState::Banned;
+            info!("Banned peer: {:?}", peer_id);
+        } else {
+            info!("Tried to ban unknown peer: {:?}", peer_id);
+        };
     }
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -55,6 +55,14 @@ pub struct PeerManagementHandler {
 
 pub struct PeerInfo {
     pub last_announce: Announcement,
+    pub state: PeerState,
+}
+
+#[warn(dead_code)]
+pub enum PeerState {
+    Connected,
+    InHandshake,
+    Banned,
 }
 
 #[warn(dead_code)]
@@ -94,8 +102,11 @@ impl PeerManagementHandler {
                         recv(receiver_cmd) -> cmd => {
                            match cmd {
                              Ok(PeerManagementCmd::BAN(peer_id)) => {
-                                // TODO ban peer
-                                 println!("Banning peer: {:?}", peer_id);
+                                // set peer state to banned
+                                peer_db.write().peers.get_mut(&peer_id).unwrap().state = PeerState::Banned;
+                                println!("Banning peer: {:?}", peer_id);
+
+                                // should disconnect it ?
                              },
                             Err(_) => {
                                     println!("Error");
@@ -168,6 +179,7 @@ impl HandshakeHandler for MassaHandshake {
         listeners: &HashMap<SocketAddr, TransportType>,
         messages_handler: MassaMessagesHandler,
     ) -> PeerNetResult<PeerId> {
+        // TODO set peer state to InHandshake ?
         let mut bytes = PeerId::from_public_key(keypair.get_public_key()).to_bytes();
         //TODO: Add version in announce
         let listeners_announcement = Announcement::new(listeners.clone(), keypair).unwrap();

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -125,13 +125,13 @@ impl PeerManagementHandler {
                             match message {
                                 PeerManagementMessage::NewPeerConnected((_peer_id, listeners)) => {
                                     for listener in listeners.into_iter() {
-                                        let _tester = Tester::new(peer_db.clone(), listener.clone());
+                                        let _tester = Tester::new(peer_db.clone(), listener);
                                     }
                                 }
                                 PeerManagementMessage::ListPeers(peers) => {
                                     for (_peer_id, listeners) in peers.into_iter() {
                                         for listener in listeners.into_iter() {
-                                            let _tester = Tester::new(peer_db.clone(), listener.clone());
+                                            let _tester = Tester::new(peer_db.clone(), listener);
                                         }
                                     }
                                 }

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -10,6 +10,7 @@ use crossbeam::{
     channel::{Receiver, Sender},
     select,
 };
+use massa_protocol_exports_2::ProtocolError;
 use massa_serialization::{DeserializeError, Deserializer, Serializer};
 use parking_lot::RwLock;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -23,7 +24,7 @@ use peernet::{
     types::Hash,
     types::{KeyPair, Signature},
 };
-use tracing::log::{info, warn};
+use tracing::log::{error, info, warn};
 
 use crate::handlers::peer_handler::{messages::PeerManagementMessage, tester::Tester};
 
@@ -64,7 +65,7 @@ pub enum PeerState {
 
 #[warn(dead_code)]
 pub enum PeerManagementCmd {
-    BAN(PeerId),
+    Ban(PeerId),
 }
 
 pub struct PeerManagementHandler {
@@ -96,12 +97,17 @@ impl PeerManagementHandler {
                         // internal command
                         recv(receiver_cmd) -> cmd => {
                            match cmd {
-                             Ok(PeerManagementCmd::BAN(peer_id)) => {
+                             Ok(PeerManagementCmd::Ban(peer_id)) => {
+
+                                // remove runing handshake ?
+
+                                // close peer connection ?
+
+                                // update peer_db
                                 peer_db.write().ban_peer(&peer_id);
-                                // should disconnect peer ?
                              },
-                            Err(_) => {
-                                println!("Error");
+                            Err(e) => {
+                                error!("error receiving command: {:?}", e);
                             }
                            }
                         },
@@ -173,6 +179,11 @@ impl PeerDB {
         } else {
             info!("Tried to ban unknown peer: {:?}", peer_id);
         };
+    }
+
+    // Flush PeerDB to disk ?
+    fn flush(&self) -> Result<(), ProtocolError> {
+        unimplemented!()
     }
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -182,8 +182,6 @@ impl HandshakeHandler for MassaHandshake {
         listeners: &HashMap<SocketAddr, TransportType>,
         messages_handler: MassaMessagesHandler,
     ) -> PeerNetResult<PeerId> {
-        // TODO set peer state to InHandshake ?
-
         let received = endpoint.receive()?;
         if received.is_empty() {
             return Err(PeerNetError::HandshakeError.error(
@@ -290,7 +288,7 @@ impl HandshakeHandler for MassaHandshake {
             });
         } else {
             peer_db_write.peers.entry(peer_id).and_modify(|info| {
-                info.state = PeerState::HandshakeSuccess;
+                info.state = PeerState::Trusted;
             });
         }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -95,7 +95,7 @@ impl PeerManagementHandler {
                             // check if peer is banned
                             if let Some(peer) = peer_db.read().peers.get(&peer_id) {
                                 if peer.state == PeerState::Banned {
-                                    warn!("Banned peer tried to connect: {:?}", peer_id);
+                                    warn!("Banned peer sent us a message: {:?}", peer_id);
                                     continue;
                                 }
                             }

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -23,6 +23,7 @@ use peernet::{
     types::Hash,
     types::{KeyPair, Signature},
 };
+use tracing::info;
 
 use crate::handlers::peer_handler::{messages::PeerManagementMessage, tester::Tester};
 
@@ -102,11 +103,8 @@ impl PeerManagementHandler {
                         recv(receiver_cmd) -> cmd => {
                            match cmd {
                              Ok(PeerManagementCmd::BAN(peer_id)) => {
-                                // set peer state to banned
-                                peer_db.write().peers.get_mut(&peer_id).unwrap().state = PeerState::Banned;
-                                println!("Banning peer: {:?}", peer_id);
-
-                                // should disconnect it ?
+                                peer_db.write().ban_peer(&peer_id);
+                                // should disconnect peer ?
                              },
                             Err(_) => {
                                     println!("Error");
@@ -148,6 +146,13 @@ impl PeerManagementHandler {
             sender,
             sender_cmd,
         )
+    }
+}
+
+impl PeerDB {
+    fn ban_peer(&mut self, peer_id: &PeerId) {
+        self.peers.get_mut(peer_id).unwrap().state = PeerState::Banned;
+        info!("Banned peer: {:?}", peer_id);
     }
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -79,7 +79,10 @@ impl PeerManagementHandler {
         Sender<(PeerId, u64, Vec<u8>)>,
         Sender<PeerManagementCmd>,
     ) {
-        let (sender, receiver) = crossbeam::channel::unbounded();
+        let (sender, receiver): (
+            Sender<(PeerId, u64, Vec<u8>)>,
+            Receiver<(PeerId, u64, Vec<u8>)>,
+        ) = crossbeam::channel::unbounded();
         let (sender_cmd, receiver_cmd): (Sender<PeerManagementCmd>, Receiver<PeerManagementCmd>) =
             crossbeam::channel::unbounded();
         for (peer_id, listeners) in &initial_peers {
@@ -138,6 +141,19 @@ impl PeerManagementHandler {
                 }
             }
         });
+
+        for (peer_id, listeners) in &initial_peers {
+            println!("Sending initial peer: {:?}", peer_id);
+            sender
+                .send((
+                    peer_id.clone(),
+                    0,
+                    PeerManagementMessage::NewPeerConnected((peer_id.clone(), listeners.clone()))
+                        .to_bytes(),
+                ))
+                .unwrap();
+        }
+
         (
             Self {
                 peer_db,

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -134,15 +134,15 @@ impl PeerManagementHandler {
                                 }
                             }
 
-                    println!("Received message len: {}", message.len());
-                    message_deserializer.set_message(message_id);
-                    let (_, message) = message_deserializer
-                        .deserialize::<DeserializeError>(&message)
-                        .unwrap();
-                    println!("Received message from peer: {:?}", peer_id);
-                    println!("Message: {:?}", message);
-                    // TODO: Bufferize launch of test thread
-                    // TODO: Add wait group or something like that to wait for all threads to finish when stop
+                            println!("Received message len: {}", message.len());
+                            message_deserializer.set_message(message_id);
+                            let (_, message) = message_deserializer
+                                .deserialize::<DeserializeError>(&message)
+                                .unwrap();
+                            println!("Received message from peer: {:?}", peer_id);
+                            println!("Message: {:?}", message);
+                            // TODO: Bufferize launch of test thread
+                            // TODO: Add wait group or something like that to wait for all threads to finish when stop
                             match message {
                                 PeerManagementMessage::NewPeerConnected((_peer_id, listeners)) => {
                                     for listener in listeners.into_iter() {

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -21,6 +21,8 @@ pub struct PeerDB {
 
 pub type SharedPeerDB = Arc<RwLock<PeerDB>>;
 
+pub type PeerMessageTuple = (PeerId, u64, Vec<u8>);
+
 pub struct PeerInfo {
     pub last_announce: Announcement,
     pub state: PeerState,
@@ -41,7 +43,7 @@ pub enum PeerManagementCmd {
 }
 
 pub struct PeerManagementChannel {
-    pub msg_sender: Sender<(PeerId, u64, Vec<u8>)>,
+    pub msg_sender: Sender<PeerMessageTuple>,
     pub command_sender: Sender<PeerManagementCmd>,
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -57,6 +57,24 @@ impl PeerDB {
         };
     }
 
+    /// get best peers for a given number of peers
+    /// returns a vector of peer ids
+    pub fn get_best_peers(&self, nb_peers: usize) -> Vec<PeerId> {
+        self.index_by_newest
+            .iter()
+            .filter_map(|(_, peer_id)| {
+                self.peers.get(peer_id).and_then(|peer| {
+                    if peer.state == PeerState::Trusted {
+                        Some(peer_id.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+            .take(nb_peers)
+            .collect()
+    }
+
     // Flush PeerDB to disk ?
     fn flush(&self) -> Result<(), ProtocolError> {
         unimplemented!()

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -31,11 +31,9 @@ pub struct PeerInfo {
 #[warn(dead_code)]
 #[derive(Eq, PartialEq)]
 pub enum PeerState {
-    Connected,
     Banned,
     InHandshake,
     HandshakeFailed,
-    HandshakeSuccess,
     Trusted,
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -1,0 +1,62 @@
+use crossbeam::channel::Sender;
+use massa_protocol_exports_2::ProtocolError;
+use parking_lot::RwLock;
+use peernet::{peer_id::PeerId, transports::TransportType};
+use std::{
+    collections::{BTreeMap, HashMap},
+    net::SocketAddr,
+    sync::Arc,
+};
+use tracing::log::info;
+
+use super::announcement::Announcement;
+
+pub type InitialPeers = HashMap<PeerId, HashMap<SocketAddr, TransportType>>;
+
+#[derive(Default)]
+pub struct PeerDB {
+    pub peers: HashMap<PeerId, PeerInfo>,
+    pub index_by_newest: BTreeMap<u128, PeerId>,
+}
+
+pub type SharedPeerDB = Arc<RwLock<PeerDB>>;
+
+pub struct PeerInfo {
+    pub last_announce: Announcement,
+    pub state: PeerState,
+}
+
+#[warn(dead_code)]
+#[derive(Eq, PartialEq)]
+pub enum PeerState {
+    Connected,
+    Banned,
+    InHandshake,
+    Trusted,
+}
+
+#[warn(dead_code)]
+pub enum PeerManagementCmd {
+    Ban(PeerId),
+}
+
+pub struct PeerManagementChannel {
+    pub msg_sender: Sender<(PeerId, u64, Vec<u8>)>,
+    pub command_sender: Sender<PeerManagementCmd>,
+}
+
+impl PeerDB {
+    pub fn ban_peer(&mut self, peer_id: &PeerId) {
+        if let Some(peer) = self.peers.get_mut(peer_id) {
+            peer.state = PeerState::Banned;
+            info!("Banned peer: {:?}", peer_id);
+        } else {
+            info!("Tried to ban unknown peer: {:?}", peer_id);
+        };
+    }
+
+    // Flush PeerDB to disk ?
+    fn flush(&self) -> Result<(), ProtocolError> {
+        unimplemented!()
+    }
+}

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -34,6 +34,8 @@ pub enum PeerState {
     Connected,
     Banned,
     InHandshake,
+    HandshakeFailed,
+    HandshakeSuccess,
     Trusted,
 }
 

--- a/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
@@ -14,7 +14,8 @@ use peernet::{
 
 use super::{
     announcement::{AnnouncementDeserializer, AnnouncementDeserializerArgs},
-    PeerInfo, SharedPeerDB,
+    models::PeerInfo,
+    SharedPeerDB,
 };
 
 #[derive(Clone)]

--- a/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
@@ -62,6 +62,8 @@ impl HandshakeHandler for TesterHandshake {
         _: &HashMap<SocketAddr, TransportType>,
         _: TesterMessagesHandler,
     ) -> PeerNetResult<PeerId> {
+        // TODO set the peer state to InHandshake
+
         let data = endpoint.receive()?;
         let peer_id = PeerId::from_bytes(&data[..32].try_into().unwrap())?;
         let (_, announcement) = self
@@ -96,6 +98,7 @@ impl HandshakeHandler for TesterHandshake {
                 })
                 .or_insert(PeerInfo {
                     last_announce: announcement,
+                    state: super::PeerState::Connected,
                 });
         }
         Ok(peer_id)

--- a/massa-protocol-worker-2/src/messages.rs
+++ b/massa-protocol-worker-2/src/messages.rs
@@ -18,34 +18,34 @@ use crate::handlers::{
 };
 
 pub enum Message {
-    BlockMessage(BlockMessage),
-    EndorsementMessage(EndorsementMessage),
-    OperationMessage(OperationMessage),
-    PeerManagementMessage(PeerManagementMessage),
+    Block(Box<BlockMessage>),
+    Endorsement(EndorsementMessage),
+    Operation(OperationMessage),
+    PeerManagement(Box<PeerManagementMessage>),
 }
 
 //TODO: Macroize this
 impl From<BlockMessage> for Message {
     fn from(message: BlockMessage) -> Self {
-        Self::BlockMessage(message)
+        Self::Block(Box::from(message))
     }
 }
 
 impl From<EndorsementMessage> for Message {
     fn from(message: EndorsementMessage) -> Self {
-        Self::EndorsementMessage(message)
+        Self::Endorsement(message)
     }
 }
 
 impl From<OperationMessage> for Message {
     fn from(message: OperationMessage) -> Self {
-        Self::OperationMessage(message)
+        Self::Operation(message)
     }
 }
 
 impl From<PeerManagementMessage> for Message {
     fn from(message: PeerManagementMessage) -> Self {
-        Self::PeerManagementMessage(message)
+        Self::PeerManagement(Box::from(message))
     }
 }
 
@@ -53,14 +53,12 @@ impl Message {
     //TODO: Macroize get_id and max_id
     fn get_id(&self) -> u64 {
         match self {
-            Message::BlockMessage(message) => message.get_id() as u64,
-            Message::EndorsementMessage(message) => {
-                message.get_id() as u64 + BlockMessage::max_id()
-            }
-            Message::OperationMessage(message) => {
+            Message::Block(message) => message.get_id() as u64,
+            Message::Endorsement(message) => message.get_id() as u64 + BlockMessage::max_id(),
+            Message::Operation(message) => {
                 message.get_id() as u64 + BlockMessage::max_id() + EndorsementMessage::max_id()
             }
-            Message::PeerManagementMessage(message) => {
+            Message::PeerManagement(message) => {
                 message.get_id() as u64
                     + BlockMessage::max_id()
                     + EndorsementMessage::max_id()
@@ -137,7 +135,7 @@ impl PeerNetMessagesSerializer<Message> for MessagesSerializer {
     /// Serialize the message
     fn serialize(&self, message: &Message, buffer: &mut Vec<u8>) -> PeerNetResult<()> {
         match message {
-            Message::BlockMessage(message) => {
+            Message::Block(message) => {
                 if let Some(serializer) = &self.block_message_serializer {
                     serializer.serialize(message, buffer).map_err(|err| {
                         PeerNetError::HandlerError.error(
@@ -152,7 +150,7 @@ impl PeerNetMessagesSerializer<Message> for MessagesSerializer {
                     ))
                 }
             }
-            Message::EndorsementMessage(message) => {
+            Message::Endorsement(message) => {
                 if let Some(serializer) = &self.endorsement_message_serializer {
                     serializer.serialize(message, buffer).map_err(|err| {
                         PeerNetError::HandlerError.error(
@@ -167,7 +165,7 @@ impl PeerNetMessagesSerializer<Message> for MessagesSerializer {
                     ))
                 }
             }
-            Message::OperationMessage(message) => {
+            Message::Operation(message) => {
                 if let Some(serializer) = &self.operation_message_serializer {
                     serializer.serialize(message, buffer).map_err(|err| {
                         PeerNetError::HandlerError.error(
@@ -182,7 +180,7 @@ impl PeerNetMessagesSerializer<Message> for MessagesSerializer {
                     ))
                 }
             }
-            Message::PeerManagementMessage(message) => {
+            Message::PeerManagement(message) => {
                 if let Some(serializer) = &self.peer_management_message_serializer {
                     serializer.serialize(message, buffer).map_err(|err| {
                         PeerNetError::HandlerError.error(

--- a/massa-protocol-worker-2/src/tests/mod.rs
+++ b/massa-protocol-worker-2/src/tests/mod.rs
@@ -7,7 +7,7 @@ use massa_storage::Storage;
 use peernet::{peer_id::PeerId, transports::TransportType};
 use tempfile::NamedTempFile;
 
-use crate::{handlers::peer_handler::InitialPeers, start_protocol_controller};
+use crate::{handlers::peer_handler::models::InitialPeers, start_protocol_controller};
 
 mod tools;
 

--- a/massa-protocol-worker-2/src/worker.rs
+++ b/massa-protocol-worker-2/src/worker.rs
@@ -23,7 +23,7 @@ pub fn start_protocol_controller(
     debug!("starting protocol controller");
 
     let (connectivity_thread_handle, controller) =
-        start_connectivity_thread(config.clone(), pool_controller, storage)?;
+        start_connectivity_thread(config, pool_controller, storage)?;
 
     let manager = ProtocolManagerImpl::new(connectivity_thread_handle);
 


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at faf5552</samp>

### Summary
🚚🔧🛠️

<!--
1.  🚚 This emoji represents the moving of the `active_connections` variable and the `InitialPeers` type from one module to another, as well as the creation of the `models` module for common types.
2.  🔧 This emoji represents the modification of the `start_connectivity_thread` function to take the `config` parameter by value, and the renaming and refactoring of the `PeerManagementHandler` struct and its methods to use a shared peer database and a sender channel for communication.
3.  🛠️ This emoji represents the refactoring of the `PeerInfo` type and the `Message` enum and its related traits and methods to use `Box` for some variants, and the improvement of the peer handling logic in the `Tester` struct and the `PeerManagementHandler` struct.
-->
This pull request improves the peer management and communication logic in the `massa-protocol-worker-2` crate by refactoring some types and modules, using a shared peer database and channels, and adding some methods and checks. It also optimizes the memory usage and performance of the `Message` enum and removes some unnecessary clones of the `active_connections` variable.

> _We're refactoring the `peer_handler` code_
> _To make it more efficient and easy to load_
> _We're moving types to the `models` module_
> _And using channels for better control_

### Walkthrough
*  Rename `PeerManagementHandler` to `PeerManagementHandler` and change its constructor to return a single instance instead of a tuple with a sender channel ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL55-R55), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL111-R113), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL39-R62), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL115-R151))
*  Add a `SharedPeerDB` field and parameter to the `MassaHandshake` struct and use it to check and update the peer state before and after the handshake ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL67-R74), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL129-R165), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL153-L165), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L67-R131))
*  Move the `active_connections` variable from the `block_handler` and `operation_handler` modules to the `connectivity` module and remove its clone ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-8c4a38023592bc37eedf7e063e33d0fa239f88ccbc8cf279dc9941d82f026f31L86-R86), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-62d09db317a78d54f6f233b93af261066042c5c00e3cacb2e3d5801a0143f853L84-R84))
*  Move some types from the `peer_handler` module to the `models` module and import it where needed ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL1-R6), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL23-R31), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-92fd577f9eff16de739adf93ad3e0bb0a0993f097a5f87d96e58666eeb704482R1-R82), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L17-R18), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-6b92add6e1289921359a853e2bdb7ed92af6b81b81ecadc14cdc26cc3e040235L10-R10))
*  Add a `sender` field of type `PeerManagementChannel` to the `PeerManagementHandler` struct and initialize it with both the message and command senders ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL39-R62), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL115-R151))
*  Split the `PeerManagementHandler`'s `receiver` channel into two channels: one for receiving messages from peers (`receiver`) and one for receiving internal commands (`receiver_cmd`) and handle them with a `select` macro ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL88-R125))
*  Add a new command variant `PeerManagementCmd::Ban` and handle it by updating the `peer_db` and closing the peer connection ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL88-R125))
*  Send the initial peers messages after spawning the `PeerManagementHandler` thread and initializing the `peer_db` ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL115-R151))
*  Borrow the `peer_id` variable when checking if it is already in the active connections map ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL141-R143))
*  Use the `peer_db`'s `get_best_peers` method to obtain the best peers for a given number of connections to try ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL124-R137))
*  Use `Box` for the `Block` and `PeerManagement` variants of the `Message` enum and update the `From` trait implementations and the `get_id` and `serialize` methods accordingly ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L21-R24), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L30-R30), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L36-R36), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L42-R42), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L48-R48), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L56-R61), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L140-R138), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L155-R153), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L170-R168), [link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-0613df7432ddf3d479b7c3c639f7d18def42b9b9e78ef9fefee3c7e408c0f5b8L185-R183))
*  Take the `config` parameter by value instead of by reference in the `start_connectivity_thread` function ([link](https://github.com/massalabs/massa/pull/3809/files?diff=unified&w=0#diff-4089776d43f58153e4e236b8959e424d514c8ab29cf5e368b8b9cbb3503ad25cL26-R26))

