### PR TITLE
Improve gRPC service configuration

### DIFF
--- a/massa-grpc/src/server.rs
+++ b/massa-grpc/src/server.rs
@@ -105,6 +105,16 @@ impl MassaGrpc {
             info!("gRPC mTLS enabled");
         }
 
+        let reflection_service_opt = if config.enable_reflection {
+            let reflection_service = tonic_reflection::server::Builder::configure()
+                .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
+                .build()?;
+
+            Some(reflection_service)
+        } else {
+            None
+        };
+
         let health_service_opt = if config.enable_health {
             let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
             health_reporter
@@ -126,52 +136,34 @@ impl MassaGrpc {
                     .allow_origin(Any)
                     .allow_headers([hyper::header::CONTENT_TYPE]);
 
-                let mut router_with_http1 = server_builder
+                let router_with_http1 = server_builder
                     .accept_http1(true)
                     .layer(cors)
                     .layer(GrpcWebLayer::new())
+                    .add_optional_service(reflection_service_opt)
                     .add_optional_service(health_service_opt)
                     .add_service(svc);
-
-                if config.enable_reflection {
-                    let reflection_service = tonic_reflection::server::Builder::configure()
-                        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-                        .build()?;
-
-                    router_with_http1 = router_with_http1.add_service(reflection_service);
-                }
 
                 tokio::spawn(
                     router_with_http1.serve_with_shutdown(config.bind, shutdown_recv.map(drop)),
                 );
             } else {
-                let mut router_with_http1 = server_builder
+                let router_with_http1 = server_builder
                     .accept_http1(true)
                     .layer(GrpcWebLayer::new())
+                    .add_optional_service(reflection_service_opt)
+                    .add_optional_service(health_service_opt)
                     .add_service(svc);
-
-                if config.enable_reflection {
-                    let reflection_service = tonic_reflection::server::Builder::configure()
-                        .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-                        .build()?;
-
-                    router_with_http1 = router_with_http1.add_service(reflection_service);
-                }
 
                 tokio::spawn(
                     router_with_http1.serve_with_shutdown(config.bind, shutdown_recv.map(drop)),
                 );
             }
         } else {
-            let mut router = server_builder.add_service(svc);
-
-            if config.enable_reflection {
-                let reflection_service = tonic_reflection::server::Builder::configure()
-                    .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-                    .build()?;
-
-                router = router.add_service(reflection_service);
-            }
+            let router = server_builder
+                .add_optional_service(reflection_service_opt)
+                .add_optional_service(health_service_opt)
+                .add_service(svc);
 
             tokio::spawn(router.serve_with_shutdown(config.bind, shutdown_recv.map(drop)));
         }


### PR DESCRIPTION
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification

closes #3955

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b9bb9c3</samp>

### Summary
🔧🧹🚀

<!--
1.  🔧 - This emoji represents a tool or a fix, and it can be used to indicate that the pull request adds an optional service that can be useful for debugging or testing purposes, such as the reflection service.
2.  🧹 - This emoji represents a broom or a cleanup, and it can be used to indicate that the pull request simplifies or refactors some code, such as the router creation code that uses a helper method to avoid repetition.
3.  🚀 - This emoji represents a rocket or a launch, and it can be used to indicate that the pull request improves the performance or functionality of the gRPC server, such as by enabling clients to discover the available services and methods without prior knowledge.
-->
This pull request enhances the gRPC server functionality and readability. It enables reflection for easier service discovery and testing, and refactors the router creation code with a helper method. It affects the file `massa-grpc/src/server.rs`.

> _`Reflection` of the server, a dark and twisted mirror_
> _Adding optional services with a helper of terror_
> _Simplifying the router, a path to the abyss_
> _gRPC is the master, we are the servants of its will_

### Walkthrough
*  Add an optional reflection service to the gRPC server based on the configuration flag ([link](https://github.com/massalabs/massa/pull/3956/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbR108-R117))
* Simplify the router creation by using the `add_optional_service` method to conditionally add the reflection service and the health service ([link](https://github.com/massalabs/massa/pull/3956/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbL129-R157), [link](https://github.com/massalabs/massa/pull/3956/files?diff=unified&w=0#diff-507c2082a69d04eed0231855a1d61745e1acdbc30467b3731c29dd6ae06765bbL166-R167))

