### PR TITLE
Add two extra saved cycles to PoS for denunciations checks

### DIFF
--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -131,8 +131,10 @@ pub const OPERATION_VALIDITY_PERIODS: u64 = 10;
 pub const PERIODS_PER_CYCLE: u64 = 128;
 /// PoS saved cycles: number of cycles saved in `PoSFinalState`
 ///
-/// 4 for PoS itself and 1 for bootstrap safety
-pub const POS_SAVED_CYCLES: usize = 6;
+/// 6 for PoS itself so we can check denuncations on selections at C-2 after a bootstrap
+/// See https://github.com/massalabs/massa/pull/3871
+/// And 1 for pruned cycle safety during bootstrap
+pub const POS_SAVED_CYCLES: usize = 7;
 /// Maximum size batch of data in a part of the ledger
 pub const LEDGER_PART_SIZE_MESSAGE_BYTES: u64 = 1_000_000;
 /// Maximum async messages in a batch of the bootstrap of the async pool

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -129,12 +129,17 @@ pub const MAX_ASYNC_MESSAGE_DATA: u64 = 1_000_000;
 pub const OPERATION_VALIDITY_PERIODS: u64 = 10;
 /// cycle duration in periods
 pub const PERIODS_PER_CYCLE: u64 = 128;
-/// PoS saved cycles: number of cycles saved in `PoSFinalState`
+/// Number of cycles saved in `PoSFinalState`
 ///
 /// 6 for PoS itself so we can check denuncations on selections at C-2 after a bootstrap
 /// See https://github.com/massalabs/massa/pull/3871
-/// And 1 for pruned cycle safety during bootstrap
+/// 1 for pruned cycle safety during bootstrap
 pub const POS_SAVED_CYCLES: usize = 7;
+/// Number of cycle draws saved in the selector cache
+///
+/// 5 to have a C-2 to C+2 range (6 cycles post-bootstrap give 5 cycle draws)
+/// 1 for margin
+pub const SELECTOR_DRAW_CACHE_SIZE: usize = 6;
 /// Maximum size batch of data in a part of the ledger
 pub const LEDGER_PART_SIZE_MESSAGE_BYTES: u64 = 1_000_000;
 /// Maximum async messages in a batch of the bootstrap of the async pool

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -132,7 +132,7 @@ pub const PERIODS_PER_CYCLE: u64 = 128;
 /// PoS saved cycles: number of cycles saved in `PoSFinalState`
 ///
 /// 4 for PoS itself and 1 for bootstrap safety
-pub const POS_SAVED_CYCLES: usize = 5;
+pub const POS_SAVED_CYCLES: usize = 6;
 /// Maximum size batch of data in a part of the ledger
 pub const LEDGER_PART_SIZE_MESSAGE_BYTES: u64 = 1_000_000;
 /// Maximum async messages in a batch of the bootstrap of the async pool

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -308,8 +308,6 @@
     broadcast_operations_channel_capacity = 5000
 
 [selector]
-    # maximum number of computed cycle's draws we keep in cache
-    max_draw_cache = 10
     # path to the initial roll distribution
     initial_rolls_path = "base_config/initial_rolls.json"
 

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -56,7 +56,7 @@ use massa_models::config::constants::{
 use massa_models::config::{
     CONSENSUS_BOOTSTRAP_PART_SIZE, DENUNCIATION_EXPIRE_PERIODS, MAX_DENUNCIATIONS_PER_BLOCK_HEADER,
     MAX_DENUNCIATION_CHANGES_LENGTH, MAX_OPERATIONS_PER_MESSAGE,
-    ROLL_COUNT_TO_SLASH_ON_DENUNCIATION,
+    ROLL_COUNT_TO_SLASH_ON_DENUNCIATION, SELECTOR_DRAW_CACHE_SIZE,
 };
 use massa_network_exports::{Establisher, NetworkConfig, NetworkManager};
 use massa_network_worker::start_network_controller;
@@ -226,7 +226,7 @@ async fn launch(
 
     // launch selector worker
     let (selector_manager, selector_controller) = start_selector_worker(SelectorConfig {
-        max_draw_cache: SETTINGS.selector.max_draw_cache,
+        max_draw_cache: SELECTOR_DRAW_CACHE_SIZE,
         channel_size: CHANNEL_SIZE,
         thread_count: THREAD_COUNT,
         endorsement_count: ENDORSEMENT_COUNT,

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -39,7 +39,6 @@ pub struct ExecutionSettings {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct SelectionSettings {
-    pub max_draw_cache: usize,
     pub initial_rolls_path: PathBuf,
 }
 


### PR DESCRIPTION
No further changes need to be done than saving 2 extra cycles because:
1. We feed every cycle we get after bootstrapping in [compute_initial_draws](https://github.com/massalabs/massa/blob/testnet_22/massa-pos-exports/src/pos_final_state.rs#L195-L210)
2. Fed cycles are computed in the same order they are fed and the selector thread checks sequentiality
3. We wait for every cycle to be drawn up to C+2 (C being the latest cycle received from bootstrap) [here](https://github.com/massalabs/massa/blob/testnet_22/massa-pos-exports/src/pos_final_state.rs#L213-L215), and we now receive 6 cycles after this change, giving us the draws for C-2, C-1, C, C+1, C+2

![image](https://user-images.githubusercontent.com/89928840/234589183-305eae72-01e5-48a2-9370-b3d558bb7a2b.png)
