### PR TITLE
script for package versions

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package massa-xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,10 +2373,8 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
- "toml_edit",
  "tracing",
  "tracing-subscriber",
- "walkdir",
 ]
 
 [[package]]
@@ -2411,6 +2409,15 @@ dependencies = [
  "wasmer-compiler-singlepass",
  "wasmer-middlewares",
  "wasmer-types",
+]
+
+[[package]]
+name = "massa-xtask"
+version = "0.23.0"
+dependencies = [
+ "massa_models",
+ "toml_edit",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,82 +2302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "massa-client"
-version = "0.23.0"
-dependencies = [
- "anyhow",
- "atty",
- "console",
- "dialoguer",
- "erased-serde",
- "lazy_static",
- "massa_api_exports",
- "massa_models",
- "massa_proto",
- "massa_sdk",
- "massa_signature",
- "massa_time",
- "massa_wallet",
- "paw",
- "rustyline",
- "rustyline-derive",
- "serde",
- "serde_json",
- "structopt",
- "strum",
- "strum_macros",
- "tokio",
- "toml_edit",
-]
-
-[[package]]
-name = "massa-node"
-version = "0.23.0"
-dependencies = [
- "anyhow",
- "chrono",
- "crossbeam-channel",
- "ctrlc",
- "dialoguer",
- "lazy_static",
- "massa_api",
- "massa_api_exports",
- "massa_async_pool",
- "massa_bootstrap",
- "massa_consensus_exports",
- "massa_consensus_worker",
- "massa_executed_ops",
- "massa_execution_exports",
- "massa_execution_worker",
- "massa_factory_exports",
- "massa_factory_worker",
- "massa_final_state",
- "massa_grpc",
- "massa_ledger_exports",
- "massa_ledger_worker",
- "massa_logging",
- "massa_models",
- "massa_pool_exports",
- "massa_pool_worker",
- "massa_pos_exports",
- "massa_pos_worker",
- "massa_protocol_exports",
- "massa_protocol_worker",
- "massa_storage",
- "massa_time",
- "massa_versioning",
- "massa_wallet",
- "parking_lot",
- "paw",
- "peernet",
- "serde",
- "structopt",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "massa-sc-runtime"
 version = "0.10.0"
 source = "git+https://github.com/massalabs/massa-sc-runtime?branch=testnet_23#37f610ed6cd29d7889b4112620542daf0d87d423"
@@ -2534,6 +2458,35 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "thiserror",
+]
+
+[[package]]
+name = "massa_client"
+version = "0.23.0"
+dependencies = [
+ "anyhow",
+ "atty",
+ "console",
+ "dialoguer",
+ "erased-serde",
+ "lazy_static",
+ "massa_api_exports",
+ "massa_models",
+ "massa_proto",
+ "massa_sdk",
+ "massa_signature",
+ "massa_time",
+ "massa_wallet",
+ "paw",
+ "rustyline",
+ "rustyline-derive",
+ "serde",
+ "serde_json",
+ "structopt",
+ "strum",
+ "strum_macros",
+ "tokio",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2857,6 +2810,53 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+]
+
+[[package]]
+name = "massa_node"
+version = "0.23.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crossbeam-channel",
+ "ctrlc",
+ "dialoguer",
+ "lazy_static",
+ "massa_api",
+ "massa_api_exports",
+ "massa_async_pool",
+ "massa_bootstrap",
+ "massa_consensus_exports",
+ "massa_consensus_worker",
+ "massa_executed_ops",
+ "massa_execution_exports",
+ "massa_execution_worker",
+ "massa_factory_exports",
+ "massa_factory_worker",
+ "massa_final_state",
+ "massa_grpc",
+ "massa_ledger_exports",
+ "massa_ledger_worker",
+ "massa_logging",
+ "massa_models",
+ "massa_pool_exports",
+ "massa_pool_worker",
+ "massa_pos_exports",
+ "massa_pos_worker",
+ "massa_protocol_exports",
+ "massa_protocol_worker",
+ "massa_storage",
+ "massa_time",
+ "massa_versioning",
+ "massa_wallet",
+ "parking_lot",
+ "paw",
+ "peernet",
+ "serde",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2302,6 +2302,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "massa-client"
+version = "0.23.0"
+dependencies = [
+ "anyhow",
+ "atty",
+ "console",
+ "dialoguer",
+ "erased-serde",
+ "lazy_static",
+ "massa_api_exports",
+ "massa_models",
+ "massa_proto",
+ "massa_sdk",
+ "massa_signature",
+ "massa_time",
+ "massa_wallet",
+ "paw",
+ "rustyline",
+ "rustyline-derive",
+ "serde",
+ "serde_json",
+ "structopt",
+ "strum",
+ "strum_macros",
+ "tokio",
+ "toml_edit",
+]
+
+[[package]]
+name = "massa-node"
+version = "0.23.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "crossbeam-channel",
+ "ctrlc",
+ "dialoguer",
+ "lazy_static",
+ "massa_api",
+ "massa_api_exports",
+ "massa_async_pool",
+ "massa_bootstrap",
+ "massa_consensus_exports",
+ "massa_consensus_worker",
+ "massa_executed_ops",
+ "massa_execution_exports",
+ "massa_execution_worker",
+ "massa_factory_exports",
+ "massa_factory_worker",
+ "massa_final_state",
+ "massa_grpc",
+ "massa_ledger_exports",
+ "massa_ledger_worker",
+ "massa_logging",
+ "massa_models",
+ "massa_pool_exports",
+ "massa_pool_worker",
+ "massa_pos_exports",
+ "massa_pos_worker",
+ "massa_protocol_exports",
+ "massa_protocol_worker",
+ "massa_storage",
+ "massa_time",
+ "massa_versioning",
+ "massa_wallet",
+ "parking_lot",
+ "paw",
+ "peernet",
+ "serde",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "massa-sc-runtime"
 version = "0.10.0"
 source = "git+https://github.com/massalabs/massa-sc-runtime?branch=main#d9355ecdab96bb04fe588b79c511e93e32163366"
@@ -2458,35 +2534,6 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "thiserror",
-]
-
-[[package]]
-name = "massa_client"
-version = "0.23.0"
-dependencies = [
- "anyhow",
- "atty",
- "console",
- "dialoguer",
- "erased-serde",
- "lazy_static",
- "massa_api_exports",
- "massa_models",
- "massa_proto",
- "massa_sdk",
- "massa_signature",
- "massa_time",
- "massa_wallet",
- "paw",
- "rustyline",
- "rustyline-derive",
- "serde",
- "serde_json",
- "structopt",
- "strum",
- "strum_macros",
- "tokio",
- "toml_edit",
 ]
 
 [[package]]
