### PR TITLE
Use schnellru crate instead of lru in massa-protocol-worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,15 +2263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
-dependencies = [
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "lz4-sys"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,7 +2955,6 @@ name = "massa_protocol_worker"
 version = "0.1.0"
 dependencies = [
  "crossbeam",
- "lru",
  "massa_consensus_exports",
  "massa_hash 0.1.0",
  "massa_logging",
@@ -2982,6 +2972,7 @@ dependencies = [
  "peernet",
  "rand 0.8.5",
  "rayon",
+ "schnellru",
  "serde_json",
  "serial_test 2.0.0",
  "tempfile",

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -15,7 +15,7 @@ num_enum = "0.5"
 peernet = { git = "https://github.com/massalabs/PeerNet", branch = "generic_peer_id" }
 tempfile = { version = "3.3", optional = true } # use with testing feature
 rayon = "1.7.0"
-lru = "0.10.0"
+schnellru = "0.2.1"
 
 # modules Custom
 massa_hash = { path = "../massa-hash" }

--- a/massa-protocol-worker/src/connectivity.rs
+++ b/massa-protocol-worker/src/connectivity.rs
@@ -12,8 +12,8 @@ use parking_lot::RwLock;
 use peernet::transports::TcpOutConnectionConfig;
 use peernet::{peer::PeerConnectionType, transports::OutConnectionConfig};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::{collections::HashMap, net::IpAddr};
-use std::{num::NonZeroUsize, sync::Arc};
 use std::{thread::JoinHandle, time::Duration};
 use tracing::{info, warn};
 
@@ -87,17 +87,17 @@ pub(crate) fn start_connectivity_thread(
             let total_in_slots = config.peers_categories.values().map(|v| v.max_in_connections_post_handshake).sum::<usize>() + config.default_category_info.max_in_connections_post_handshake;
             let total_out_slots = config.peers_categories.values().map(| v| v.target_out_connections).sum::<usize>() + config.default_category_info.target_out_connections;
             let operation_cache = Arc::new(RwLock::new(OperationCache::new(
-                NonZeroUsize::new(config.max_known_ops_size).unwrap(),
-                NonZeroUsize::new(total_in_slots + total_out_slots).unwrap(),
+                config.max_known_blocks_size.try_into().unwrap(),
+                (total_in_slots + total_out_slots).try_into().unwrap(),
             )));
             let endorsement_cache = Arc::new(RwLock::new(EndorsementCache::new(
-                NonZeroUsize::new(config.max_known_endorsements_size).unwrap(),
-                NonZeroUsize::new(total_in_slots + total_out_slots).unwrap(),
+                config.max_known_endorsements_size.try_into().unwrap(),
+                (total_in_slots + total_out_slots).try_into().unwrap()
             )));
 
             let block_cache = Arc::new(RwLock::new(BlockCache::new(
-                NonZeroUsize::new(config.max_known_blocks_size).unwrap(),
-                NonZeroUsize::new(total_in_slots + total_out_slots).unwrap(),
+                config.max_known_blocks_size.try_into().unwrap(),
+                (total_in_slots + total_out_slots).try_into().unwrap(),
             )));
 
             // Start handlers

--- a/massa-protocol-worker/src/handlers/block_handler/cache.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/cache.rs
@@ -1,15 +1,15 @@
-use std::{num::NonZeroUsize, sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant};
 
-use lru::LruCache;
 use massa_models::{block_header::SecuredHeader, block_id::BlockId};
 use massa_protocol_exports::PeerId;
 use parking_lot::RwLock;
+use schnellru::{ByLength, LruMap};
 
 pub struct BlockCache {
-    pub checked_headers: LruCache<BlockId, SecuredHeader>,
+    pub checked_headers: LruMap<BlockId, SecuredHeader>,
     #[allow(clippy::type_complexity)]
-    pub blocks_known_by_peer: LruCache<PeerId, (LruCache<BlockId, (bool, Instant)>, Instant)>,
-    pub max_known_blocks_by_peer: NonZeroUsize,
+    pub blocks_known_by_peer: LruMap<PeerId, (LruMap<BlockId, (bool, Instant)>, Instant)>,
+    pub max_known_blocks_by_peer: u32,
 }
 
 impl BlockCache {
@@ -22,20 +22,25 @@ impl BlockCache {
     ) {
         let (blocks, _) = self
             .blocks_known_by_peer
-            .get_or_insert_mut(from_peer_id.clone(), || {
-                (LruCache::new(self.max_known_blocks_by_peer), Instant::now())
-            });
+            .get_or_insert(from_peer_id.clone(), || {
+                (
+                    LruMap::new(ByLength::new(self.max_known_blocks_by_peer)),
+                    Instant::now(),
+                )
+            })
+            .ok_or(())
+            .expect("blocks_known_by_peer limit reached");
         for block_id in block_ids {
-            blocks.put(*block_id, (val, timeout));
+            blocks.insert(*block_id, (val, timeout));
         }
     }
 }
 
 impl BlockCache {
-    pub fn new(max_known_blocks: NonZeroUsize, max_known_blocks_by_peer: NonZeroUsize) -> Self {
+    pub fn new(max_known_blocks: u32, max_known_blocks_by_peer: u32) -> Self {
         Self {
-            checked_headers: LruCache::new(max_known_blocks),
-            blocks_known_by_peer: LruCache::new(max_known_blocks_by_peer),
+            checked_headers: LruMap::new(ByLength::new(max_known_blocks)),
+            blocks_known_by_peer: LruMap::new(ByLength::new(max_known_blocks_by_peer)),
             max_known_blocks_by_peer,
         }
     }

--- a/massa-protocol-worker/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/propagation.rs
@@ -81,7 +81,7 @@ impl PropagationThread {
                                     }
                                 }
                                 for peer_id in peers_connected {
-                                    if !cache_write.blocks_known_by_peer.peek(&peer_id).is_some() {
+                                    if cache_write.blocks_known_by_peer.peek(&peer_id).is_none() {
                                         //TODO: Change to detect the connection before
                                         cache_write.blocks_known_by_peer.insert(
                                             peer_id,

--- a/massa-protocol-worker/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/propagation.rs
@@ -1,12 +1,12 @@
-use std::{collections::VecDeque, num::NonZeroUsize, thread::JoinHandle, time::Instant};
+use std::{collections::VecDeque, thread::JoinHandle, time::Instant};
 
 use crossbeam::channel::{Receiver, Sender};
-use lru::LruCache;
 use massa_logging::massa_trace;
 use massa_models::{block_id::BlockId, prehash::PreHashSet};
 use massa_protocol_exports::PeerId;
 use massa_protocol_exports::{ProtocolConfig, ProtocolError};
 use massa_storage::Storage;
+use schnellru::{ByLength, LruMap};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -77,18 +77,18 @@ impl PropagationThread {
                                     self.active_connections.get_peer_ids_connected();
                                 for peer_id in peers {
                                     if !peers_connected.contains(&peer_id) {
-                                        cache_write.blocks_known_by_peer.pop(&peer_id);
+                                        cache_write.blocks_known_by_peer.remove(&peer_id);
                                     }
                                 }
                                 for peer_id in peers_connected {
-                                    if !cache_write.blocks_known_by_peer.contains(&peer_id) {
+                                    if cache_write.blocks_known_by_peer.get(&peer_id).is_none() {
                                         //TODO: Change to detect the connection before
-                                        cache_write.blocks_known_by_peer.put(
+                                        cache_write.blocks_known_by_peer.insert(
                                             peer_id,
                                             (
-                                                LruCache::new(
-                                                    NonZeroUsize::new(self.config.max_node_known_blocks_size)
-                                                        .expect("max_node_known_blocks_size in config must be > 0"),
+                                                LruMap::new(
+                                                    ByLength::new(self.config.max_node_known_blocks_size.try_into()
+                                                        .expect("max_node_known_blocks_size in config must be > 0")),
                                                 ),
                                                 Instant::now(),
                                             ),
@@ -98,7 +98,8 @@ impl PropagationThread {
                             }
                             {
                                 let cache_read = self.cache.read();
-                                for (peer_id, (blocks_known, _)) in &cache_read.blocks_known_by_peer
+                                for (peer_id, (blocks_known, _)) in
+                                    cache_read.blocks_known_by_peer.iter()
                                 {
                                     // peer that isn't asking for that block
                                     let cond = blocks_known.peek(&block_id);

--- a/massa-protocol-worker/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/propagation.rs
@@ -81,7 +81,7 @@ impl PropagationThread {
                                     }
                                 }
                                 for peer_id in peers_connected {
-                                    if cache_write.blocks_known_by_peer.get(&peer_id).is_none() {
+                                    if !cache_write.blocks_known_by_peer.peek(&peer_id).is_some() {
                                         //TODO: Change to detect the connection before
                                         cache_write.blocks_known_by_peer.insert(
                                             peer_id,

--- a/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
@@ -1138,14 +1138,8 @@ impl RetrievalThread {
                             ),
                         );
                     } else {
-                        let data = cache_write
-                            .blocks_known_by_peer
-                            .remove(&peer_id)
-                            .ok_or(())
-                            .expect("promote peer_id not found");
-                        cache_write
-                            .blocks_known_by_peer
-                            .insert(peer_id.clone(), data);
+                        // Promote peer_id as the newest used key
+                        cache_write.blocks_known_by_peer.get(&peer_id);
                     }
 
                     if !self.asked_blocks.contains_key(&peer_id) {

--- a/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
-    num::NonZeroUsize,
     thread::JoinHandle,
     time::Instant,
 };
@@ -21,7 +20,6 @@ use crossbeam::{
     channel::{at, Receiver, Sender},
     select,
 };
-use lru::LruCache;
 use massa_consensus_exports::ConsensusController;
 use massa_hash::{Hash, HASH_SIZE_BYTES};
 use massa_logging::massa_trace;
@@ -42,6 +40,7 @@ use massa_serialization::{DeserializeError, Deserializer, Serializer};
 use massa_storage::Storage;
 use massa_time::TimeError;
 use massa_versioning::versioning::MipStore;
+use schnellru::{ByLength, LruMap};
 use tracing::{debug, info, warn};
 
 use super::{
@@ -309,7 +308,7 @@ impl RetrievalThread {
             let connected_peers = self.active_connections.get_peer_ids_connected();
             for peer_id in peers {
                 if !connected_peers.contains(&peer_id) {
-                    cache_write.blocks_known_by_peer.pop(&peer_id);
+                    cache_write.blocks_known_by_peer.remove(&peer_id);
                     self.asked_blocks.remove(&peer_id);
                 }
             }
@@ -503,14 +502,18 @@ impl RetrievalThread {
                     let mut endorsement_cache_write = self.endorsement_cache.write();
                     let endorsement_ids = endorsement_cache_write
                         .endorsements_known_by_peer
-                        .get_or_insert_mut(from_peer_id.clone(), || {
-                            LruCache::new(
-                                NonZeroUsize::new(self.config.max_node_known_blocks_size)
+                        .get_or_insert(from_peer_id.clone(), || {
+                            LruMap::new(ByLength::new(
+                                self.config
+                                    .max_node_known_blocks_size
+                                    .try_into()
                                     .expect("max_node_known_blocks_size in config must be > 0"),
-                            )
-                        });
+                            ))
+                        })
+                        .ok_or(())
+                        .expect("endorsements_known_by_peer limit reached");
                     for endorsement_id in block_header.content.endorsements.iter().map(|e| e.id) {
-                        endorsement_ids.put(endorsement_id, ());
+                        endorsement_ids.insert(endorsement_id, ());
                     }
                 }
                 return Ok(Some((block_id, false)));
@@ -557,7 +560,7 @@ impl RetrievalThread {
         }
         {
             let mut cache_write = self.cache.write();
-            cache_write.checked_headers.put(block_id, header.clone());
+            cache_write.checked_headers.insert(block_id, header.clone());
             cache_write.insert_blocks_known(from_peer_id, &[block_id], true, Instant::now());
             cache_write.insert_blocks_known(
                 from_peer_id,
@@ -569,14 +572,18 @@ impl RetrievalThread {
                 let mut endorsement_cache_write = self.endorsement_cache.write();
                 let endorsement_ids = endorsement_cache_write
                     .endorsements_known_by_peer
-                    .get_or_insert_mut(from_peer_id.clone(), || {
-                        LruCache::new(
-                            NonZeroUsize::new(self.config.max_node_known_blocks_size)
+                    .get_or_insert(from_peer_id.clone(), || {
+                        LruMap::new(ByLength::new(
+                            self.config
+                                .max_node_known_blocks_size
+                                .try_into()
                                 .expect("max_node_known_blocks_size in config must be > 0"),
-                        )
-                    });
+                        ))
+                    })
+                    .ok_or(())
+                    .expect("endorsements_known_by_peer limit reached");
                 for endorsement_id in header.content.endorsements.iter().map(|e| e.id) {
-                    endorsement_ids.put(endorsement_id, ());
+                    endorsement_ids.insert(endorsement_id, ());
                 }
             }
         }
@@ -626,7 +633,11 @@ impl RetrievalThread {
             // check endorsement signature if not already checked
             {
                 let read_cache = self.endorsement_cache.read();
-                if !read_cache.checked_endorsements.contains(&endorsement_id) {
+                if read_cache
+                    .checked_endorsements
+                    .peek(&endorsement_id)
+                    .is_none()
+                {
                     new_endorsements.insert(endorsement_id, endorsement);
                 }
             }
@@ -651,20 +662,23 @@ impl RetrievalThread {
             let mut cache_write = self.endorsement_cache.write();
             // add to verified signature cache
             for endorsement_id in endorsement_ids.iter() {
-                cache_write.checked_endorsements.put(*endorsement_id, ());
+                cache_write.checked_endorsements.insert(*endorsement_id, ());
             }
             // add to known endorsements for source node.
-            let endorsements = cache_write.endorsements_known_by_peer.get_or_insert_mut(
-                from_peer_id.clone(),
-                || {
-                    LruCache::new(
-                        NonZeroUsize::new(self.config.max_node_known_endorsements_size)
+            let endorsements = cache_write
+                .endorsements_known_by_peer
+                .get_or_insert(from_peer_id.clone(), || {
+                    LruMap::new(ByLength::new(
+                        self.config
+                            .max_node_known_endorsements_size
+                            .try_into()
                             .expect("max_node_known_endorsements_size in config should be > 0"),
-                    )
-                },
-            );
+                    ))
+                })
+                .ok_or(())
+                .expect("endorsements_known_by_peer limit reached");
             for endorsement_id in endorsement_ids.iter() {
-                endorsements.put(*endorsement_id, ());
+                endorsements.insert(*endorsement_id, ());
             }
         }
 
@@ -706,17 +720,20 @@ impl RetrievalThread {
         // add to known ops
         {
             let mut cache_write = self.operation_cache.write();
-            let known_ops =
-                cache_write
-                    .ops_known_by_peer
-                    .get_or_insert_mut(from_peer_id.clone(), || {
-                        LruCache::new(
-                            NonZeroUsize::new(self.config.max_node_known_ops_size)
-                                .expect("max_node_known_ops_size in config should be > 0"),
-                        )
-                    });
+            let known_ops = cache_write
+                .ops_known_by_peer
+                .get_or_insert(from_peer_id.clone(), || {
+                    LruMap::new(ByLength::new(
+                        self.config
+                            .max_node_known_ops_size
+                            .try_into()
+                            .expect("max_node_known_ops_size in config should be > 0"),
+                    ))
+                })
+                .ok_or(())
+                .expect("ops_known_by_peer limitation reached");
             for op_id in operation_ids_set.iter() {
-                known_ops.put(op_id.prefix(), ());
+                known_ops.insert(op_id.prefix(), ());
             }
         }
         let info = if let Some(info) = self.block_wishlist.get_mut(&block_id) {
@@ -1014,11 +1031,12 @@ impl RetrievalThread {
             };
 
             // Check operation signature only if not already checked.
-            if !self
+            if self
                 .operation_cache
                 .read()
                 .checked_operations
-                .contains(&operation_id)
+                .peek(&operation_id)
+                .is_none()
             {
                 // check signature if the operation wasn't in `checked_operation`
                 new_operations.insert(operation_id, operation);
@@ -1093,7 +1111,7 @@ impl RetrievalThread {
                     .collect();
                 for peer_id in peers_in_cache {
                     if !peers_connected.contains(&peer_id) {
-                        cache_write.blocks_known_by_peer.pop(&peer_id);
+                        cache_write.blocks_known_by_peer.remove(&peer_id);
                     }
                 }
                 let peers_in_asked_blocks: Vec<PeerId> =
@@ -1105,20 +1123,29 @@ impl RetrievalThread {
                 }
                 // Add new peers
                 for peer_id in peers_connected {
-                    if !cache_write.blocks_known_by_peer.contains(&peer_id) {
+                    if cache_write.blocks_known_by_peer.get(&peer_id).is_none() {
                         //TODO: Change to detect the connection before
-                        cache_write.blocks_known_by_peer.put(
+                        cache_write.blocks_known_by_peer.insert(
                             peer_id.clone(),
                             (
-                                LruCache::new(
-                                    NonZeroUsize::new(self.config.max_node_known_blocks_size)
+                                LruMap::new(ByLength::new(
+                                    self.config
+                                        .max_node_known_blocks_size
+                                        .try_into()
                                         .expect("max_node_known_blocks_size in config must be > 0"),
-                                ),
+                                )),
                                 Instant::now(),
                             ),
                         );
                     } else {
-                        cache_write.blocks_known_by_peer.promote(&peer_id);
+                        let data = cache_write
+                            .blocks_known_by_peer
+                            .remove(&peer_id)
+                            .ok_or(())
+                            .expect("promote peer_id not found");
+                        cache_write
+                            .blocks_known_by_peer
+                            .insert(peer_id.clone(), data);
                     }
 
                     if !self.asked_blocks.contains_key(&peer_id) {
@@ -1126,7 +1153,16 @@ impl RetrievalThread {
                             .insert(peer_id.clone(), PreHashMap::default());
                     }
                 }
-                for (peer_id, (blocks_known, _)) in cache_write.blocks_known_by_peer.iter_mut() {
+                let all_keys: Vec<PeerId> = cache_write
+                    .blocks_known_by_peer
+                    .iter()
+                    .map(|(k, _)| k)
+                    .cloned()
+                    .collect();
+                for peer_id in all_keys.iter() {
+                    // for (peer_id, (blocks_known, _)) in cache_write.blocks_known_by_peer.iter() {
+                    let (blocks_known, _) =
+                        cache_write.blocks_known_by_peer.peek_mut(peer_id).unwrap();
                     // map to remove the borrow on asked_blocks. Otherwise can't call insert_known_blocks
                     let ask_time_opt = self
                         .asked_blocks
@@ -1167,10 +1203,10 @@ impl RetrievalThread {
                             continue; // not a candidate
                         }
                         // timed out, supposed to have it
-                        (true, Some(timeout_at), Some((true, info_time))) => {
-                            if info_time < &timeout_at {
+                        (true, Some(mut timeout_at), Some((true, info_time))) => {
+                            if info_time < &mut timeout_at {
                                 // info less recent than timeout: mark as not having it
-                                blocks_known.put(*hash, (false, timeout_at));
+                                blocks_known.insert(*hash, (false, timeout_at));
                                 (2u8, ask_time_opt)
                             } else {
                                 // told us it has it after a timeout: good candidate again
@@ -1178,16 +1214,16 @@ impl RetrievalThread {
                             }
                         }
                         // timed out, supposed to not have it
-                        (true, Some(timeout_at), Some((false, info_time))) => {
-                            if info_time < &timeout_at {
+                        (true, Some(mut timeout_at), Some((false, info_time))) => {
+                            if info_time < &mut timeout_at {
                                 // info less recent than timeout: update info time
-                                blocks_known.put(*hash, (false, timeout_at));
+                                blocks_known.insert(*hash, (false, timeout_at));
                             }
                             (2u8, ask_time_opt)
                         }
                         // timed out but don't know if has it: mark as not having it
                         (true, Some(timeout_at), None) => {
-                            blocks_known.put(*hash, (false, timeout_at));
+                            blocks_known.insert(*hash, (false, timeout_at));
                             (2u8, ask_time_opt)
                         }
                     };

--- a/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
@@ -1,23 +1,20 @@
-use std::{num::NonZeroUsize, sync::Arc};
+use std::sync::Arc;
 
-use lru::LruCache;
 use massa_models::endorsement::EndorsementId;
 use massa_protocol_exports::PeerId;
 use parking_lot::RwLock;
+use schnellru::{ByLength, LruMap};
 
 pub struct EndorsementCache {
-    pub checked_endorsements: LruCache<EndorsementId, ()>,
-    pub endorsements_known_by_peer: LruCache<PeerId, LruCache<EndorsementId, ()>>,
+    pub checked_endorsements: LruMap<EndorsementId, ()>,
+    pub endorsements_known_by_peer: LruMap<PeerId, LruMap<EndorsementId, ()>>,
 }
 
 impl EndorsementCache {
-    pub fn new(
-        max_known_endorsements: NonZeroUsize,
-        max_known_endorsements_by_peer: NonZeroUsize,
-    ) -> Self {
+    pub fn new(max_known_endorsements: u32, max_known_endorsements_by_peer: u32) -> Self {
         Self {
-            checked_endorsements: LruCache::new(max_known_endorsements),
-            endorsements_known_by_peer: LruCache::new(max_known_endorsements_by_peer),
+            checked_endorsements: LruMap::new(ByLength::new(max_known_endorsements)),
+            endorsements_known_by_peer: LruMap::new(ByLength::new(max_known_endorsements_by_peer)),
         }
     }
 }

--- a/massa-protocol-worker/src/handlers/operation_handler/cache.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/cache.rs
@@ -1,29 +1,29 @@
-use std::{num::NonZeroUsize, sync::Arc};
+use std::sync::Arc;
 
-use lru::LruCache;
 use massa_models::operation::{OperationId, OperationPrefixId};
 use massa_protocol_exports::PeerId;
 use parking_lot::RwLock;
+use schnellru::{ByLength, LruMap};
 
 pub struct OperationCache {
-    pub checked_operations: LruCache<OperationId, ()>,
-    pub checked_operations_prefix: LruCache<OperationPrefixId, ()>,
-    pub ops_known_by_peer: LruCache<PeerId, LruCache<OperationPrefixId, ()>>,
+    pub checked_operations: LruMap<OperationId, ()>,
+    pub checked_operations_prefix: LruMap<OperationPrefixId, ()>,
+    pub ops_known_by_peer: LruMap<PeerId, LruMap<OperationPrefixId, ()>>,
 }
 
 impl OperationCache {
-    pub fn new(max_known_ops: NonZeroUsize, max_known_ops_by_peer: NonZeroUsize) -> Self {
+    pub fn new(max_known_ops: u32, max_known_ops_by_peer: u32) -> Self {
         Self {
-            checked_operations: LruCache::new(max_known_ops),
-            checked_operations_prefix: LruCache::new(max_known_ops),
-            ops_known_by_peer: LruCache::new(max_known_ops_by_peer),
+            checked_operations: LruMap::new(ByLength::new(max_known_ops)),
+            checked_operations_prefix: LruMap::new(ByLength::new(max_known_ops)),
+            ops_known_by_peer: LruMap::new(ByLength::new(max_known_ops_by_peer)),
         }
     }
 
     pub fn insert_checked_operation(&mut self, operation_id: OperationId) {
-        self.checked_operations.put(operation_id, ());
+        self.checked_operations.insert(operation_id, ());
         self.checked_operations_prefix
-            .put(operation_id.prefix(), ());
+            .insert(operation_id.prefix(), ());
     }
 }
 

--- a/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
@@ -102,7 +102,7 @@ impl PropagationThread {
 
             // Add new potential peers
             for peer_id in peers_connected {
-                if cache_write.ops_known_by_peer.get(&peer_id).is_none() {
+                if cache_write.ops_known_by_peer.peek(&peer_id).is_none() {
                     cache_write.ops_known_by_peer.insert(
                         peer_id.clone(),
                         LruMap::new(ByLength::new(

--- a/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
@@ -1,11 +1,11 @@
-use std::{mem, num::NonZeroUsize, thread::JoinHandle};
+use std::{mem, thread::JoinHandle};
 
 use crossbeam::channel::{Receiver, RecvTimeoutError};
-use lru::LruCache;
 use massa_logging::massa_trace;
 use massa_models::operation::OperationId;
 use massa_protocol_exports::PeerId;
 use massa_protocol_exports::ProtocolConfig;
+use schnellru::{ByLength, LruMap};
 use tracing::{debug, info, log::warn};
 
 use crate::{
@@ -96,33 +96,42 @@ impl PropagationThread {
 
             for peer_id in peers {
                 if !peers_connected.contains(&peer_id) {
-                    cache_write.ops_known_by_peer.pop(&peer_id);
+                    cache_write.ops_known_by_peer.remove(&peer_id);
                 }
             }
 
             // Add new potential peers
             for peer_id in peers_connected {
-                if !cache_write.ops_known_by_peer.contains(&peer_id) {
-                    cache_write.ops_known_by_peer.put(
+                if cache_write.ops_known_by_peer.get(&peer_id).is_none() {
+                    cache_write.ops_known_by_peer.insert(
                         peer_id.clone(),
-                        LruCache::new(
-                            NonZeroUsize::new(self.config.max_node_known_ops_size)
+                        LruMap::new(ByLength::new(
+                            self.config
+                                .max_node_known_ops_size
+                                .try_into()
                                 .expect("max_node_known_endorsements_size in config is > 0"),
-                        ),
+                        )),
                     );
                 }
             }
 
             // Propagate to peers
-            for (peer_id, ops) in cache_write.ops_known_by_peer.iter_mut() {
+            let all_keys: Vec<PeerId> = cache_write
+                .ops_known_by_peer
+                .iter()
+                .map(|(k, _)| k)
+                .cloned()
+                .collect();
+            for peer_id in all_keys {
+                let ops = cache_write.ops_known_by_peer.peek_mut(&peer_id).unwrap();
                 let new_ops: Vec<OperationId> = operation_ids
                     .iter()
-                    .filter(|id| !ops.contains(&id.prefix()))
+                    .filter(|id| ops.peek(&id.prefix()).is_none())
                     .copied()
                     .collect();
                 if !new_ops.is_empty() {
                     for id in &new_ops {
-                        ops.put(id.prefix(), ());
+                        ops.insert(id.prefix(), ());
                     }
                     debug!(
                         "Send operations announcement of len {} to {}",
@@ -132,7 +141,7 @@ impl PropagationThread {
                     for sub_list in new_ops.chunks(self.config.max_operations_per_message as usize)
                     {
                         if let Err(err) = self.active_connections.send_to_peer(
-                            peer_id,
+                            &peer_id,
                             &self.operation_message_serializer,
                             OperationMessage::OperationsAnnouncement(
                                 sub_list.iter().map(|id| id.into_prefix()).collect(),

--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{HashMap, VecDeque},
-    num::NonZeroUsize,
     thread::JoinHandle,
     time::Instant,
 };
@@ -9,7 +8,6 @@ use crossbeam::{
     channel::{tick, Receiver, Sender},
     select,
 };
-use lru::LruCache;
 use massa_logging::massa_trace;
 use massa_models::{
     operation::{OperationId, OperationPrefixId, OperationPrefixIds, SecureShareOperation},
@@ -24,6 +22,7 @@ use massa_protocol_exports::{ProtocolConfig, ProtocolError};
 use massa_serialization::{DeserializeError, Deserializer};
 use massa_storage::Storage;
 use massa_time::{MassaTime, TimeError};
+use schnellru::{ByLength, LruMap};
 
 use crate::{
     handlers::peer_handler::models::{PeerManagementCmd, PeerMessageTuple},
@@ -57,7 +56,7 @@ pub struct RetrievalThread {
     receiver: Receiver<PeerMessageTuple>,
     pool_controller: Box<dyn PoolController>,
     cache: SharedOperationCache,
-    asked_operations: LruCache<OperationPrefixId, (Instant, Vec<PeerId>)>,
+    asked_operations: LruMap<OperationPrefixId, (Instant, Vec<PeerId>)>,
     active_connections: Box<dyn ActiveConnectionsTrait>,
     op_batch_buffer: VecDeque<OperationBatchItem>,
     stored_operations: HashMap<Instant, PreHashSet<OperationId>>,
@@ -194,7 +193,13 @@ impl RetrievalThread {
             received_ids.insert(operation_id);
 
             // Check operation signature only if not already checked.
-            if !self.cache.read().checked_operations.contains(&operation_id) {
+            if self
+                .cache
+                .read()
+                .checked_operations
+                .peek(&operation_id)
+                .is_none()
+            {
                 // check signature if the operation wasn't in `checked_operation`
                 new_operations.insert(operation_id, operation);
             };
@@ -216,17 +221,20 @@ impl RetrievalThread {
             }
 
             // add to known ops
-            let known_ops =
-                cache_write
-                    .ops_known_by_peer
-                    .get_or_insert_mut(source_peer_id.clone(), || {
-                        LruCache::new(
-                            NonZeroUsize::new(self.config.max_node_known_ops_size)
-                                .expect("max_node_known_ops_size in config must be > 0"),
-                        )
-                    });
+            let known_ops = cache_write
+                .ops_known_by_peer
+                .get_or_insert(source_peer_id.clone(), || {
+                    LruMap::new(ByLength::new(
+                        self.config
+                            .max_node_known_ops_size
+                            .try_into()
+                            .expect("max_node_known_ops_size in config must be > 0"),
+                    ))
+                })
+                .ok_or(())
+                .expect("ops_known_by_peer limitation reached");
             for id in received_ids {
-                known_ops.put(id.prefix(), ());
+                known_ops.insert(id.prefix(), ());
             }
         }
 
@@ -310,24 +318,27 @@ impl RetrievalThread {
         // mark sender as knowing the ops
         {
             let mut cache_write = self.cache.write();
-            let known_ops =
-                cache_write
-                    .ops_known_by_peer
-                    .get_or_insert_mut(peer_id.clone(), || {
-                        LruCache::new(
-                            NonZeroUsize::new(self.config.max_node_known_ops_size)
-                                .expect("max_node_known_ops_size in config must be > 0"),
-                        )
-                    });
+            let known_ops = cache_write
+                .ops_known_by_peer
+                .get_or_insert(peer_id.clone(), || {
+                    LruMap::new(ByLength::new(
+                        self.config
+                            .max_node_known_ops_size
+                            .try_into()
+                            .expect("max_node_known_ops_size in config must be > 0"),
+                    ))
+                })
+                .ok_or(())
+                .expect("ops_known_by_peer limitation reached");
             for prefix in &op_batch {
-                known_ops.put(*prefix, ());
+                known_ops.insert(*prefix, ());
             }
         }
 
         // filter out the operations that we already know about
         {
             let cache_read = self.cache.read();
-            op_batch.retain(|prefix| !cache_read.checked_operations_prefix.contains(prefix));
+            op_batch.retain(|prefix| cache_read.checked_operations_prefix.peek(prefix).is_none());
         }
 
         let mut ask_set = OperationPrefixIds::with_capacity(op_batch.len());
@@ -336,7 +347,7 @@ impl RetrievalThread {
         let now = Instant::now();
         let mut count_reask = 0;
         for op_id in op_batch {
-            let wish = match self.asked_operations.get_mut(&op_id) {
+            let wish = match self.asked_operations.get(&op_id) {
                 Some(wish) => {
                     if wish.1.contains(peer_id) {
                         continue; // already asked to the `peer_id`
@@ -364,7 +375,7 @@ impl RetrievalThread {
             } else {
                 ask_set.insert(op_id);
                 self.asked_operations
-                    .put(op_id, (now, vec![peer_id.clone()]));
+                    .insert(op_id, (now, vec![peer_id.clone()]));
             }
         } // EndOf for op_id in op_batch:
 
@@ -405,7 +416,7 @@ impl RetrievalThread {
                     warn!("Failed to send AskForOperations message to peer: {}", err);
                     {
                         let mut cache_write = self.cache.write();
-                        cache_write.ops_known_by_peer.pop(peer_id);
+                        cache_write.ops_known_by_peer.remove(peer_id);
                     }
                 }
             }
@@ -469,7 +480,7 @@ impl RetrievalThread {
                 warn!("Failed to send Operations message to peer: {}", err);
                 {
                     let mut cache_write = self.cache.write();
-                    cache_write.ops_known_by_peer.pop(peer_id);
+                    cache_write.ops_known_by_peer.remove(peer_id);
                 }
             }
         }
@@ -509,10 +520,12 @@ pub fn start_retrieval_thread(
                 receiver_ext,
                 cache,
                 active_connections,
-                asked_operations: LruCache::new(
-                    NonZeroUsize::new(config.asked_operations_buffer_capacity)
+                asked_operations: LruMap::new(ByLength::new(
+                    config
+                        .asked_operations_buffer_capacity
+                        .try_into()
                         .expect("asked_operations_buffer_capacity in config must be > 0"),
-                ),
+                )),
                 config,
                 operation_message_serializer: MessagesSerializer::new()
                     .with_operation_message_serializer(OperationMessageSerializer::new()),


### PR DESCRIPTION
Closes #3844

Uses `schnellru` version `0.2.1` for the Lru cache in protocol worker.
Some hacks were required to make it work as it doesn't have any `contains`, `iter_mut` and `promote` functions.
Also, some other functions have different behavior (`get` returns a `&mut` to have a immutable we have to use `peek`)