### PR TITLE
Use blocking_send instead of the async send

### DIFF
--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -698,7 +698,6 @@ fn manage_bootstrap(
 ) -> Result<(), BootstrapError> {
     massa_trace!("bootstrap.lib.manage_bootstrap", {});
     let read_error_timeout: Duration = bootstrap_config.read_error_timeout.into();
-    let rt_hack = massa_network_exports::make_runtime();
 
     server.handshake_timeout(version, Some(bootstrap_config.read_timeout.into()))?;
 
@@ -733,8 +732,7 @@ fn manage_bootstrap(
                     server.send_msg(
                         write_timeout,
                         BootstrapServerMessage::BootstrapPeers {
-                            peers: rt_hack
-                                .block_on(network_command_sender.get_bootstrap_peers())?,
+                            peers: network_command_sender.sync_get_bootstrap_peers()?,
                         },
                     )?;
                 }

--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -174,7 +174,7 @@ fn test_bootstrap_server() {
     let mut mocked1 = NetworkCommandSender::new();
     let mut mocked2 = NetworkCommandSender::new();
     mocked2
-        .expect_get_bootstrap_peers()
+        .expect_sync_get_bootstrap_peers()
         .times(1)
         .returning(|| Ok(get_peers()));
 

--- a/massa-network-exports/src/lib.rs
+++ b/massa-network-exports/src/lib.rs
@@ -14,11 +14,9 @@ pub use error::{HandshakeErrorType, NetworkConnectionErrorType, NetworkError};
 pub use establisher::{Establisher, Listener, ReadHalf, WriteHalf};
 
 #[cfg(any(test, feature = "testing"))]
-pub use network_controller::MockNetworkCommandSender;
+pub use network_controller::{make_runtime, MockNetworkCommandSender};
 
-pub use network_controller::{
-    make_runtime, NetworkCommandSender, NetworkEventReceiver, NetworkManager,
-};
+pub use network_controller::{NetworkCommandSender, NetworkEventReceiver, NetworkManager};
 pub use peers::{
     BootstrapPeers, BootstrapPeersDeserializer, BootstrapPeersSerializer, ConnectionCount, Peer,
     PeerInfo, PeerType, Peers,


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification