### PR TITLE
ban peer if note_operations_from_peer is Err

### DIFF
--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -100,6 +100,7 @@ pub fn start_connectivity_thread(
                 receiver_operations,
                 sender_operations_ext,
                 receiver_operations_ext,
+                peer_management_handler.sender.command_sender.clone(),
             );
             let mut endorsement_handler = EndorsementHandler::new(
                 pool_controller,

--- a/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
@@ -19,7 +19,7 @@ mod retrieval;
 
 pub(crate) use messages::{OperationMessage, OperationMessageSerializer};
 
-use super::peer_handler::models::PeerMessageTuple;
+use super::peer_handler::models::{PeerManagementCmd, PeerMessageTuple};
 
 pub struct OperationHandler {
     pub operation_retrieval_thread: Option<JoinHandle<()>>,
@@ -36,6 +36,7 @@ impl OperationHandler {
         receiver_network: Receiver<PeerMessageTuple>,
         local_sender: Sender<OperationHandlerCommand>,
         local_receiver: Receiver<OperationHandlerCommand>,
+        peer_cmd_sender: Sender<PeerManagementCmd>,
     ) -> Self {
         //TODO: Define bound channel
         let operation_retrieval_thread = start_retrieval_thread(
@@ -46,6 +47,7 @@ impl OperationHandler {
             cache.clone(),
             active_connections.clone(),
             local_sender,
+            peer_cmd_sender,
         );
 
         let operation_propagation_thread =

--- a/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/models.rs
@@ -37,7 +37,6 @@ pub enum PeerState {
     Trusted,
 }
 
-#[warn(dead_code)]
 pub enum PeerManagementCmd {
     Ban(PeerId),
 }


### PR DESCRIPTION
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 696eefe</samp>

### Summary
📡🗑️🚫

<!--
1.  📡 This emoji represents the communication or sending of commands between different modules or handlers, such as the connectivity, operation, and peer management handlers. It could be used for the first, third, and fourth changes.
2.  🗑️ This emoji represents the removal or deletion of something that is no longer needed or useful, such as the unused attribute warn(dead_code). It could be used for the second change.
3.  🚫 This emoji represents the banning or blocking of malicious peers who send incorrect or harmful operations. It could be used for the third and fourth changes.
-->
This pull request adds the ability to ban malicious peers who send incorrect operations. It does this by enabling the communication between the operation handler and the peer management handler using the `PeerManagementCmd` enum and command senders. It also removes an unnecessary attribute from the `PeerMessageTuple` struct.

> _`ban_node` method_
> _protects from bad peers in_
> _autumn of trust_

### Walkthrough
*  Add a clone of the peer management command sender to the connectivity module ([link](https://github.com/massalabs/massa/pull/3826/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eR103)) to enable sending commands to the peer handler

