### PR TITLE
Refactor server start to remove waker-dance

### DIFF
--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 humantime = "2.1.0"
 thiserror = "1.0"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
-tracing = "0.1"
+tracing = {version =  "0.1", features = ["log"] }
 substruct = { git = "https://github.com/sydhds/substruct" }
 socket2 = "0.4.7"
 crossbeam = "0.8.2"

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -11,7 +11,7 @@ use crate::server::BSEventPoller;
 const NEW_CONNECTION: Token = Token(0);
 const STOP_LISTENER: Token = Token(10);
 
-/// TODO: this should be crate-private. currently needed for models testing
+/// Inject into `start_bootstrap_server` to provide the listen-dependency
 pub struct BootstrapTcpListener {
     poll: Poll,
     events: Events,

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -76,7 +76,7 @@ pub struct BootstrapManager {
     // need to preserve the listener handle up to here to prevent it being destroyed
     #[allow(clippy::type_complexity)]
     main_handle: thread::JoinHandle<Result<(), BootstrapError>>,
-    listener_stopper: Option<BootstrapListenerStopHandle>,
+    listener_stopper: BootstrapListenerStopHandle,
     update_stopper_tx: crossbeam::channel::Sender<()>,
 }
 
@@ -87,29 +87,23 @@ impl BootstrapManager {
         update_handle: thread::JoinHandle<Result<(), BootstrapError>>,
         main_handle: thread::JoinHandle<Result<(), BootstrapError>>,
         update_stopper_tx: crossbeam::channel::Sender<()>,
+        listener_stopper: BootstrapListenerStopHandle,
     ) -> Self {
         Self {
             update_handle,
             main_handle,
             update_stopper_tx,
-            listener_stopper: None,
+            listener_stopper,
         }
     }
-    /// Sets an event-emmiter. `Self::stop`] will use this stopper to signal the listener that created this stopper.
-    pub fn set_listener_stopper(&mut self, listener_stopper: BootstrapListenerStopHandle) {
-        self.listener_stopper = Some(listener_stopper);
-    }
-
     /// stop the bootstrap server
     pub fn stop(self) -> Result<(), BootstrapError> {
         massa_trace!("bootstrap.lib.stop", {});
         // `as_ref` is critical here, as the stopper has to be alive until the poll in the event
         // loop acts on the stop-signal
         // TODO: Refactor the waker so that its existance is tied to the life of the event-loop
-        if let Some(listen_stop_handle) = self.listener_stopper.as_ref() {
-            if listen_stop_handle.stop().is_err() {
-                warn!("bootstrap server already dropped");
-            }
+        if self.listener_stopper.stop().is_err() {
+            warn!("bootstrap server already dropped");
         }
         if self.update_stopper_tx.send(()).is_err() {
             warn!("bootstrap ip-list-updater already dropped");
@@ -132,6 +126,7 @@ impl BootstrapManager {
 #[allow(clippy::too_many_arguments)]
 pub fn start_bootstrap_server<L: BSEventPoller + Send + 'static>(
     ev_poller: L,
+    waker: BootstrapListenerStopHandle,
     consensus_controller: Box<dyn ConsensusController>,
     protocol_controller: Box<dyn ProtocolController>,
     final_state: Arc<RwLock<FinalState>>,
@@ -195,6 +190,7 @@ pub fn start_bootstrap_server<L: BSEventPoller + Send + 'static>(
         update_handle,
         main_handle,
         update_stopper_tx,
+        waker,
     ))
 }
 

--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -171,8 +171,10 @@ fn mock_bootstrap_manager(addr: SocketAddr, bootstrap_config: BootstrapConfig) -
         .expect_clone_box()
         .return_once(move || stream_mock2);
 
+    let (waker, listener) = BootstrapTcpListener::new(&addr).unwrap();
     start_bootstrap_server(
-        BootstrapTcpListener::new(&addr).unwrap().1,
+        listener,
+        waker,
         stream_mock1,
         mocked1,
         final_state_server,
@@ -361,8 +363,10 @@ fn test_bootstrap_server() {
     let bootstrap_manager_thread = std::thread::Builder::new()
         .name("bootstrap_thread".to_string())
         .spawn(move || {
+            let (waker, _) = BootstrapTcpListener::new(&"127.0.0.1:0".parse().unwrap()).unwrap();
             start_bootstrap_server(
                 mock_bs_listener,
+                waker,
                 stream_mock1,
                 Box::new(mocked1),
                 final_state_server_clone1,

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -709,8 +709,9 @@ async fn launch(
                 format!("Could not bind to address: {}", addr).as_str()
             )
         });
-        let mut manager = start_bootstrap_server(
+        start_bootstrap_server(
             listener,
+            waker,
             consensus_controller.clone(),
             protocol_controller.clone(),
             final_state.clone(),
@@ -719,9 +720,7 @@ async fn launch(
             *VERSION,
             mip_store.clone(),
         )
-        .expect("Could not start bootstrap server");
-        manager.set_listener_stopper(waker);
-        manager
+        .expect("Could not start bootstrap server")
     });
 
     let api_config: APIConfig = APIConfig {


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification