### PR TITLE
Update config on new protocol network and clean-up

### DIFF
--- a/massa-protocol-exports-2/src/settings.rs
+++ b/massa-protocol-exports-2/src/settings.rs
@@ -20,8 +20,6 @@ pub struct ProtocolConfig {
     pub max_in_connections: usize,
     /// max number of out connections
     pub max_out_connections: usize,
-    /// running threads count
-    pub thread_count: u8,
     /// after `ask_block_timeout` milliseconds we try to ask a block to another node
     pub ask_block_timeout: MassaTime,
     /// Max known blocks we keep in block_handler
@@ -61,7 +59,7 @@ pub struct ProtocolConfig {
     /// Maximum time we keep an operation in the storage
     pub max_operation_storage_time: MassaTime,
     /// Maximum of operations sent in one message.
-    pub max_operations_per_message: u64,
+    pub max_operations_per_message: u32,
     /// Maximum of operations sent in one block.
     pub max_operations_per_block: u64,
     /// Maximum size in bytes of all serialized operations size in a block
@@ -80,6 +78,8 @@ pub struct ProtocolConfig {
     pub max_endorsements_propagation_time: MassaTime,
     /// number of thread tester
     pub thread_tester_count: u8,
+    /// Max size of the channel for command to the connectivity thread
+    pub max_size_channel_commands_connectivity: usize,
     /// Max size of channel to send commands to retrieval thread of operations
     pub max_size_channel_commands_retrieval_operations: usize,
     /// Max size of channel to send commands to propagation thread of operations
@@ -92,6 +92,44 @@ pub struct ProtocolConfig {
     pub max_size_channel_commands_retrieval_blocks: usize,
     /// Max size of channel to send commands to propagation thread of blocks
     pub max_size_channel_commands_propagation_blocks: usize,
+    /// Max size of channel to send commands to thread of peers
+    pub max_size_channel_commands_peers: usize,
+    /// Max size of channel to send commands to the peer testers
+    pub max_size_channel_commands_peer_testers: usize,
+    /// Max size of channel that transfer message from network to operation handler
+    pub max_size_channel_network_to_operation_handler: usize,
+    /// Max size of channel that transfer message from network to block handler
+    pub max_size_channel_network_to_block_handler: usize,
+    /// Max size of channel that transfer message from network to endorsement handler
+    pub max_size_channel_network_to_endorsement_handler: usize,
+    /// Max size of channel that transfer message from network to peer handler
+    pub max_size_channel_network_to_peer_handler: usize,
+    /// endorsements per block
+    pub endorsement_count: u32,
+    /// running threads count
+    pub thread_count: u8,
+    /// Max of block infos you can send
+    pub max_size_block_infos: u64,
+    /// Maximum size of an value user datastore
+    pub max_size_value_datastore: u64,
+    /// Maximum size of a function name
+    pub max_size_function_name: u16,
+    /// Maximum size of a parameter of a call in ops
+    pub max_size_call_sc_parameter: u32,
+    // Maximum size of an op datastore in ops
+    pub max_op_datastore_entry_count: u64,
+    // Maximum size of a key the in op datastore in ops
+    pub max_op_datastore_key_length: u8,
+    // Maximum size of a value in the op datastore in ops
+    pub max_op_datastore_value_length: u64,
+    /// Maximum number of denunciations in a block header
+    pub max_denunciations_in_block_header: u32,
+    /// Maximum number of endorsements that can be propagated in one message
+    pub max_endorsements_per_message: u64,
+    /// Maximum number of peers per announcement
+    pub max_size_peers_announcement: u64,
+    /// Maximum number of listeners per peer
+    pub max_size_listeners_per_peer: u64,
     /// debug prints
     pub debug: bool,
 }

--- a/massa-protocol-exports-2/src/settings.rs
+++ b/massa-protocol-exports-2/src/settings.rs
@@ -26,7 +26,7 @@ pub struct ProtocolConfig {
     pub ask_block_timeout: MassaTime,
     /// Max known blocks we keep in block_handler
     pub max_known_blocks_saved_size: usize,
-    /// max known blocks of current nodes we keep in memory (by node)
+    /// max known blocks of current nodes we keep in memory
     pub max_known_blocks_size: usize,
     /// max known blocks of foreign nodes we keep in memory (by node)
     pub max_node_known_blocks_size: usize,
@@ -80,6 +80,18 @@ pub struct ProtocolConfig {
     pub max_endorsements_propagation_time: MassaTime,
     /// number of thread tester
     pub thread_tester_count: u8,
+    /// Max size of channel to send commands to retrieval thread of operations
+    pub max_size_channel_commands_retrieval_operations: usize,
+    /// Max size of channel to send commands to propagation thread of operations
+    pub max_size_channel_commands_propagation_operations: usize,
+    /// Max size of channel to send commands to retrieval thread of endorsements
+    pub max_size_channel_commands_retrieval_endorsements: usize,
+    /// Max size of channel to send commands to propagation thread of blocks
+    pub max_size_channel_commands_propagation_endorsements: usize,
+    /// Max size of channel to send commands to retrieval thread of blocks
+    pub max_size_channel_commands_retrieval_blocks: usize,
+    /// Max size of channel to send commands to propagation thread of blocks
+    pub max_size_channel_commands_propagation_blocks: usize,
     /// debug prints
     pub debug: bool,
 }

--- a/massa-protocol-exports-2/src/test_exports/config.rs
+++ b/massa-protocol-exports-2/src/test_exports/config.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::ProtocolConfig;
+use massa_models::config::ENDORSEMENT_COUNT;
 use massa_time::MassaTime;
 use peernet::types::KeyPair;
 use tempfile::NamedTempFile;
@@ -45,12 +46,31 @@ impl Default for ProtocolConfig {
                 .to_path_buf(),
             listeners: HashMap::default(),
             thread_tester_count: 2,
+            max_size_channel_commands_connectivity: 1000,
             max_size_channel_commands_retrieval_operations: 10000,
             max_size_channel_commands_propagation_operations: 10000,
             max_size_channel_commands_retrieval_blocks: 1000,
             max_size_channel_commands_propagation_blocks: 1000,
             max_size_channel_commands_propagation_endorsements: 5000,
             max_size_channel_commands_retrieval_endorsements: 5000,
+            max_size_channel_network_to_block_handler: 1000,
+            max_size_channel_network_to_endorsement_handler: 1000,
+            max_size_channel_network_to_operation_handler: 10000,
+            max_size_channel_network_to_peer_handler: 1000,
+            max_size_channel_commands_peer_testers: 10000,
+            max_size_channel_commands_peers: 300,
+            endorsement_count: ENDORSEMENT_COUNT,
+            max_size_block_infos: 200,
+            max_size_value_datastore: 1_000_000,
+            max_size_function_name: u16::MAX,
+            max_size_call_sc_parameter: 10_000_000,
+            max_denunciations_in_block_header: 100,
+            max_op_datastore_entry_count: 100000,
+            max_op_datastore_key_length: u8::MAX,
+            max_op_datastore_value_length: 1000000,
+            max_endorsements_per_message: 1000,
+            max_size_listeners_per_peer: 100,
+            max_size_peers_announcement: 100,
             debug: true,
         }
     }

--- a/massa-protocol-exports-2/src/test_exports/config.rs
+++ b/massa-protocol-exports-2/src/test_exports/config.rs
@@ -45,6 +45,12 @@ impl Default for ProtocolConfig {
                 .to_path_buf(),
             listeners: HashMap::default(),
             thread_tester_count: 2,
+            max_size_channel_commands_retrieval_operations: 10000,
+            max_size_channel_commands_propagation_operations: 10000,
+            max_size_channel_commands_retrieval_blocks: 1000,
+            max_size_channel_commands_propagation_blocks: 1000,
+            max_size_channel_commands_propagation_endorsements: 5000,
+            max_size_channel_commands_retrieval_endorsements: 5000,
             debug: true,
         }
     }

--- a/massa-protocol-worker-2/src/connectivity.rs
+++ b/massa-protocol-worker-2/src/connectivity.rs
@@ -32,7 +32,9 @@ pub enum ConnectivityCommand {
     Stop,
 }
 
-pub fn start_connectivity_thread(
+#[allow(clippy::type_complexity)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_connectivity_thread(
     config: ProtocolConfig,
     mut network_controller: Box<dyn NetworkController>,
     consensus_controller: Box<dyn ConsensusController>,
@@ -79,7 +81,7 @@ pub fn start_connectivity_thread(
             for (addr, transport) in &config.listeners {
                 network_controller
                     .start_listener(*transport, *addr)
-                    .expect(&format!(
+                    .unwrap_or_else(|_| panic!(
                         "Failed to start listener {:?} of transport {:?} in protocol",
                         addr, transport
                     ));
@@ -195,7 +197,7 @@ pub fn start_connectivity_thread(
                                 }
                                 {
                                     {
-                                        if !network_controller.get_active_connections().check_addr_accepted(&addr) {
+                                        if !network_controller.get_active_connections().check_addr_accepted(addr) {
                                             println!("Address already connected");
                                             continue;
                                         }

--- a/massa-protocol-worker-2/src/handlers/block_handler/cache.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/cache.rs
@@ -7,7 +7,6 @@ use peernet::peer_id::PeerId;
 
 pub struct BlockCache {
     pub checked_headers: LruCache<BlockId, SecuredHeader>,
-    //TODO: Add the val true fal as a value
     pub blocks_known_by_peer: LruCache<PeerId, (LruCache<BlockId, (bool, Instant)>, Instant)>,
     pub max_known_blocks_by_peer: NonZeroUsize,
 }

--- a/massa-protocol-worker-2/src/handlers/block_handler/cache.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/cache.rs
@@ -7,6 +7,7 @@ use peernet::peer_id::PeerId;
 
 pub struct BlockCache {
     pub checked_headers: LruCache<BlockId, SecuredHeader>,
+    #[allow(clippy::type_complexity)]
     pub blocks_known_by_peer: LruCache<PeerId, (LruCache<BlockId, (bool, Instant)>, Instant)>,
     pub max_known_blocks_by_peer: NonZeroUsize,
 }
@@ -35,7 +36,7 @@ impl BlockCache {
         Self {
             checked_headers: LruCache::new(max_known_blocks),
             blocks_known_by_peer: LruCache::new(max_known_blocks_by_peer),
-            max_known_blocks_by_peer: max_known_blocks_by_peer,
+            max_known_blocks_by_peer,
         }
     }
 }

--- a/massa-protocol-worker-2/src/handlers/block_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/messages.rs
@@ -44,6 +44,8 @@ pub enum BlockInfoReply {
 }
 
 #[derive(Debug)]
+//TODO: Fix this clippy warning
+#[allow(clippy::large_enum_variant)]
 pub enum BlockMessage {
     /// Block header
     BlockHeader(SecuredHeader),

--- a/massa-protocol-worker-2/src/handlers/block_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/mod.rs
@@ -42,6 +42,7 @@ pub struct BlockHandler {
 }
 
 impl BlockHandler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         active_connections: Box<dyn ActiveConnectionsTrait>,
         consensus_controller: Box<dyn ConsensusController>,
@@ -66,7 +67,7 @@ impl BlockHandler {
             receiver_network,
             receiver_ext,
             internal_sender.clone(),
-            sender_propagations_ops.clone(),
+            sender_propagations_ops,
             peer_cmd_sender.clone(),
             config.clone(),
             endorsement_cache,

--- a/massa-protocol-worker-2/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/propagation.rs
@@ -106,7 +106,7 @@ impl PropagationThread {
                                     if !cond.map_or_else(|| false, |v| v.0) {
                                         massa_trace!("protocol.protocol_worker.process_command.integrated_block.send_header", { "peer_id": peer_id, "block_id": block_id});
                                         if let Err(err) = self.active_connections.send_to_peer(
-                                            &peer_id,
+                                            peer_id,
                                             &self.block_serializer,
                                             BlockMessage::BlockHeader(header.clone()).into(),
                                             true,

--- a/massa-protocol-worker-2/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/propagation.rs
@@ -170,20 +170,22 @@ pub fn start_propagation_thread(
     cache: SharedBlockCache,
     storage: Storage,
 ) -> JoinHandle<()> {
-    //TODO: Here and everywhere add id to threads
-    std::thread::spawn(move || {
-        let block_serializer =
-            MessagesSerializer::new().with_block_message_serializer(BlockMessageSerializer::new());
-        let mut propagation_thread = PropagationThread {
-            receiver,
-            config,
-            cache,
-            peer_cmd_sender,
-            active_connections,
-            block_serializer,
-            storage,
-            saved_blocks: VecDeque::default(),
-        };
-        propagation_thread.run();
-    })
+    std::thread::Builder::new()
+        .name("protocol-block-handler-propagation".to_string())
+        .spawn(move || {
+            let block_serializer = MessagesSerializer::new()
+                .with_block_message_serializer(BlockMessageSerializer::new());
+            let mut propagation_thread = PropagationThread {
+                receiver,
+                config,
+                cache,
+                peer_cmd_sender,
+                active_connections,
+                block_serializer,
+                storage,
+                saved_blocks: VecDeque::default(),
+            };
+            propagation_thread.run();
+        })
+        .expect("OS failed to start block propagation thread")
 }

--- a/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
@@ -1267,26 +1267,29 @@ pub fn start_retrieval_thread(
 ) -> JoinHandle<()> {
     let block_message_serializer =
         MessagesSerializer::new().with_block_message_serializer(BlockMessageSerializer::new());
-    std::thread::spawn(move || {
-        let mut retrieval_thread = RetrievalThread {
-            active_connections,
-            consensus_controller,
-            pool_controller,
-            next_timer_ask_block: Instant::now() + config.ask_block_timeout.to_duration(),
-            block_wishlist: PreHashMap::default(),
-            asked_blocks: HashMap::default(),
-            peer_cmd_sender,
-            sender_propagation_ops,
-            receiver_network,
-            block_message_serializer,
-            receiver,
-            _internal_sender,
-            cache,
-            endorsement_cache,
-            operation_cache,
-            config,
-            storage,
-        };
-        retrieval_thread.run();
-    })
+    std::thread::Builder::new()
+        .name("protocol-block-handler-retrieval".to_string())
+        .spawn(move || {
+            let mut retrieval_thread = RetrievalThread {
+                active_connections,
+                consensus_controller,
+                pool_controller,
+                next_timer_ask_block: Instant::now() + config.ask_block_timeout.to_duration(),
+                block_wishlist: PreHashMap::default(),
+                asked_blocks: HashMap::default(),
+                peer_cmd_sender,
+                sender_propagation_ops,
+                receiver_network,
+                block_message_serializer,
+                receiver,
+                _internal_sender,
+                cache,
+                endorsement_cache,
+                operation_cache,
+                config,
+                storage,
+            };
+            retrieval_thread.run();
+        })
+        .expect("OS failed to start block retrieval thread")
 }

--- a/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
@@ -102,20 +102,19 @@ pub struct RetrievalThread {
 
 impl RetrievalThread {
     fn run(&mut self) {
-        //TODO: Add real values
         let mut block_message_deserializer =
             BlockMessageDeserializer::new(BlockMessageDeserializerArgs {
                 thread_count: self.config.thread_count,
-                endorsement_count: 10000,
-                block_infos_length_max: 10000,
-                max_operations_per_block: 10000,
-                max_datastore_value_length: 10000,
-                max_function_name_length: 10000,
-                max_parameters_size: 10000,
-                max_op_datastore_entry_count: 10000,
-                max_op_datastore_key_length: 100,
-                max_op_datastore_value_length: 10000,
-                max_denunciations_in_block_header: 10000,
+                endorsement_count: self.config.endorsement_count,
+                block_infos_length_max: self.config.max_size_block_infos,
+                max_operations_per_block: self.config.max_operations_per_block as u32,
+                max_datastore_value_length: self.config.max_size_value_datastore,
+                max_function_name_length: self.config.max_size_function_name,
+                max_parameters_size: self.config.max_size_call_sc_parameter,
+                max_op_datastore_entry_count: self.config.max_op_datastore_entry_count,
+                max_op_datastore_key_length: self.config.max_op_datastore_key_length,
+                max_op_datastore_value_length: self.config.max_op_datastore_value_length,
+                max_denunciations_in_block_header: self.config.max_denunciations_in_block_header,
                 last_start_period: None,
             });
         loop {

--- a/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/block_handler/retrieval.rs
@@ -447,9 +447,9 @@ impl RetrievalThread {
         {
             let mut cache_write = self.cache.write();
             if let Some(block_header) = cache_write.checked_headers.get(&block_id).cloned() {
-                cache_write.insert_blocks_known(&from_peer_id, &[block_id], true, Instant::now());
+                cache_write.insert_blocks_known(from_peer_id, &[block_id], true, Instant::now());
                 cache_write.insert_blocks_known(
-                    &from_peer_id,
+                    from_peer_id,
                     &block_header.content.parents,
                     true,
                     Instant::now(),
@@ -513,9 +513,9 @@ impl RetrievalThread {
         {
             let mut cache_write = self.cache.write();
             cache_write.checked_headers.put(block_id, header.clone());
-            cache_write.insert_blocks_known(&from_peer_id, &[block_id], true, Instant::now());
+            cache_write.insert_blocks_known(from_peer_id, &[block_id], true, Instant::now());
             cache_write.insert_blocks_known(
-                &from_peer_id,
+                from_peer_id,
                 &header.content.parents,
                 true,
                 Instant::now(),
@@ -1249,6 +1249,7 @@ impl RetrievalThread {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn start_retrieval_thread(
     active_connections: Box<dyn ActiveConnectionsTrait>,
     consensus_controller: Box<dyn ConsensusController>,

--- a/massa-protocol-worker-2/src/handlers/endorsement_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/endorsement_handler/messages.rs
@@ -11,7 +11,6 @@ use nom::{
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use std::ops::Bound::Included;
 
-//TODO: Upgrade to use a similar workflow as operations
 #[derive(Debug)]
 pub enum EndorsementMessage {
     /// Endorsements

--- a/massa-protocol-worker-2/src/handlers/endorsement_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/endorsement_handler/mod.rs
@@ -32,6 +32,7 @@ pub struct EndorsementHandler {
 }
 
 impl EndorsementHandler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool_controller: Box<dyn PoolController>,
         cache: SharedEndorsementCache,

--- a/massa-protocol-worker-2/src/handlers/endorsement_handler/propagation.rs
+++ b/massa-protocol-worker-2/src/handlers/endorsement_handler/propagation.rs
@@ -152,17 +152,19 @@ pub fn start_propagation_thread(
     config: ProtocolConfig,
     active_connections: Box<dyn ActiveConnectionsTrait>,
 ) -> JoinHandle<()> {
-    //TODO: Here and everywhere add id to threads
-    std::thread::spawn(move || {
-        let endorsement_serializer = MessagesSerializer::new()
-            .with_endorsement_message_serializer(EndorsementMessageSerializer::new());
-        let mut propagation_thread = PropagationThread {
-            receiver,
-            config,
-            active_connections,
-            cache,
-            endorsement_serializer,
-        };
-        propagation_thread.run();
-    })
+    std::thread::Builder::new()
+        .name("protocol-endorsement-handler-propagation".to_string())
+        .spawn(move || {
+            let endorsement_serializer = MessagesSerializer::new()
+                .with_endorsement_message_serializer(EndorsementMessageSerializer::new());
+            let mut propagation_thread = PropagationThread {
+                receiver,
+                config,
+                active_connections,
+                cache,
+                endorsement_serializer,
+            };
+            propagation_thread.run();
+        })
+        .expect("OS failed to start endorsement propagation thread")
 }

--- a/massa-protocol-worker-2/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/endorsement_handler/retrieval.rs
@@ -250,17 +250,20 @@ pub fn start_retrieval_thread(
     config: ProtocolConfig,
     storage: Storage,
 ) -> JoinHandle<()> {
-    std::thread::spawn(move || {
-        let mut retrieval_thread = RetrievalThread {
-            receiver,
-            receiver_ext,
-            peer_cmd_sender,
-            cache,
-            internal_sender,
-            pool_controller,
-            config,
-            storage,
-        };
-        retrieval_thread.run();
-    })
+    std::thread::Builder::new()
+        .name("protocol-endorsement-handler-retrieval".to_string())
+        .spawn(move || {
+            let mut retrieval_thread = RetrievalThread {
+                receiver,
+                receiver_ext,
+                peer_cmd_sender,
+                cache,
+                internal_sender,
+                pool_controller,
+                config,
+                storage,
+            };
+            retrieval_thread.run();
+        })
+        .expect("OS failed to start endorsement retrieval thread")
 }

--- a/massa-protocol-worker-2/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/endorsement_handler/retrieval.rs
@@ -244,6 +244,7 @@ impl RetrievalThread {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn start_retrieval_thread(
     receiver: Receiver<PeerMessageTuple>,
     receiver_ext: Receiver<EndorsementHandlerRetrievalCommand>,

--- a/massa-protocol-worker-2/src/handlers/operation_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/messages.rs
@@ -93,17 +93,17 @@ pub struct OperationMessageDeserializerArgs {
     /// Maximum of full operations sent in one message
     pub max_operations: u32,
     //TODO: All of this arguments should be in a `OperationDeserializer` struct that would be used here
-    ///
+    /// Maximum size of a user datastore value
     pub max_datastore_value_length: u64,
-    ///
+    /// Maximum size of a function name
     pub max_function_name_length: u16,
-    ///
+    /// Maximum size of parameters
     pub max_parameters_size: u32,
-    ///
+    /// Maximum number of entries in the op datastore
     pub max_op_datastore_entry_count: u64,
-    ///
+    /// Maximum size of a op datastore key
     pub max_op_datastore_key_length: u8,
-    ///
+    /// Maximum size of a op datastore value
     pub max_op_datastore_value_length: u64,
 }
 

--- a/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
@@ -45,7 +45,6 @@ impl OperationHandler {
         local_receiver: Receiver<OperationHandlerPropagationCommand>,
         peer_cmd_sender: Sender<PeerManagementCmd>,
     ) -> Self {
-        //TODO: Define bound channel
         let operation_retrieval_thread = start_retrieval_thread(
             receiver_network,
             pool_controller,

--- a/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/mod.rs
@@ -32,6 +32,7 @@ pub struct OperationHandler {
 }
 
 impl OperationHandler {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool_controller: Box<dyn PoolController>,
         storage: Storage,

--- a/massa-protocol-worker-2/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/propagation.rs
@@ -148,16 +148,19 @@ pub fn start_propagation_thread(
     config: ProtocolConfig,
     cache: SharedOperationCache,
 ) -> JoinHandle<()> {
-    std::thread::spawn(move || {
-        let mut propagation_thread = PropagationThread {
-            internal_receiver,
-            active_connections,
-            operations_to_announce: Vec::new(),
-            config,
-            cache,
-            operation_message_serializer: MessagesSerializer::new()
-                .with_operation_message_serializer(OperationMessageSerializer::new()),
-        };
-        propagation_thread.run();
-    })
+    std::thread::Builder::new()
+        .name("protocol-operation-handler-propagation".to_string())
+        .spawn(move || {
+            let mut propagation_thread = PropagationThread {
+                internal_receiver,
+                active_connections,
+                operations_to_announce: Vec::new(),
+                config,
+                cache,
+                operation_message_serializer: MessagesSerializer::new()
+                    .with_operation_message_serializer(OperationMessageSerializer::new()),
+            };
+            propagation_thread.run();
+        })
+        .expect("OS failed to start operation propagation thread")
 }

--- a/massa-protocol-worker-2/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker-2/src/handlers/operation_handler/retrieval.rs
@@ -464,6 +464,7 @@ impl RetrievalThread {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn start_retrieval_thread(
     receiver: Receiver<(PeerId, u64, Vec<u8>)>,
     pool_controller: Box<dyn PoolController>,

--- a/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/messages.rs
@@ -12,6 +12,8 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use peernet::{peer_id::PeerId, transports::TransportType, types::PUBLIC_KEY_SIZE_BYTES};
 
 #[derive(Debug, Clone)]
+//TODO: Fix this clippy warning
+#[allow(clippy::large_enum_variant)]
 pub enum PeerManagementMessage {
     // Receive the ip addresses sent by a peer when connecting.
     NewPeerConnected((PeerId, HashMap<SocketAddr, TransportType>)),
@@ -40,6 +42,7 @@ pub enum MessageTypeId {
     ListPeers = 1,
 }
 
+#[derive(Default)]
 pub struct PeerManagementMessageSerializer {
     length_serializer: U64VarIntSerializer,
     ip_addr_serializer: IpAddrSerializer,

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -69,7 +69,9 @@ impl PeerManagementHandler {
 
         let (test_sender, testers) = Tester::run(config, peer_db.clone());
 
-        let thread_join = std::thread::spawn({
+        let thread_join = std::thread::Builder::new()
+        .name("protocol-peer-handler".to_string())
+        .spawn({
             let peer_db = peer_db.clone();
             let ticker = tick(Duration::from_secs(10));
 
@@ -159,7 +161,7 @@ impl PeerManagementHandler {
                     }
                 }
             }
-        });
+        }).expect("OS failed to start peer management thread");
 
         for (peer_id, listeners) in &initial_peers {
             let mut message = Vec::new();

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -64,7 +64,7 @@ impl PeerManagementHandler {
         config: &ProtocolConfig,
     ) -> Self {
         let (sender_cmd, receiver_cmd): (Sender<PeerManagementCmd>, Receiver<PeerManagementCmd>) =
-            crossbeam::channel::unbounded();
+            crossbeam::channel::bounded(config.max_size_channel_commands_peers);
         let message_serializer = PeerManagementMessageSerializer::new();
 
         let (test_sender, testers) = Tester::run(config, peer_db.clone());
@@ -79,9 +79,8 @@ impl PeerManagementHandler {
                 .with_peer_management_message_serializer(PeerManagementMessageSerializer::new());
             let mut message_deserializer =
                 PeerManagementMessageDeserializer::new(PeerManagementMessageDeserializerArgs {
-                    //TODO: Real config values
-                    max_peers_per_announcement: 1000,
-                    max_listeners_per_peer: 100,
+                    max_peers_per_announcement: config.max_size_peers_announcement,
+                    max_listeners_per_peer: config.max_size_listeners_per_peer,
                 });
             move || {
                 loop {
@@ -138,11 +137,18 @@ impl PeerManagementHandler {
                             }
 
                             message_deserializer.set_message(message_id);
-                            let (_, message) = message_deserializer
-                                .deserialize::<DeserializeError>(&message)
-                                .unwrap();
-                            // TODO: Bufferize launch of test thread
-                            // TODO: Add wait group or something like that to wait for all threads to finish when stop
+                            let (rest, message) = match message_deserializer
+                                .deserialize::<DeserializeError>(&message) {
+                                Ok((rest, message)) => (rest, message),
+                                Err(e) => {
+                                    warn!("error when deserializing message: {:?}", e);
+                                    continue;
+                                }
+                            };
+                            if !rest.is_empty() {
+                                warn!("message not fully deserialized");
+                                continue;
+                            }
                             match message {
                                 PeerManagementMessage::NewPeerConnected((peer_id, listeners)) => {
                                    if let Err(e) = test_sender.send((peer_id, listeners)) {
@@ -204,20 +210,21 @@ impl PeerManagementHandler {
 pub struct MassaHandshake {
     pub announcement_serializer: AnnouncementSerializer,
     pub announcement_deserializer: AnnouncementDeserializer,
+    pub config: ProtocolConfig,
     pub peer_db: SharedPeerDB,
 }
 
 impl MassaHandshake {
-    pub fn new(peer_db: SharedPeerDB) -> Self {
+    pub fn new(peer_db: SharedPeerDB, config: ProtocolConfig) -> Self {
         Self {
             peer_db,
             announcement_serializer: AnnouncementSerializer::new(),
             announcement_deserializer: AnnouncementDeserializer::new(
                 AnnouncementDeserializerArgs {
-                    //TODO: Config
-                    max_listeners: 1000,
+                    max_listeners: config.max_size_listeners_per_peer,
                 },
             ),
+            config,
         }
     }
 }
@@ -262,9 +269,6 @@ impl HandshakeHandler for MassaHandshake {
                         info.state = PeerState::InHandshake;
                     });
             }
-
-            //TODO: We use this to verify the signature before sending it to the handler.
-            //This will be done also in the handler but as we are in the handshake we want to do it to invalid the handshake in case it fails.
 
             offset += 32;
             let (_, announcement) = self
@@ -322,7 +326,6 @@ impl HandshakeHandler for MassaHandshake {
 
             // check their signature
             peer_id.verify_signature(&self_random_hash, &other_signature)?;
-
             Ok(peer_id.clone())
         };
 
@@ -337,7 +340,6 @@ impl HandshakeHandler for MassaHandshake {
                 info.state = PeerState::Trusted;
             });
         }
-
         res
     }
 }

--- a/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/mod.rs
@@ -95,7 +95,7 @@ impl PeerManagementHandler {
 
                             for peer_id in &active_connections.get_peer_ids_connected() {
                                if let Err(e) = active_connections
-                                    .send_to_peer(&peer_id, &message_serializer, msg.clone().into(), false) {
+                                    .send_to_peer(peer_id, &message_serializer, msg.clone().into(), false) {
                                     error!("error sending ListPeers message to peer: {:?}", e);
                                }
                             }

--- a/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
@@ -148,6 +148,7 @@ pub struct Tester {
     pub handler: Option<JoinHandle<()>>,
 }
 
+#[allow(clippy::type_complexity)]
 impl Tester {
     pub fn run(
         config: &ProtocolConfig,

--- a/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker-2/src/handlers/peer_handler/tester.rs
@@ -176,7 +176,9 @@ impl Tester {
     ) -> Self {
         tracing::log::debug!("running new tester");
 
-        let handle = std::thread::spawn(move || {
+        let handle = std::thread::Builder::new()
+        .name("protocol-peer-handler-tester".to_string())
+        .spawn(move || {
             let db = peer_db.clone();
             let mut config = PeerNetConfiguration::default(
                 TesterHandshake::new(peer_db),
@@ -246,7 +248,7 @@ impl Tester {
                     }
                 }
             }
-        });
+        }).expect("OS failed to start peer tester thread");
 
         Self {
             handler: Some(handle),

--- a/massa-protocol-worker-2/src/messages.rs
+++ b/massa-protocol-worker-2/src/messages.rs
@@ -77,6 +77,12 @@ pub struct MessagesSerializer {
     peer_management_message_serializer: Option<PeerManagementMessageSerializer>,
 }
 
+impl Default for MessagesSerializer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl MessagesSerializer {
     pub fn new() -> Self {
         Self {

--- a/massa-protocol-worker-2/src/tests/ban_nodes_scenarios.rs
+++ b/massa-protocol-worker-2/src/tests/ban_nodes_scenarios.rs
@@ -66,7 +66,7 @@ fn test_protocol_bans_node_sending_block_header_with_invalid_signature() {
             );
 
             //5. Check that protocol does not send block to consensus.
-            match consensus_event_receiver.wait_command(MassaTime::from_millis(100), |_| Some(())) {
+            match consensus_event_receiver.wait_command(MassaTime::from_millis(500), |_| Some(())) {
                 Some(()) => {
                     panic!("Protocol sent block to consensus.");
                 }
@@ -126,7 +126,7 @@ fn test_protocol_bans_node_sending_operation_with_invalid_signature() {
             );
 
             //5. Check that protocol does not send operation to pool.
-            match pool_event_receiver.wait_command(MassaTime::from_millis(100), |_| Some(())) {
+            match pool_event_receiver.wait_command(MassaTime::from_millis(500), |_| Some(())) {
                 Some(()) => {
                     panic!("Protocol sent block to consensus.");
                 }
@@ -283,7 +283,7 @@ fn test_protocol_does_not_asks_for_block_from_banned_node_who_propagated_header(
 
             //5. Check that protocol does send block to consensus.
             match consensus_event_receiver.wait_command(
-                MassaTime::from_millis(100),
+                MassaTime::from_millis(500),
                 |evt| match evt {
                     MockConsensusControllerMessage::RegisterBlockHeader {
                         block_id,
@@ -384,7 +384,7 @@ fn test_protocol_bans_all_nodes_propagating_an_attack_attempt() {
                 .unwrap();
             //4. Check that protocol does send block to consensus the first time.
             match consensus_event_receiver.wait_command(
-                MassaTime::from_millis(100),
+                MassaTime::from_millis(500),
                 |evt| match evt {
                     MockConsensusControllerMessage::RegisterBlockHeader {
                         block_id,
@@ -410,7 +410,7 @@ fn test_protocol_bans_all_nodes_propagating_an_attack_attempt() {
                 )
                 .unwrap();
             //5. Check that protocol does send block to consensus the second time.
-            match consensus_event_receiver.wait_command(MassaTime::from_millis(100), |_| Some(())) {
+            match consensus_event_receiver.wait_command(MassaTime::from_millis(500), |_| Some(())) {
                 Some(()) => panic!("Protocol should not send block to consensus"),
                 None => {}
             }

--- a/massa-protocol-worker-2/src/tests/context.rs
+++ b/massa-protocol-worker-2/src/tests/context.rs
@@ -5,7 +5,7 @@ use crate::{
     manager::ProtocolManagerImpl, messages::MessagesHandler,
     tests::mock_network::MockNetworkController,
 };
-use crossbeam::channel::unbounded;
+use crossbeam::channel::bounded;
 use massa_consensus_exports::{
     test_exports::{ConsensusControllerImpl, ConsensusEventReceiver},
     ConsensusController,
@@ -46,10 +46,13 @@ pub fn start_protocol_controller_with_mock_network(
     debug!("starting protocol controller with mock network");
     let peer_db = Arc::new(RwLock::new(PeerDB::default()));
 
-    let (sender_operations, receiver_operations) = unbounded();
-    let (sender_endorsements, receiver_endorsements) = unbounded();
-    let (sender_blocks, receiver_blocks) = unbounded();
-    let (sender_peers, receiver_peers) = unbounded();
+    let (sender_operations, receiver_operations) =
+        bounded(config.max_size_channel_network_to_operation_handler);
+    let (sender_endorsements, receiver_endorsements) =
+        bounded(config.max_size_channel_network_to_endorsement_handler);
+    let (sender_blocks, receiver_blocks) =
+        bounded(config.max_size_channel_network_to_block_handler);
+    let (sender_peers, receiver_peers) = bounded(config.max_size_channel_network_to_peer_handler);
 
     // Register channels for handlers
     let message_handlers: MessagesHandler = MessagesHandler {

--- a/massa-protocol-worker-2/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker-2/src/tests/endorsements_scenarios.rs
@@ -217,7 +217,6 @@ fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_about_it_b
             let (node_a_peer_id, node_a) = network_controller.create_fake_connection(
                 PeerId::from_bytes(node_a_keypair.get_public_key().to_bytes()).unwrap(),
             );
-            println!("Node A peer id: {:?}", node_a_peer_id);
             let (_node_b_peer_id, node_b) = network_controller.create_fake_connection(
                 PeerId::from_bytes(node_b_keypair.get_public_key().to_bytes()).unwrap(),
             );

--- a/massa-protocol-worker-2/src/tests/mod.rs
+++ b/massa-protocol-worker-2/src/tests/mod.rs
@@ -62,7 +62,7 @@ fn basic() {
     config1.max_out_connections = 1;
     config2.initial_peers = initial_peers_file_2.path().to_path_buf();
     config2.max_in_connections = 5;
-    config2.max_out_connections = 1;
+    config2.max_out_connections = 0;
     config2.debug = false;
 
     // Setup the storages

--- a/massa-protocol-worker-2/src/tests/mod.rs
+++ b/massa-protocol-worker-2/src/tests/mod.rs
@@ -62,7 +62,7 @@ fn basic() {
     config1.max_out_connections = 1;
     config2.initial_peers = initial_peers_file_2.path().to_path_buf();
     config2.max_in_connections = 5;
-    config2.max_out_connections = 0;
+    config2.max_out_connections = 1;
     config2.debug = false;
 
     // Setup the storages
@@ -77,7 +77,7 @@ fn basic() {
         start_protocol_controller(config2, consensus_controller2, pool_controller2, storage2)
             .expect("Failed to start protocol 2");
 
-    std::thread::sleep(Duration::from_secs(5));
+    std::thread::sleep(Duration::from_secs(15));
     // Stop the protocols
     sender_manager1.stop();
     manager1.stop();

--- a/massa-protocol-worker-2/src/worker.rs
+++ b/massa-protocol-worker-2/src/worker.rs
@@ -25,6 +25,7 @@ use crate::{
 /// * `config`: protocol settings
 /// * `consensus_controller`: interact with consensus module
 /// * `storage`: Shared storage to fetch data that are fetch across all modules
+#[allow(clippy::type_complexity)]
 pub fn start_protocol_controller(
     config: ProtocolConfig,
     consensus_controller: Box<dyn ConsensusController>,

--- a/massa-protocol-worker-2/src/worker.rs
+++ b/massa-protocol-worker-2/src/worker.rs
@@ -52,7 +52,6 @@ pub fn start_protocol_controller(
         PeerNetConfiguration::default(MassaHandshake::new(peer_db.clone()), message_handlers);
     peernet_config.self_keypair = config.keypair.clone();
     peernet_config.fallback_function = Some(&fallback_function);
-    //TODO: Add the rest of the config
     peernet_config.max_in_connections = config.max_in_connections;
     peernet_config.max_out_connections = config.max_out_connections;
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4d0d4bc</samp>

### Summary
🛠️📝🔧

<!--
1.  🛠️ - This emoji represents the general theme of fixing, improving, and refactoring the code, as well as addressing clippy warnings and TODO comments.
2.  📝 - This emoji represents the addition of documentation comments and thread names, which enhance the readability and understanding of the code.
3.  🔧 - This emoji represents the introduction of configurable parameters and tuning options for the protocol, which allow for more flexibility and customization.
-->
This pull request updates the protocol worker module to use the latest protocol configuration, improve the code quality and performance of the handlers, and enhance the error handling and logging of the threads. It also fixes some clippy warnings, removes some obsolete comments, and adds some documentation. The main files affected are `connectivity.rs`, `block_handler.rs`, `endorsement_handler.rs`, `operation_handler.rs`, `peer_handler.rs`, and `messages.rs`.

> _We're tuning up the protocol, we're fixing all the bugs_
> _We're handling all the errors, we're suppressing all the clugs_
> _We're naming all the threads, we're using bounded channels_
> _We're heaving on the `ProtocolConfig`, one, two, three, and pull!_

### Walkthrough
*  Remove `thread_count` field from `ProtocolConfig` struct and replace it with constant `THREAD_COUNT` ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6288abd5afc84916487dfa91aa480aad35779a7aab0100a9ac98416eb65990a7L23-R27))
* Change type of `max_operations_per_message` field from `u64` to `u32` in `ProtocolConfig` struct ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6288abd5afc84916487dfa91aa480aad35779a7aab0100a9ac98416eb65990a7L64-R62))
* Add new fields to `ProtocolConfig` struct for various protocol parameters and limits ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6288abd5afc84916487dfa91aa480aad35779a7aab0100a9ac98416eb65990a7R81-R132))
* Import `ENDORSEMENT_COUNT` constant and initialize new fields of `ProtocolConfig` struct in test exports module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-054bff72c425c79c212a96848f1d0d568325e29fbb45abd276f59b9da65d6d8fR4), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-054bff72c425c79c212a96848f1d0d568325e29fbb45abd276f59b9da65d6d8fR49-R73))
* Change import of `crossbeam` crate from `unbounded` to `bounded` and import `tracing::warn` macro ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL2-R2), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eR16))
* Add clippy annotations to suppress warnings about type complexity and number of arguments in `start_connectivity_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL34-R37))
* Change creation of channels from `unbounded` to `bounded` with `ProtocolConfig` fields and create thread with name in `start_connectivity_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL55-R75))
* Change initialization of caches with `ProtocolConfig` fields and add clippy annotation to suppress warning about type complexity in `BlockCache` struct ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL74-R103))
* Add check for peer info existence and change use of `peer_id` and `addr` from reference to value in `connectivity_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL179-R192), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL187-R200), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL196-R211))
* Add error handling and create thread with name in `start_listener` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c2d72e603a7e395a81a361e7ff5aa497652841761cc6dc0c1f587abf2d778b7eL204-R220))
* Add clippy annotation to suppress warning about large enum variant in `BlockMessage` enum ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-cd393b7f1880a5026157f50754af3696f45ba2aca45123c13dc50ce425ef33e9L10-R10), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-b65c06e9d8ae615cdfc4d905e87d56bddc4774cf95a759bcc678872a906d1eb3R47-R48))
* Remove redundant field name in `BlockCache` struct initialization ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-cd393b7f1880a5026157f50754af3696f45ba2aca45123c13dc50ce425ef33e9L39-R39))
* Add clippy annotation to suppress warning about number of arguments in `start_block_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-8c4a38023592bc37eedf7e063e33d0fa239f88ccbc8cf279dc9941d82f026f31R45))
* Remove redundant cloning of channel sender in `start_block_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-8c4a38023592bc37eedf7e063e33d0fa239f88ccbc8cf279dc9941d82f026f31L69-R70))
* Change use of `peer_id` from reference to value in `propagate_blocks` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-96858fc09a34d4fa80457fbda8ede414b0844ae40385c9c0d38574e0e6983adfL109-R109))
* Add error handling and create thread with name in `start_block_propagation_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-96858fc09a34d4fa80457fbda8ede414b0844ae40385c9c0d38574e0e6983adfL173-R190))
* Change initialization of `block_message_deserializer` with `ProtocolConfig` fields in `start_block_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9bb654cd720a34b029e918b26fb2b2e4ed7f43ba55a3c4d8f93511c18d4470c7L105-R117))
* Change use of `from_peer_id` from reference to value in `handle_block_message` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9bb654cd720a34b029e918b26fb2b2e4ed7f43ba55a3c4d8f93511c18d4470c7L451-R452), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9bb654cd720a34b029e918b26fb2b2e4ed7f43ba55a3c4d8f93511c18d4470c7L517-R518))
* Add clippy annotation to suppress warning about number of arguments in `start_block_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9bb654cd720a34b029e918b26fb2b2e4ed7f43ba55a3c4d8f93511c18d4470c7R1252))
* Add error handling and create thread with name in `start_block_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9bb654cd720a34b029e918b26fb2b2e4ed7f43ba55a3c4d8f93511c18d4470c7L1270-R1294))
* Remove TODO comment in `messages.rs` file of endorsement handler module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-b10363e0cd63b1b70ba7192f1bdb2ba89931b77dd57de00c80c239752db9183eL14))
* Add clippy annotation to suppress warning about number of arguments in `start_endorsement_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-1d8c8d7bfd18d2ce8b4fa7207c62858625c7f86b42d1f842f52031efcbce98f0R35))
* Add error handling and create thread with name in `start_endorsement_propagation_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-8dce794d137d73851b17676ae6c1a41db8d5d26ef53ceb9db1dd67d24b3b48b1L155-R169))
* Change initialization of `endorsement_message_deserializer` with `ProtocolConfig` fields and add error handling and empty message check in `start_endorsement_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c8624e622a87909c2dd0639a7cd4bde89c3919dbe979bd824c955917a7553d8bL51-R55), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c8624e622a87909c2dd0639a7cd4bde89c3919dbe979bd824c955917a7553d8bL64-R70))
* Add clippy annotation to suppress warning about number of arguments in `start_endorsement_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c8624e622a87909c2dd0639a7cd4bde89c3919dbe979bd824c955917a7553d8bR247))
* Add error handling and create thread with name in `start_endorsement_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-c8624e622a87909c2dd0639a7cd4bde89c3919dbe979bd824c955917a7553d8bL253-R273))
* Add documentation comments to fields of `OperationMessageDeserializerArgs` struct in `messages.rs` file of operation handler module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-dffea73be3986ded33a9fd57d3e34ee033aa3db1f28093bdb817277ce1c1ab06L96-R106))
* Add clippy annotation to suppress warning about number of arguments in `start_operation_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-62d09db317a78d54f6f233b93af261066042c5c00e3cacb2e3d5801a0143f853R35))
* Remove TODO comment in `start_operation_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-62d09db317a78d54f6f233b93af261066042c5c00e3cacb2e3d5801a0143f853L48))
* Add error handling and create thread with name in `start_operation_propagation_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-ebd5ebb2124045f7a99c004e7c84a3ea6f35019c30df62f39ccc1932ce4d60bdL151-R165))
* Change initialization of `operation_message_deserializer` with `ProtocolConfig` fields and add error handling and empty message check in `start_operation_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6bc4c5b8233d6b37c580df3c0c9f5f2939f9ba27e89427a9aaee178e8cc14417L74-R83), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6bc4c5b8233d6b37c580df3c0c9f5f2939f9ba27e89427a9aaee178e8cc14417L95-R100))
* Add clippy annotation to suppress warning about number of arguments in `start_operation_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6bc4c5b8233d6b37c580df3c0c9f5f2939f9ba27e89427a9aaee178e8cc14417R467))
* Add error handling and create thread with name in `start_operation_retrieval_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-6bc4c5b8233d6b37c580df3c0c9f5f2939f9ba27e89427a9aaee178e8cc14417L475-R503))
* Add clippy annotation to suppress warning about large enum variant in `PeerManagementMessage` enum and add `Default` implementation for `PeerAnnounce` struct in `messages.rs` file of peer handler module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-3ee6b5d03a2ec8bd4ea221282881616b72acc1f9ee84cfedca9acefb431b3026R15-R16), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-3ee6b5d03a2ec8bd4ea221282881616b72acc1f9ee84cfedca9acefb431b3026R45))
* Change creation of channels from `unbounded` to `bounded` with `ProtocolConfig` fields and change initialization of `message_deserializer` with `ProtocolConfig` fields in `start_peer_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL67-R74), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL80-R83))
* Change use of `peer_id` from reference to value and remove TODO comment in `handle_peer_message` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL97-R98), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL139-R151))
* Add documentation comments to fields of `AnnouncementDeserializerArgs` struct and add `config` field to `MassaHandshake` struct in `start_peer_handler_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL162-R170), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL205-R218))
* Remove TODO comment in `start_peer_tester_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL264-L266))
* Remove empty lines in `start_peer_tester_thread` function ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL323), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-7165d31835e99b9c8715c9c94afb5149d2e6b8c39cb3a3dd244811f71c1ae65cL338))
* Add `config` argument to `new` method of `TesterHandshake` and `Tester` structs and add clippy annotation to suppress warning about type complexity in `run` method of `Tester` struct in `tester.rs` file of peer handler module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L36-R41), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09R151), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L163-R171))
* Change calculation of elapsed seconds since last announcement and add error handling and create thread with name in `tester.rs` file of peer handler module ([link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L175-R190), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L232-R240), [link](https://github.com/massalabs/massa/pull/3875/files?diff=unified&w=0#diff-9d9bbaebe84221f667ce39359894963e4c0212978110bdc7bc16fff3b7d69e09L249-R257))

