### PR TITLE
Clean event polling bootstrap - Windows routability

### DIFF
--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -44,6 +44,7 @@ impl BootstrapTcpListener {
             socket.set_only_v6(false)?;
         }
         // This is needed for the mio-polling system, which depends on the socket being non-blocking.
+        // If we don't set non-blocking, then we can .accept() on the mio_server bellow, which is needed to ensure the polling triggers every time.
         socket.set_nonblocking(true)?;
         socket.bind(&(*addr).into())?;
 
@@ -101,8 +102,13 @@ impl BSEventPoller for BootstrapTcpListener {
 
         // We need to have an accept() error with WouldBlock, otherwise polling may not raise any new events.
         // See https://users.rust-lang.org/t/why-mio-poll-only-receives-the-very-first-event/87501
-        while self._mio_server.accept().is_ok() {
-            warn!("Mio server still had bootstrap connection data to read");
+        // However, we cannot add potential connections on the mio_server to the connections vec,
+        // as this yields mio::net::TcpStream instead of std::net::TcpStream
+        while let Ok((_, remote_addr)) = self._mio_server.accept() {
+            warn!(
+                "Mio server still had bootstrap connection data to read. Remote address: {}",
+                remote_addr
+            );
         }
 
         Ok(PollEvent::NewConnections(results))

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -43,6 +43,7 @@ impl BootstrapTcpListener {
         if addr.is_ipv6() {
             socket.set_only_v6(false)?;
         }
+        // This is needed for the mio-polling system, which depends on the socket being non-blocking.
         socket.set_nonblocking(true)?;
         socket.bind(&(*addr).into())?;
 
@@ -86,7 +87,7 @@ impl BSEventPoller for BootstrapTcpListener {
             return Ok(vec![PollEvent::Stop]);
         }
 
-        let mut results = Vec::new();
+        let mut results = Vec::with_capacity(self.events.iter().count());
 
         // Process each event.
         for event in self.events.iter() {

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -79,6 +79,9 @@ impl BootstrapTcpListener {
 
 impl BSEventPoller for BootstrapTcpListener {
     fn poll(&mut self) -> Result<Vec<PollEvent>, BootstrapError> {
+
+        println!("Waiting for poll event");
+
         self.poll.poll(&mut self.events, None).unwrap();
 
         // Confirm that we are not being signalled to shut down
@@ -87,6 +90,8 @@ impl BSEventPoller for BootstrapTcpListener {
         }
 
         let mut results = Vec::new();
+
+        println!("Accepting {} new connection", self.events.iter().count());
 
         // Process each event.
         for event in self.events.iter() {

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -98,6 +98,8 @@ impl BSEventPoller for BootstrapTcpListener {
             }
         }
 
+        // We need to have an accept() error with WouldBlock, otherwise polling may not raise any new events.
+        // See https://users.rust-lang.org/t/why-mio-poll-only-receives-the-very-first-event/87501
         if self._mio_server.accept().is_ok() {
             debug!("Mio server still had bootstrap connection data to read");
         }

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -79,9 +79,6 @@ impl BootstrapTcpListener {
 
 impl BSEventPoller for BootstrapTcpListener {
     fn poll(&mut self) -> Result<Vec<PollEvent>, BootstrapError> {
-
-        println!("Waiting for poll event");
-
         self.poll.poll(&mut self.events, None).unwrap();
 
         // Confirm that we are not being signalled to shut down
@@ -90,8 +87,6 @@ impl BSEventPoller for BootstrapTcpListener {
         }
 
         let mut results = Vec::new();
-
-        println!("Accepting {} new connection", self.events.iter().count());
 
         // Process each event.
         for event in self.events.iter() {

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -255,9 +255,6 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
             }
 
             for (dplx, remote_addr) in connections {
-
-                println!("Accepting new connection - event_loop. Remote addr: {} Session count: {}", remote_addr, Arc::strong_count(&bootstrap_sessions_counter) - 1);
-
                 // claim a slot in the max_bootstrap_sessions
                 let server_binding = BootstrapServerBinder::new(
                     dplx,
@@ -331,8 +328,6 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
                     let config = self.bootstrap_config.clone();
 
                     let bootstrap_count_token = bootstrap_sessions_counter.clone();
-
-                    println!("Starting bootstrap session (remote_addr: {})", remote_addr);
 
                     let _ = thread::Builder::new()
                         .name(format!("bootstrap thread, peer: {}", remote_addr))

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -267,7 +267,6 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
 
                 // check whether incoming peer IP is allowed.
                 if let Err(error_msg) = self.white_black_list.is_ip_allowed(&remote_addr) {
-                    println!("BS - IP NOT IN WHITELIST: {}", remote_addr);
                     server_binding.close_and_send_error(
                         error_msg.to_string(),
                         remote_addr,
@@ -294,7 +293,7 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
                             .retain(|_k, v| now.duration_since(*v) <= per_ip_min_interval);
                         if self.ip_hist_map.len() > self.bootstrap_config.ip_list_max_size {
                             // too many IPs are spamming us: clear cache
-                            println!("BS - high bootstrap load: at least {} different IPs attempted bootstrap in the last {}", self.ip_hist_map.len(),format_duration(self.bootstrap_config.per_ip_min_interval.to_duration()).to_string());
+                            warn!("high bootstrap load: at least {} different IPs attempted bootstrap in the last {}", self.ip_hist_map.len(),format_duration(self.bootstrap_config.per_ip_min_interval.to_duration()).to_string());
                             self.ip_hist_map.clear();
                         }
                     }
@@ -306,17 +305,12 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
                         now,
                         per_ip_min_interval,
                     ) {
-                        
-                        println!("BS - TOO MANY CONNECTIONS FROM SAME CLIENT: {}", remote_addr);
                         // Client has been too greedy: send out the bad-news :(
                         let msg = format!(
                             "Your last bootstrap on this server was {} ago and you have to wait {} before retrying.",
                             format_duration(msg),
                             format_duration(per_ip_min_interval.saturating_sub(msg))
                         );
-
-                        println!("BS - TOO MANY CONNECTIONS FROM SAME CLIENT: {}, message: {}", remote_addr, msg);
-
                         let tracer = move || {
                             massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {
                                 "remote_addr": remote_addr
@@ -359,9 +353,6 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
                         "active_count": Arc::strong_count(&bootstrap_sessions_counter) - 1
                     });
                 } else {
-                    
-                    println!("BS - Bootstrap failed because the bootstrap server currently has no slots available. for addr: {}", remote_addr);
-
                     server_binding.close_and_send_error(
                         "Bootstrap failed because the bootstrap server currently has no slots available.".to_string(),
                         remote_addr,
@@ -419,7 +410,7 @@ fn run_bootstrap_session(
     consensus_command_sender: Box<dyn ConsensusController>,
     protocol_controller: Box<dyn ProtocolController>,
 ) {
-    debug!("BS SESSION START - running bootstrap for peer {}", remote_addr);
+    debug!("running bootstrap for peer {}", remote_addr);
     let deadline = Instant::now() + config.bootstrap_timeout.to_duration();
     // TODO: reinstate prevention of bootstrap slot camping. Deadline cancellation is one option
     let res = manage_bootstrap(
@@ -440,7 +431,7 @@ fn run_bootstrap_session(
     drop(arc_counter);
     match res {
         Err(BootstrapError::TimedOut(_)) => {
-            println!("BS ERROR - bootstrap timeout for peer {}", remote_addr);
+            debug!("bootstrap timeout for peer {}", remote_addr);
             // We allow unused result because we don't care if an error is thrown when
             // sending the error message to the server we will close the socket anyway.
             let _ = server.send_error_timeout(format!(
@@ -448,18 +439,18 @@ fn run_bootstrap_session(
                 format_duration(config.bootstrap_timeout.to_duration())
             ));
         }
-        Err(BootstrapError::ReceivedError(error)) => println!(
-            "BS ERROR - bootstrap serving error received from peer {}: {}",
+        Err(BootstrapError::ReceivedError(error)) => debug!(
+            "bootstrap serving error received from peer {}: {}",
             remote_addr, error
         ),
         Err(err) => {
-            println!("BS ERROR - bootstrap serving error for peer {}: {}", remote_addr, err);
+            debug!("bootstrap serving error for peer {}: {}", remote_addr, err);
             // We allow unused result because we don't care if an error is thrown when
             // sending the error message to the server we will close the socket anyway.
             let _ = server.send_error_timeout(err.to_string());
         }
         Ok(_) => {
-            info!("BS SUCCESS - bootstrapped peer {}", remote_addr);
+            info!("bootstrapped peer {}", remote_addr);
         }
     }
 }

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -255,6 +255,9 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
             }
 
             for (dplx, remote_addr) in connections {
+
+                println!("Accepting new connection - event_loop. Remote addr: {} Session count: {}", remote_addr, Arc::strong_count(&bootstrap_sessions_counter) - 1);
+
                 // claim a slot in the max_bootstrap_sessions
                 let server_binding = BootstrapServerBinder::new(
                     dplx,
@@ -328,6 +331,8 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
                     let config = self.bootstrap_config.clone();
 
                     let bootstrap_count_token = bootstrap_sessions_counter.clone();
+
+                    println!("Starting bootstrap session (remote_addr: {})", remote_addr);
 
                     let _ = thread::Builder::new()
                         .name(format!("bootstrap thread, peer: {}", remote_addr))

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -255,7 +255,6 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
             }
 
             for (dplx, remote_addr) in connections {
-
                 // claim a slot in the max_bootstrap_sessions
                 let server_binding = BootstrapServerBinder::new(
                     dplx,

--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -63,7 +63,7 @@ use crate::{
 /// Specifies a common interface that can be used by standard, or mockers
 #[cfg_attr(test, mockall::automock)]
 pub trait BSEventPoller {
-    fn poll(&mut self) -> Result<PollEvent, BootstrapError>;
+    fn poll(&mut self) -> Result<Vec<PollEvent>, BootstrapError>;
 }
 /// Abstraction layer over data produced by the listener, and transported
 /// over to the worker via a channel
@@ -234,109 +234,127 @@ impl<L: BSEventPoller> BootstrapServer<'_, L> {
         // TODO: Work out how to integration-test this
         loop {
             // block until we have a connection to work with, or break out of main-loop
-            let (dplx, remote_addr) = match self.ev_poller.poll() {
-                Ok(PollEvent::NewConnection((dplx, remote_addr))) => (dplx, remote_addr),
-                Ok(PollEvent::Stop) => break Ok(()),
-                Err(e) => {
-                    error!("bootstrap listener error: {}", e);
-                    break Err(e);
-                }
-            };
 
-            // claim a slot in the max_bootstrap_sessions
-            let server_binding = BootstrapServerBinder::new(
-                dplx,
-                self.keypair.clone(),
-                (&self.bootstrap_config).into(),
-            );
+            let mut connections = Vec::new();
 
-            // check whether incoming peer IP is allowed.
-            if let Err(error_msg) = self.white_black_list.is_ip_allowed(&remote_addr) {
-                server_binding.close_and_send_error(error_msg.to_string(), remote_addr, move || {});
-                continue;
-            };
-
-            // the `- 1` is to account for the top-level Arc that is created at the top
-            // of this method. subsequent counts correspond to each `clone` that is passed
-            // into a thread
-            // TODO: If we don't find a way to handle the counting automagically, make
-            //       a dedicated wrapper-type with doc-comments, manual drop impl that
-            //       integrates logging, etc...
-            if Arc::strong_count(&bootstrap_sessions_counter) - 1 < max_bootstraps {
-                massa_trace!("bootstrap.lib.run.select.accept", {
-                    "remote_addr": remote_addr
-                });
-                let now = Instant::now();
-
-                // clear IP history if necessary
-                if self.ip_hist_map.len() > self.bootstrap_config.ip_list_max_size {
-                    self.ip_hist_map
-                        .retain(|_k, v| now.duration_since(*v) <= per_ip_min_interval);
-                    if self.ip_hist_map.len() > self.bootstrap_config.ip_list_max_size {
-                        // too many IPs are spamming us: clear cache
-                        warn!("high bootstrap load: at least {} different IPs attempted bootstrap in the last {}", self.ip_hist_map.len(),format_duration(self.bootstrap_config.per_ip_min_interval.to_duration()).to_string());
-                        self.ip_hist_map.clear();
+            match self.ev_poller.poll() {
+                Ok(events) => {
+                    for event in events {
+                        match event {
+                            PollEvent::NewConnection((dplx, remote_addr)) => {
+                                connections.push((dplx, remote_addr))
+                            }
+                            PollEvent::Stop => return Ok(()),
+                        };
                     }
                 }
+                Err(e) => {
+                    error!("bootstrap listener error: {}", e);
+                    return Err(e);
+                }
+            }
 
-                // check IP's bootstrap attempt history
-                if let Err(msg) = BootstrapServer::<L>::greedy_client_check(
-                    &mut self.ip_hist_map,
-                    remote_addr,
-                    now,
-                    per_ip_min_interval,
-                ) {
-                    // Client has been too greedy: send out the bad-news :(
-                    let msg = format!(
-                        "Your last bootstrap on this server was {} ago and you have to wait {} before retrying.",
-                        format_duration(msg),
-                        format_duration(per_ip_min_interval.saturating_sub(msg))
+            for (dplx, remote_addr) in connections {
+
+                // claim a slot in the max_bootstrap_sessions
+                let server_binding = BootstrapServerBinder::new(
+                    dplx,
+                    self.keypair.clone(),
+                    (&self.bootstrap_config).into(),
+                );
+
+                // check whether incoming peer IP is allowed.
+                if let Err(error_msg) = self.white_black_list.is_ip_allowed(&remote_addr) {
+                    server_binding.close_and_send_error(
+                        error_msg.to_string(),
+                        remote_addr,
+                        move || {},
                     );
-                    let tracer = move || {
-                        massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {
-                            "remote_addr": remote_addr
-                        })
-                    };
-                    server_binding.close_and_send_error(msg, remote_addr, tracer);
                     continue;
                 };
 
-                // Clients Option<last-attempt> is good, and has been updated
-                massa_trace!("bootstrap.lib.run.select.accept.cache_available", {});
-
-                // launch bootstrap
-                let version = self.version;
-                let data_execution = self.final_state.clone();
-                let consensus_command_sender = self.consensus_controller.clone();
-                let protocol_controller = self.protocol_controller.clone();
-                let config = self.bootstrap_config.clone();
-
-                let bootstrap_count_token = bootstrap_sessions_counter.clone();
-
-                let _ = thread::Builder::new()
-                    .name(format!("bootstrap thread, peer: {}", remote_addr))
-                    .spawn(move || {
-                        run_bootstrap_session(
-                            server_binding,
-                            bootstrap_count_token,
-                            config,
-                            remote_addr,
-                            data_execution,
-                            version,
-                            consensus_command_sender,
-                            protocol_controller,
-                        )
+                // the `- 1` is to account for the top-level Arc that is created at the top
+                // of this method. subsequent counts correspond to each `clone` that is passed
+                // into a thread
+                // TODO: If we don't find a way to handle the counting automagically, make
+                //       a dedicated wrapper-type with doc-comments, manual drop impl that
+                //       integrates logging, etc...
+                if Arc::strong_count(&bootstrap_sessions_counter) - 1 < max_bootstraps {
+                    massa_trace!("bootstrap.lib.run.select.accept", {
+                        "remote_addr": remote_addr
                     });
+                    let now = Instant::now();
 
-                massa_trace!("bootstrap.session.started", {
-                    "active_count": Arc::strong_count(&bootstrap_sessions_counter) - 1
-                });
-            } else {
-                server_binding.close_and_send_error(
-                    "Bootstrap failed because the bootstrap server currently has no slots available.".to_string(),
-                    remote_addr,
-                    move || debug!("did not bootstrap {}: no available slots", remote_addr),
-                );
+                    // clear IP history if necessary
+                    if self.ip_hist_map.len() > self.bootstrap_config.ip_list_max_size {
+                        self.ip_hist_map
+                            .retain(|_k, v| now.duration_since(*v) <= per_ip_min_interval);
+                        if self.ip_hist_map.len() > self.bootstrap_config.ip_list_max_size {
+                            // too many IPs are spamming us: clear cache
+                            warn!("high bootstrap load: at least {} different IPs attempted bootstrap in the last {}", self.ip_hist_map.len(),format_duration(self.bootstrap_config.per_ip_min_interval.to_duration()).to_string());
+                            self.ip_hist_map.clear();
+                        }
+                    }
+
+                    // check IP's bootstrap attempt history
+                    if let Err(msg) = BootstrapServer::<L>::greedy_client_check(
+                        &mut self.ip_hist_map,
+                        remote_addr,
+                        now,
+                        per_ip_min_interval,
+                    ) {
+                        // Client has been too greedy: send out the bad-news :(
+                        let msg = format!(
+                            "Your last bootstrap on this server was {} ago and you have to wait {} before retrying.",
+                            format_duration(msg),
+                            format_duration(per_ip_min_interval.saturating_sub(msg))
+                        );
+                        let tracer = move || {
+                            massa_trace!("bootstrap.lib.run.select.accept.refuse_limit", {
+                                "remote_addr": remote_addr
+                            })
+                        };
+                        server_binding.close_and_send_error(msg, remote_addr, tracer);
+                        continue;
+                    };
+
+                    // Clients Option<last-attempt> is good, and has been updated
+                    massa_trace!("bootstrap.lib.run.select.accept.cache_available", {});
+
+                    // launch bootstrap
+                    let version = self.version;
+                    let data_execution = self.final_state.clone();
+                    let consensus_command_sender = self.consensus_controller.clone();
+                    let protocol_controller = self.protocol_controller.clone();
+                    let config = self.bootstrap_config.clone();
+
+                    let bootstrap_count_token = bootstrap_sessions_counter.clone();
+
+                    let _ = thread::Builder::new()
+                        .name(format!("bootstrap thread, peer: {}", remote_addr))
+                        .spawn(move || {
+                            run_bootstrap_session(
+                                server_binding,
+                                bootstrap_count_token,
+                                config,
+                                remote_addr,
+                                data_execution,
+                                version,
+                                consensus_command_sender,
+                                protocol_controller,
+                            )
+                        });
+
+                    massa_trace!("bootstrap.session.started", {
+                        "active_count": Arc::strong_count(&bootstrap_sessions_counter) - 1
+                    });
+                } else {
+                    server_binding.close_and_send_error(
+                        "Bootstrap failed because the bootstrap server currently has no slots available.".to_string(),
+                        remote_addr,
+                        move || debug!("did not bootstrap {}: no available slots", remote_addr),
+                    );
+                }
             }
         }
     }

--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -571,13 +571,13 @@ fn conn_establishment_mocks() -> (MockBSEventPoller, MockBSConnector) {
         .expect_poll()
         .times(1)
         // Mock the `accept` method here by receiving from the listen-loop thread
-        .returning(move || Ok(vec![PollEvent::NewConnection(conn_rx.recv().unwrap())]))
+        .returning(move || Ok(PollEvent::NewConnections(vec![conn_rx.recv().unwrap()])))
         .in_sequence(&mut seq);
     mock_bs_listener
         .expect_poll()
         .times(1)
         // Mock the `accept` method here by receiving from the listen-loop thread
-        .returning(move || Ok(vec![PollEvent::Stop]))
+        .returning(move || Ok(PollEvent::Stop))
         .in_sequence(&mut seq);
 
     let mut seq = Sequence::new();

--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -571,13 +571,13 @@ fn conn_establishment_mocks() -> (MockBSEventPoller, MockBSConnector) {
         .expect_poll()
         .times(1)
         // Mock the `accept` method here by receiving from the listen-loop thread
-        .returning(move || Ok(PollEvent::NewConnection(conn_rx.recv().unwrap())))
+        .returning(move || Ok(vec![PollEvent::NewConnection(conn_rx.recv().unwrap())]))
         .in_sequence(&mut seq);
     mock_bs_listener
         .expect_poll()
         .times(1)
         // Mock the `accept` method here by receiving from the listen-loop thread
-        .returning(move || Ok(PollEvent::Stop))
+        .returning(move || Ok(vec![PollEvent::Stop]))
         .in_sequence(&mut seq);
 
     let mut seq = Sequence::new();


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

The goal of this PR was to clean up some event polling for Bootstrap listener, in order to resolve routability issues on Windows.
It is currently running on one testnet bootstrap server and seems to be doing fine (no signs of regressions), but I'll keep monitoring what's happening.