### PR TITLE
Add gRPC health check

### DIFF
--- a/massa-grpc/src/config.rs
+++ b/massa-grpc/src/config.rs
@@ -14,6 +14,8 @@ pub struct GrpcConfig {
     pub accept_http1: bool,
     /// whether to enable CORS. Works only if `accept_http1` is true
     pub enable_cors: bool,
+    /// whether to enable gRPC health service
+    pub enable_health: bool,
     /// whether to enable gRPC reflection
     pub enable_reflection: bool,
     /// bind for the Massa gRPC API

--- a/massa-grpc/src/tests/test.rs
+++ b/massa-grpc/src/tests/test.rs
@@ -47,6 +47,7 @@ async fn test_start_grpc_server() {
         enabled: true,
         accept_http1: true,
         enable_cors: true,
+        enable_health: true,
         enable_reflection: true,
         bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888),
         accept_compressed: None,

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -45,6 +45,8 @@
     accept_http1 = false
     # whether to enable CORS. works only if `accept_http1` is true
     enable_cors = false
+    # whether to enable gRPC health service
+    enable_health = true
     # whether to enable gRPC reflection(introspection)
     enable_reflection = true
     # bind for the Massa gRPC API

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -727,6 +727,7 @@ async fn launch(
             enabled: SETTINGS.grpc.enabled,
             accept_http1: SETTINGS.grpc.accept_http1,
             enable_cors: SETTINGS.grpc.enable_cors,
+            enable_health: SETTINGS.grpc.enable_health,
             enable_reflection: SETTINGS.grpc.enable_reflection,
             bind: SETTINGS.grpc.bind,
             accept_compressed: SETTINGS.grpc.accept_compressed.clone(),

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -234,6 +234,8 @@ pub struct GrpcSettings {
     pub accept_http1: bool,
     /// whether to enable CORS. Works only if `accept_http1` is true
     pub enable_cors: bool,
+    /// whether to enable gRPC health service
+    pub enable_health: bool,
     /// whether to enable gRPC reflection
     pub enable_reflection: bool,
     /// bind for the Massa gRPC API


### PR DESCRIPTION
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cbdc4c4</samp>

### Summary
🩺🛠️📄

<!--
1.  🩺 - This emoji represents the health service, which is the main feature of this pull request. It also conveys the idea of monitoring and checking the status of the gRPC server.
2.  🛠️ - This emoji represents the bug fix in the `ScExecutionEventContext` message, which was a minor but necessary correction to the protobuf definition. It also conveys the idea of fixing and improving the code quality.
3.  📄 - This emoji represents the config file changes, which allow users to enable or disable the health service via the config file. It also conveys the idea of adding documentation and configuration options.
-->
This pull request adds a gRPC health service to the `MassaService` and allows users to enable or disable it via the config file. It also fixes a bug in the `ScExecutionEventContext` message definition in the `massa-proto` crate.

> _We are the Massa, we serve the gRPC_
> _We check our health with `enable_health`_
> _We fix our bugs and we load our config_
> _We rock the network with `MassaService`_

### Walkthrough
*  Add a new field `enable_health` to the `GrpcConfig` struct and the `GrpcSettings` struct to allow users to configure the gRPC health service via the config file ([link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-f2a63de0b5493af00a5aa27559dac1da15340da33516a41b325cc9df09797ae1R17-R18), [link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-1f883ba25a829313ad70daa6c31595706cf842a63e6e7bc0c342d89081084226R248-R249))
*  Pass the `enable_health` value from the config file to the gRPC server initialization in the `main` function ([link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-535b75052259fc1e2f15ad89ecd55326f762d8a118074d573377d09116533761R726))
*  Create and add an optional `HealthService` to the gRPC server based on the `enable_health` flag in the `start` function of `massa-grpc/src/server.rs` ([link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR17), [link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR80-R91), [link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR105))
*  Define and spawn a task to periodically update the health status of the `MassaService` using a `HealthReporter` and a stub function `massa_service_status` in `massa-grpc/src/server.rs` ([link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR80-R91), [link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR172-R179))
*  Fix a bug in the tag numbers of the `ScExecutionEventContext` message definition in `massa-proto/src/massa.api.v1.rs` ([link](https://github.com/massalabs/massa/pull/3888/files?diff=unified&w=0#diff-798542cd089e9e67e2cab48d3814caacfc251213c60a050e968c493ea39a5062L767-R782))