@@ -2810,53 +2857,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "massa_node"
-version = "0.23.0"
-dependencies = [
- "anyhow",
- "chrono",
- "crossbeam-channel",
- "ctrlc",
- "dialoguer",
- "lazy_static",
- "massa_api",
- "massa_api_exports",
- "massa_async_pool",
- "massa_bootstrap",
- "massa_consensus_exports",
- "massa_consensus_worker",
- "massa_executed_ops",
- "massa_execution_exports",
- "massa_execution_worker",
- "massa_factory_exports",
- "massa_factory_worker",
- "massa_final_state",
- "massa_grpc",
- "massa_ledger_exports",
- "massa_ledger_worker",
- "massa_logging",
- "massa_models",
- "massa_pool_exports",
- "massa_pool_worker",
- "massa_pos_exports",
- "massa_pos_worker",
- "massa_protocol_exports",
- "massa_protocol_worker",
- "massa_storage",
- "massa_time",
- "massa_versioning",
- "massa_wallet",
- "parking_lot",
- "paw",
- "peernet",
- "serde",
- "structopt",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "massa-client"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "atty",
@@ -2373,8 +2373,10 @@ dependencies = [
  "serde",
  "structopt",
  "tokio",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -2390,7 +2392,7 @@ dependencies = [
  "function_name",
  "glob",
  "loupe",
- "massa_hash 0.1.0 (git+https://github.com/massalabs/massa.git)",
+ "massa_hash 0.1.0",
  "more-asserts 0.3.1",
  "num_enum",
  "parking_lot",
@@ -2413,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "massa_api"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -2423,12 +2425,12 @@ dependencies = [
  "massa_api_exports",
  "massa_consensus_exports",
  "massa_execution_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
  "massa_protocol_exports",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_storage",
  "massa_time",
@@ -2446,14 +2448,14 @@ dependencies = [
 
 [[package]]
 name = "massa_api_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
  "jsonrpsee",
  "massa_consensus_exports",
  "massa_execution_exports",
  "massa_final_state",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_protocol_exports",
  "massa_signature",
@@ -2469,13 +2471,13 @@ dependencies = [
 
 [[package]]
 name = "massa_async_pool"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_models",
  "massa_proto",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_time",
  "nom",
@@ -2486,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "massa_bootstrap"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "bitvec",
  "crossbeam",
@@ -2497,7 +2499,7 @@ dependencies = [
  "massa_consensus_exports",
  "massa_executed_ops",
  "massa_final_state",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_ledger_worker",
  "massa_logging",
@@ -2505,7 +2507,7 @@ dependencies = [
  "massa_pos_exports",
  "massa_pos_worker",
  "massa_protocol_exports",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_time",
  "massa_versioning",
@@ -2526,11 +2528,11 @@ dependencies = [
 
 [[package]]
 name = "massa_cipher"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "aes-gcm",
  "displaydoc",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "pbkdf2",
  "rand 0.8.5",
  "thiserror",
@@ -2538,18 +2540,18 @@ dependencies = [
 
 [[package]]
 name = "massa_consensus_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-channel",
  "displaydoc",
  "jsonrpsee",
  "massa_execution_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
  "massa_protocol_exports",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_storage",
  "massa_time",
@@ -2563,11 +2565,11 @@ dependencies = [
 
 [[package]]
 name = "massa_consensus_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "itertools",
  "massa_consensus_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_logging",
  "massa_models",
  "massa_signature",
@@ -2581,22 +2583,22 @@ dependencies = [
 
 [[package]]
 name = "massa_executed_ops"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "nom",
 ]
 
 [[package]]
 name = "massa_execution_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
  "massa-sc-runtime",
  "massa_final_state",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_models",
  "massa_module_cache",
@@ -2614,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "massa_execution_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2624,7 +2626,7 @@ dependencies = [
  "massa_executed_ops",
  "massa_execution_exports",
  "massa_final_state",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_ledger_worker",
  "massa_models",
@@ -2649,11 +2651,11 @@ dependencies = [
 
 [[package]]
 name = "massa_factory_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
  "massa_consensus_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
@@ -2666,12 +2668,12 @@ dependencies = [
 
 [[package]]
 name = "massa_factory_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-channel",
  "massa_consensus_exports",
  "massa_factory_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
@@ -2687,19 +2689,19 @@ dependencies = [
 
 [[package]]
 name = "massa_final_state"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "bs58",
  "displaydoc",
  "massa_async_pool",
  "massa_executed_ops",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_ledger_worker",
  "massa_models",
  "massa_pos_exports",
  "massa_proto",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "nom",
  "serde",
@@ -2709,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "massa_grpc"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam",
  "displaydoc",
@@ -2719,13 +2721,13 @@ dependencies = [
  "itertools",
  "massa_consensus_exports",
  "massa_execution_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
  "massa_proto",
  "massa_protocol_exports",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_storage",
  "massa_time",
  "massa_versioning",
@@ -2745,11 +2747,25 @@ dependencies = [
 [[package]]
 name = "massa_hash"
 version = "0.1.0"
+source = "git+https://github.com/massalabs/massa.git#e0d4af3e906960c9c92bd7789e1b4611c8176e06"
 dependencies = [
  "blake3",
  "bs58",
  "displaydoc",
  "massa_serialization 0.1.0",
+ "nom",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "massa_hash"
+version = "0.23.0"
+dependencies = [
+ "blake3",
+ "bs58",
+ "displaydoc",
+ "massa_serialization 0.23.0",
  "nom",
  "serde",
  "serde_json",
@@ -2758,28 +2774,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "massa_hash"
-version = "0.1.0"
-source = "git+https://github.com/massalabs/massa.git#e0d4af3e906960c9c92bd7789e1b4611c8176e06"
-dependencies = [
- "blake3",
- "bs58",
- "displaydoc",
- "massa_serialization 0.1.0 (git+https://github.com/massalabs/massa.git)",
- "nom",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "massa_ledger_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_proto",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "nom",
  "num_enum",
  "serde",
@@ -2790,12 +2792,12 @@ dependencies = [
 
 [[package]]
 name = "massa_ledger_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_ledger_exports",
  "massa_models",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "nom",
  "rocksdb",
@@ -2806,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "massa_logging"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "serde_json",
  "tracing",
@@ -2814,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "massa_models"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "bitvec",
  "bs58",
@@ -2822,9 +2824,9 @@ dependencies = [
  "directories",
  "displaydoc",
  "lazy_static",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_proto",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_time",
  "nom",
@@ -2840,14 +2842,14 @@ dependencies = [
 
 [[package]]
 name = "massa_module_cache"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "displaydoc",
  "massa-sc-runtime",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "nom",
  "num_enum",
  "rand 0.8.5",
@@ -2861,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "massa_pool_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-channel",
  "massa_models",
@@ -2874,11 +2876,11 @@ dependencies = [
 
 [[package]]
 name = "massa_pool_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam-channel",
  "massa_execution_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",
@@ -2894,14 +2896,14 @@ dependencies = [
 
 [[package]]
 name = "massa_pos_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "bitvec",
  "crossbeam-channel",
  "displaydoc",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "mockall",
  "nom",
@@ -2915,9 +2917,9 @@ dependencies = [
 
 [[package]]
 name = "massa_pos_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_pos_exports",
  "parking_lot",
@@ -2929,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "massa_proto"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "glob",
  "prost",
@@ -2941,12 +2943,12 @@ dependencies = [
 
 [[package]]
 name = "massa_protocol_exports"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_storage",
  "massa_time",
@@ -2962,16 +2964,16 @@ dependencies = [
 
 [[package]]
 name = "massa_protocol_worker"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "crossbeam",
  "massa_consensus_exports",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_logging",
  "massa_models",
  "massa_pool_exports",
  "massa_protocol_exports",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_storage",
  "massa_time",
@@ -2991,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "massa_sdk"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -3008,16 +3010,6 @@ dependencies = [
 [[package]]
 name = "massa_serialization"
 version = "0.1.0"
-dependencies = [
- "displaydoc",
- "nom",
- "thiserror",
- "unsigned-varint",
-]
-
-[[package]]
-name = "massa_serialization"
-version = "0.1.0"
 source = "git+https://github.com/massalabs/massa.git#e0d4af3e906960c9c92bd7789e1b4611c8176e06"
 dependencies = [
  "displaydoc",
@@ -3027,14 +3019,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "massa_serialization"
+version = "0.23.0"
+dependencies = [
+ "displaydoc",
+ "nom",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "massa_signature"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "bs58",
  "displaydoc",
  "ed25519-dalek",
- "massa_hash 0.1.0",
- "massa_serialization 0.1.0",
+ "massa_hash 0.23.0",
+ "massa_serialization 0.23.0",
  "nom",
  "rand 0.7.3",
  "serde",
@@ -3046,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "massa_storage"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "massa_factory_exports",
  "massa_models",
@@ -3056,10 +3058,10 @@ dependencies = [
 
 [[package]]
 name = "massa_time"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "nom",
  "serde",
  "thiserror",
@@ -3068,14 +3070,14 @@ dependencies = [
 
 [[package]]
 name = "massa_versioning"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "machine",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_proto",
- "massa_serialization 0.1.0",
+ "massa_serialization 0.23.0",
  "massa_signature",
  "massa_time",
  "more-asserts 0.3.1",
@@ -3088,11 +3090,11 @@ dependencies = [
 
 [[package]]
 name = "massa_wallet"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "displaydoc",
  "massa_cipher",
- "massa_hash 0.1.0",
+ "massa_hash 0.23.0",
  "massa_models",
  "massa_signature",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,15 +2412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "massa-xtask"
-version = "0.23.0"
-dependencies = [
- "massa_models",
- "toml_edit",
- "walkdir",
-]
-
-[[package]]
 name = "massa_api"
 version = "0.23.0"
 dependencies = [
@@ -3109,6 +3100,15 @@ dependencies = [
  "serde_qs",
  "tempfile",
  "thiserror",
+]
+
+[[package]]
+name = "massa_xtask"
+version = "0.23.0"
+dependencies = [
+ "massa_models",
+ "toml_edit",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "massa-node"
-version = "0.1.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "massa-versioning",
   "massa-grpc",
   "massa-proto",
+  "massa-xtask",
 ]
 resolver = "2"
 

--- a/massa-api-exports/Cargo.toml
+++ b/massa-api-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_api_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-api/Cargo.toml
+++ b/massa-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_api"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/massa-async-pool/Cargo.toml
+++ b/massa-async-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_async_pool"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_bootstrap"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-cipher/Cargo.toml
+++ b/massa-cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_cipher"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa-client"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "massa-client"
+name = "massa_client"
 version = "0.23.0"
 edition = "2021"
 

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "massa_client"
+name = "massa-client"
 version = "0.23.0"
 edition = "2021"
 

--- a/massa-consensus-exports/Cargo.toml
+++ b/massa-consensus-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_consensus_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-consensus-worker/Cargo.toml
+++ b/massa-consensus-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_consensus_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-executed-ops/Cargo.toml
+++ b/massa-executed-ops/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_executed_ops"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-execution-exports/Cargo.toml
+++ b/massa-execution-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_execution_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-execution-worker/Cargo.toml
+++ b/massa-execution-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_execution_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-factory-exports/Cargo.toml
+++ b/massa-factory-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_factory_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-factory-worker/Cargo.toml
+++ b/massa-factory-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_factory_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-final-state/Cargo.toml
+++ b/massa-final-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_final_state"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-grpc/Cargo.toml
+++ b/massa-grpc/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "massa_grpc"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 description = "GRPC API for Massa Blockchain"
 repository = "https://github.com/massalabs/massa/"

--- a/massa-hash/Cargo.toml
+++ b/massa-hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_hash"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-ledger-exports/Cargo.toml
+++ b/massa-ledger-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_ledger_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-ledger-worker/Cargo.toml
+++ b/massa-ledger-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_ledger_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-logging/Cargo.toml
+++ b/massa-logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_logging"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-models/Cargo.toml
+++ b/massa-models/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_models"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-module-cache/Cargo.toml
+++ b/massa-module-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_module_cache"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 [dependencies]

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -3,14 +3,9 @@ name = "massa-node"
 version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
-build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[build-dependencies]
-massa_models = { path = "../massa-models" }
-toml_edit = "0.19.8"
-walkdir = "2.3.3"
 
 [dependencies]
 crossbeam-channel = "0.5.6"

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -9,6 +9,8 @@ build = "build.rs"
 
 [build-dependencies]
 massa_models = { path = "../massa-models" }
+toml_edit = "0.19.8"
+walkdir = "2.3.3"
 
 [dependencies]
 crossbeam-channel = "0.5.6"

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -1,10 +1,14 @@
 [package]
 name = "massa-node"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+massa_models = { path = "../massa-models" }
 
 [dependencies]
 crossbeam-channel = "0.5.6"

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "massa_node"
+name = "massa-node"
 version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "massa-node"
+name = "massa_node"
 version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"

--- a/massa-node/build.rs
+++ b/massa-node/build.rs
@@ -29,10 +29,10 @@ fn check_package_version(
 
     if let Some(package) = doc["package"].as_table_mut() {
         if let Some(version) = package.get_mut("version") {
-            let to_string = version.to_string().replace("\"", "");
+            let to_string = version.to_string().replace('\"', "");
             let actual_version = to_string.trim();
             if new_version.ne(actual_version) {
-                *version = Item::Value(Value::String(Formatted::new(new_version.clone())));
+                *version = Item::Value(Value::String(Formatted::new(new_version)));
             }
         }
     }

--- a/massa-node/build.rs
+++ b/massa-node/build.rs
@@ -1,0 +1,44 @@
+use massa_models::config::constants::VERSION;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    println!("hello world");
+
+    let mut to_string = VERSION.to_string();
+
+    if to_string.contains("TEST") || to_string.contains("SAND") {
+        to_string.replace_range(0..3, "0");
+    } else {
+        to_string.replace_range(0..3, "1");
+    };
+
+    println!("version: {}", to_string);
+
+    // let dest_path = Path::new("/Users/urvoy/dev/massa").join("hello.rs");
+    // fs::write(
+    //     &dest_path,
+    //     "pub fn message() -> &'static str {
+    //         \"Hello, World!\"
+    //     }
+    //     ",
+    // )
+    // .unwrap();
+
+    let workspace_path = Path::new("../"); // Mettez ici le chemin vers votre workspace
+
+    let output = Command::new("cargo")
+        .arg("run")
+        .arg("--manifest-path")
+        .arg(workspace_path.join("Cargo.toml"))
+        .env("CARGO_MANIFEST_DIR", workspace_path)
+        .env("NEW_VERSION", to_string)
+        .status()
+        .expect("Erreur lors de l'exécution du script de pré-construction.");
+
+    if output.success() {
+        println!("Script de pré-construction exécuté avec succès !");
+    } else {
+        eprintln!("Erreur lors de l'exécution du script de pré-construction.");
+    }
+}

--- a/massa-pool-exports/Cargo.toml
+++ b/massa-pool-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_pool_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-pool-worker/Cargo.toml
+++ b/massa-pool-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_pool_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-pos-exports/Cargo.toml
+++ b/massa-pos-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_pos_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-pos-worker/Cargo.toml
+++ b/massa-pos-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_pos_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-proto/Cargo.toml
+++ b/massa-proto/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "massa_proto"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 description = "Protobuf definitions for the Massa blockchain"
 repository = "https://github.com/massalabs/massa/"

--- a/massa-protocol-exports/Cargo.toml
+++ b/massa-protocol-exports/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_protocol_exports"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_protocol_worker"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-sdk/Cargo.toml
+++ b/massa-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_sdk"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 [dependencies]

--- a/massa-serialization/Cargo.toml
+++ b/massa-serialization/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_serialization"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-signature/Cargo.toml
+++ b/massa-signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_signature"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-storage/Cargo.toml
+++ b/massa-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_storage"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-time/Cargo.toml
+++ b/massa-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_time"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-versioning/Cargo.toml
+++ b/massa-versioning/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_versioning"
-version = "0.1.0"
+version = "0.23.0"
 authors = ["Massa Labs <info@massa.net>"]
 edition = "2021"
 

--- a/massa-wallet/Cargo.toml
+++ b/massa-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "massa_wallet"
-version = "0.1.0"
+version = "0.23.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/massa-xtask/Cargo.toml
+++ b/massa-xtask/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "massa-xtask"
+version = "0.23.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+massa_models = { path = "../massa-models" }
+toml_edit = "0.19.8"
+walkdir = "2.3.3"

--- a/massa-xtask/Cargo.toml
+++ b/massa-xtask/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "massa-xtask"
+name = "massa_xtask"
 version = "0.23.0"
 edition = "2021"
 

--- a/massa-xtask/src/main.rs
+++ b/massa-xtask/src/main.rs
@@ -1,0 +1,15 @@
+mod update_package_versions;
+use crate::update_package_versions::update_package_versions;
+use std::env;
+
+/// to use it task: cargo xtask <task_name>
+/// example: cargo xtask update_package_versions to update package versions
+fn main() {
+    let task = env::args().nth(1);
+
+    match task.as_deref() {
+        // We can add more tasks here
+        Some("update_package_versions") => update_package_versions(),
+        _ => panic!("Unknown task"),
+    }
+}

--- a/massa-xtask/src/update_package_versions.rs
+++ b/massa-xtask/src/update_package_versions.rs
@@ -4,10 +4,12 @@ use std::path::Path;
 use toml_edit::{Document, Formatted, Item, Value};
 use walkdir::WalkDir;
 
-fn update_workspace_packages_version(
+/// check the version of the packages in the workspace
+fn check_workspace_packages_version(
     new_version: String,
     workspace_path: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<i32, Box<dyn std::error::Error>> {
+    let mut nb_files_updated = 0;
     // search for Cargo.toml files in the workspace
     for entry in WalkDir::new(workspace_path)
         .into_iter()
@@ -15,19 +17,29 @@ fn update_workspace_packages_version(
     {
         if entry.file_name() == "Cargo.toml" {
             // if the Cargo.toml file is found, check the version and update it if necessary
-            check_package_version(new_version.clone(), entry.path())?;
+            if check_package_version(new_version.clone(), entry.path())? {
+                // if version has been updated
+                nb_files_updated += 1;
+            }
         }
     }
 
-    Ok(())
+    Ok(nb_files_updated)
 }
 
+/// check the version of the package in the Cargo.toml file
+///
+/// Update it if version is different from the new version and if the package is a massa package
+///
+/// return Ok(true) if the version has been updated
 fn check_package_version(
     new_version: String,
     cargo_toml_path: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> Result<bool, Box<dyn std::error::Error>> {
     let cargo_toml_content = fs::read_to_string(cargo_toml_path)?;
     let mut doc = cargo_toml_content.parse::<Document>()?;
+
+    let mut update = false;
 
     if let Some(package) = doc["package"].as_table_mut() {
         if package["name"].to_string().contains("massa") {
@@ -39,16 +51,19 @@ fn check_package_version(
                     println!(
                         "Updating version of package {} from {} to {}",
                         package["name"], actual_version, new_version
-                    )
+                    );
+                    update = true;
                 }
             }
         }
     }
 
-    let updated_cargo_toml_content = doc.to_string();
-    fs::write(cargo_toml_path, updated_cargo_toml_content)?;
+    if update {
+        let updated_cargo_toml_content = doc.to_string();
+        fs::write(cargo_toml_path, updated_cargo_toml_content)?;
+    }
 
-    Ok(())
+    Ok(update)
 }
 
 pub(crate) fn update_package_versions() {
@@ -66,7 +81,8 @@ pub(crate) fn update_package_versions() {
 
     let workspace_path = Path::new("./");
 
-    if let Err(e) = update_workspace_packages_version(to_string, workspace_path) {
-        panic!("Error updating workspace packages version: {}", e);
+    match check_workspace_packages_version(to_string, workspace_path) {
+        Err(e) => panic!("Error updating workspace packages version: {}", e),
+        Ok(nb_files_updated) => println!("{} files updated", nb_files_updated),
     }
 }


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Proposal : 

if we consider that the versions >= 1 are MainNet and versions <1 are TestNet / SandBox.
Parsing the current `VERSION` in `massa-models/src/config/constants` and for now, remove `TEST` or `SAND` from it to replace by `0`. 
That give for example `0.23.0`.
Then replace in all `Cargo.toml` the package version by this version.


<details>
<summary>Deprecated</summary>

Actually the script is in build.rs file which is a pre-build script. It's fast but maybe it's "overkill" to run it at every build ? 

</details>


A new massa-package called `massa-xtask` was created with this `main.rs`
```rust
/// to use it task: cargo xtask <task_name>
/// example: cargo xtask update_package_versions to update package versions
fn main() {
    let task = env::args().nth(1);

    match task.as_deref() {
        // We can add more tasks here
        Some("update_package_versions") => update_package_versions(),
        _ => panic!("Unknown task"),
    }
}
```

We can run the task with `cargo xtask update_package_versions`. With that it's possible to add easily some other task.

Example : 

- update `VERSION` to `TEST.24.0` in `massa-models/src/config/constants.rs` 
- call `cargo xtask update_package_versions`

![image](https://github.com/massalabs/massa/assets/9607217/16854465-d9b6-4376-8c5c-2849bdd144ef)

