### PR TITLE
Add grpc access to massa client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,7 +2957,10 @@ dependencies = [
  "jsonrpsee-ws-client",
  "massa_api_exports",
  "massa_models",
+ "massa_proto",
  "massa_time",
+ "thiserror",
+ "tonic",
 ]
 
 [[package]]

--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -7,6 +7,7 @@ timeout = 1000
 ip = "127.0.0.1"
 private_port = 33034
 public_port = 33035
+grpc_port = 33037
 
 [client]
     # maximum size in bytes of a request

--- a/massa-client/src/cmds.rs
+++ b/massa-client/src/cmds.rs
@@ -439,7 +439,7 @@ impl Command {
     ///     it means that we don't want to print anything we just want the json output
     pub(crate) async fn run(
         &self,
-        client: &Client,
+        client: &mut Client,
         wallet_opt: &mut Option<Wallet>,
         parameters: &[String],
         json: bool,

--- a/massa-client/src/repl.rs
+++ b/massa-client/src/repl.rs
@@ -77,7 +77,7 @@ struct MyHelper {
 }
 
 pub(crate) async fn run(
-    client: &Client,
+    client: &mut Client,
     wallet_path: &Path,
     args_password: Option<String>,
 ) -> Result<()> {

--- a/massa-client/src/settings.rs
+++ b/massa-client/src/settings.rs
@@ -24,6 +24,7 @@ pub struct DefaultNode {
     pub ip: IpAddr,
     pub private_port: u16,
     pub public_port: u16,
+    pub grpc_port: u16,
 }
 
 /// Client settings

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -40,7 +40,7 @@
 
 [grpc]
     # whether to enable gRPC
-    enabled = false
+    enabled = true
     # whether to add HTTP 1 layer
     accept_http1 = false
     # whether to enable CORS. works only if `accept_http1` is true
@@ -52,7 +52,7 @@
     # whether to enable mTLS
     enable_mtls = false
     # bind for the Massa gRPC API
-    bind = "0.0.0.0:33037"
+    bind = "127.0.0.1:33037"
     # which compression encodings does the server accept for requests
     accept_compressed = "Gzip"
     # which compression encodings might the server use for responses

--- a/massa-sdk/Cargo.toml
+++ b/massa-sdk/Cargo.toml
@@ -8,6 +8,9 @@ jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee.git", rev = "118acc
 jsonrpsee-http-client = { git = "https://github.com/paritytech/jsonrpsee.git", rev = "118acc3", features = ["webpki-tls"] }
 jsonrpsee-ws-client = { git = "https://github.com/paritytech/jsonrpsee.git", rev = "118acc3", features = ["webpki-tls"] }
 http = "0.2.8"
+tonic = { version = "0.9.1", features = ["gzip"] }
+thiserror = "1.0"
 massa_api_exports = { path = "../massa-api-exports" }
 massa_models = { path = "../massa-models" }
 massa_time = { path = "../massa-time" }
+massa_proto = { path = "../massa-proto" }

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -40,11 +40,13 @@ use massa_models::{
     prehash::{PreHashMap, PreHashSet},
     version::Version,
 };
-
-use jsonrpsee_http_client as _;
-use jsonrpsee_ws_client as _;
+use massa_proto::massa::api::v1::massa_service_client::MassaServiceClient;
 
 use jsonrpsee::{core::Error as JsonRpseeError, core::RpcResult, http_client::HttpClientBuilder};
+use jsonrpsee_http_client as _;
+use jsonrpsee_ws_client as _;
+use thiserror::Error;
+
 use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 
@@ -53,12 +55,25 @@ pub use config::ClientConfig;
 pub use config::HttpConfig;
 pub use config::WsConfig;
 
+/// Error when creating a new client
+#[derive(Error, Debug)]
+pub enum ClientError {
+    /// Url error
+    #[error("Invalid grpc url: {0}")]
+    Url(#[from] http::uri::InvalidUri),
+    /// Connection error
+    #[error("Cannot connect to grpc server: {0}")]
+    Connect(#[from] tonic::transport::Error),
+}
+
 /// Client
 pub struct Client {
     /// public component
     pub public: RpcClient,
     /// private component
     pub private: RpcClient,
+    /// grpc client
+    pub grpc: MassaServiceClient<tonic::transport::Channel>,
 }
 
 impl Client {
@@ -67,16 +82,25 @@ impl Client {
         ip: IpAddr,
         public_port: u16,
         private_port: u16,
+        grpc_port: u16,
         http_config: &HttpConfig,
-    ) -> Client {
+    ) -> Result<Client, ClientError> {
         let public_socket_addr = SocketAddr::new(ip, public_port);
         let private_socket_addr = SocketAddr::new(ip, private_port);
+        let grpc_socket_addr = SocketAddr::new(ip, grpc_port);
         let public_url = format!("http://{}", public_socket_addr);
         let private_url = format!("http://{}", private_socket_addr);
-        Client {
+        let grpc_url = format!("grpc://{}", grpc_socket_addr);
+
+        // start grpc client and connect to the server
+        let channel = tonic::transport::Channel::from_shared(grpc_url)?
+            .connect()
+            .await?;
+        Ok(Client {
             public: RpcClient::from_url(&public_url, http_config).await,
             private: RpcClient::from_url(&private_url, http_config).await,
-        }
+            grpc: MassaServiceClient::new(channel),
+        })
     }
 }
 


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2ded563</samp>

### Summary
🚀🔧📄

<!--
1.  🚀 This emoji represents the new feature of GRPC support, which is a fast and efficient way of communicating with the node.
2.  🔧 This emoji represents the modifications to the existing code, which required some adjustments to the signatures and parameters of the client functions.
3.  📄 This emoji represents the additions to the configuration file and the dependencies, which are necessary to enable and use the GRPC feature.
-->
This pull request adds GRPC support to the `massa-client` and the `massa-sdk` crates. It allows the user to specify the GRPC port for the Massa API in the configuration file, and updates the client code to use the `MassaServiceClient` from the `tonic` library. It also handles the GRPC connection errors and modifies the function signatures to pass mutable references to the GRPC client.

> _We are the masters of the binary protocol_
> _We unleash the power of the `grpc_port`_
> _We face the errors with the `ClientError`_
> _We are the rebels of the Massa GRPC API_

### Walkthrough
*  Add a new configuration option `grpc_port` to specify the port for the Massa GRPC API ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-b71f5c1c659c020ba7e9849d8408407917b4262889f0e1697bd3c437aa4acc19R10))
*  Add a new command-line argument `grpc_port` to override the default port for the Massa GRPC API ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-67e388fc9353bc27224c6f1a18f20974cfa5cc01f92f9d8775645e22dbe7d747R36-R38))
*  Modify the `Client` struct and its `new` method to use the `MassaServiceClient` type from the `tonic` crate as the GRPC client for the Massa API ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bR75-R76), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bL70-R103))
*  Handle the possible errors from creating the GRPC client and URL using the `ClientError` enum and the `thiserror` crate ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bR58-R68), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bR75-R76), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bL70-R103))
*  Change the `client` parameter from a reference to a mutable reference in the `run` methods of the `Command` enum and the `repl` module, as well as the `client` variable in the `main` function, to allow the GRPC client to send requests ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-38f1fe83b7203d0c6f5555df6f6ead7f2a43b9ddadce4a7372ba5723e34d5645L442-R442), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-67e388fc9353bc27224c6f1a18f20974cfa5cc01f92f9d8775645e22dbe7d747L140-R152), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-67e388fc9353bc27224c6f1a18f20974cfa5cc01f92f9d8775645e22dbe7d747L164-R173), [link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-daf7cd7959a568b6feae23c8e11bf39814c0d942a2e91cdcd6451e19bcd339acL80-R80))
*  Add the `tonic` and `thiserror` dependencies to the `massa-sdk` crate ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-7fa5e7c899d945da356ff5f0e7be794fe0987f467ea551d6b78369407e53b429L11-R16))
*  Import the generated GRPC client type and the `Error` derive macro in the `massa-sdk` crate ([link](https://github.com/massalabs/massa/pull/3957/files?diff=unified&w=0#diff-e71b845a7059b2849e90ee807800068ed15d65fb076b4b565cc06014a2a57e6bL43-R49))

