### PR TITLE
Correct amount parsing

### DIFF
--- a/massa-execution-worker/src/interface_impl.rs
+++ b/massa-execution-worker/src/interface_impl.rs
@@ -124,7 +124,7 @@ impl InterfaceImpl {
         execution_context.speculative_ledger.added_changes.0.insert(
             sender_addr,
             SetUpdateOrDelete::Set(LedgerEntry {
-                balance: Amount::from_mantissa_scale(1_000_000_000, 0),
+                balance: Amount::const_init(1_000_000_000, 0),
                 ..Default::default()
             }),
         );

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -2475,7 +2475,7 @@ mod tests {
             Amount::from_str("300000")
                 .unwrap()
                 // Gas fee
-                .saturating_sub(Amount::from_mantissa_scale(10, 0))
+                .saturating_sub(Amount::const_init(10, 0))
                 // Storage cost key
                 .saturating_sub(
                     exec_cfg
@@ -2655,10 +2655,10 @@ mod tests {
         // create the block containing the operation
         let operation = Operation::new_verifiable(
             Operation {
-                fee: Amount::from_mantissa_scale(10, 0),
+                fee: Amount::const_init(10, 0),
                 expire_period: 10,
                 op: OperationType::ExecuteSC {
-                    max_coins: Amount::from_mantissa_scale(0, 0),
+                    max_coins: Amount::const_init(0, 0),
                     data: bytecode.to_vec(),
                     max_gas: 0,
                     datastore: BTreeMap::default(),
@@ -2711,7 +2711,7 @@ mod tests {
         };
         let op = Operation::new_verifiable(
             Operation {
-                fee: Amount::from_mantissa_scale(10, 0),
+                fee: Amount::const_init(10, 0),
                 expire_period: 10,
                 op,
             },
@@ -2946,7 +2946,7 @@ mod tests {
             Amount::from_str("300000")
                 .unwrap()
                 // Gas fee
-                .saturating_sub(Amount::from_mantissa_scale(10, 0))
+                .saturating_sub(Amount::const_init(10, 0))
         );
 
         // stop the execution controller

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -103,15 +103,15 @@ pub fn get_period_from_args() -> u64 {
 }
 
 /// Price of a roll in the network
-pub const ROLL_PRICE: Amount = Amount::from_mantissa_scale(100, 0);
+pub const ROLL_PRICE: Amount = Amount::const_init(100, 0);
 /// Block reward is given for each block creation
-pub const BLOCK_REWARD: Amount = Amount::from_mantissa_scale(3, 1);
+pub const BLOCK_REWARD: Amount = Amount::const_init(3, 1);
 /// Cost to store one byte in the ledger
-pub const LEDGER_COST_PER_BYTE: Amount = Amount::from_mantissa_scale(25, 5);
+pub const LEDGER_COST_PER_BYTE: Amount = Amount::const_init(25, 5);
 /// Address size in bytes
 pub const ADDRESS_SIZE_BYTES: usize = 32;
 /// Cost for a base entry default 0.01 MASSA
-pub const LEDGER_ENTRY_BASE_COST: Amount = Amount::from_mantissa_scale(1, 2);
+pub const LEDGER_ENTRY_BASE_COST: Amount = Amount::const_init(1, 2);
 /// Cost for a base entry datastore 10 bytes constant to avoid paying more for longer keys
 pub const LEDGER_ENTRY_DATASTORE_BASE_SIZE: usize = 10;
 /// Time between the periods in the same thread.
@@ -300,7 +300,7 @@ pub const MAX_LISTENERS_PER_PEER: u64 = 100;
 // Constants used in versioning
 //
 /// Threshold to accept a new versioning
-pub const VERSIONING_THRESHOLD_TRANSITION_ACCEPTED: Amount = Amount::from_mantissa_scale(75, 0);
+pub const VERSIONING_THRESHOLD_TRANSITION_ACCEPTED: Amount = Amount::const_init(75, 0);
 /// Block count to process in MipStoreStats (for state change threshold)
 pub const MIP_STORE_STATS_BLOCK_CONSIDERED: usize = 1000;
 /// Max number of stats counters

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -303,7 +303,9 @@ async fn launch(
                 components: BTreeMap::from([(MipComponent::FinalStateHashKind, 1)]),
                 start: mip_0002_start,
                 timeout: mip_0002_timeout,
-                activation_delay: T0.saturating_mul(PERIODS_PER_CYCLE.saturating_add(1)).saturating_mul(40),
+                activation_delay: T0
+                    .saturating_mul(PERIODS_PER_CYCLE.saturating_add(1))
+                    .saturating_mul(40),
             },
             MipState::new(mip_0002_defined_start),
         ),

--- a/massa-node/src/operation_injector.rs
+++ b/massa-node/src/operation_injector.rs
@@ -57,11 +57,11 @@ pub fn start_operation_injector(
                 wallet
                     .create_operation(
                         Operation {
-                            fee: Amount::from_mantissa_scale(0, 0),
+                            fee: Amount::const_init(0, 0),
                             expire_period: final_slot.period + 8,
                             op: OperationType::Transaction {
                                 recipient_address: addr,
-                                amount: Amount::from_mantissa_scale(10000, 0),
+                                amount: Amount::const_init(10000, 0),
                             },
                         },
                         return_addr,
@@ -97,7 +97,7 @@ pub fn start_operation_injector(
                 for _ in 0..txps {
                     let amount = rng.gen_range(1..=10000);
                     let content = Operation {
-                        fee: Amount::from_mantissa_scale(0, 0),
+                        fee: Amount::const_init(0, 0),
                         expire_period: final_slot.period + 8,
                         op: OperationType::Transaction {
                             recipient_address: return_addr,

--- a/massa-pool-worker/src/tests/operation_pool_tests.rs
+++ b/massa-pool-worker/src/tests/operation_pool_tests.rs
@@ -41,8 +41,8 @@ fn test_add_operation() {
                     vec![
                         (
                             // Operations need to be paid for
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
                         );
                         addrs.len()
                     ]
@@ -104,8 +104,8 @@ fn test_add_irrelevant_operation() {
                     vec![
                         (
                             // Operations need to be paid for
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
                         );
                         addrs.len()
                     ]
@@ -167,8 +167,8 @@ fn test_pool() {
                     vec![
                         (
                             // Operations need to be paid for
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
-                            Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
+                            Some(Amount::const_init(1_000_000_000, 0)),
                         );
                         addrs.len()
                     ]
@@ -212,7 +212,7 @@ fn test_pool() {
         let expire_period = 3;
         let op = OpGenerator::default()
             .expirery(expire_period)
-            .fee(Amount::from_mantissa_scale(1 + i, 3))
+            .fee(Amount::const_init(1 + i, 3)) // can panic but not a big deal as we are testing
             .generate(); //get_transaction(expire_period, fee);
 
         storage.store_operations(vec![op.clone()]);

--- a/massa-pool-worker/src/tests/scenario.rs
+++ b/massa-pool-worker/src/tests/scenario.rs
@@ -130,8 +130,8 @@ pub fn create_basic_get_block_operation_execution_mock(
             vec![
                 (
                     // Operations need to be paid for
-                    Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
-                    Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
+                    Some(Amount::const_init(1_000_000_000, 0)),
+                    Some(Amount::const_init(1_000_000_000, 0)),
                 );
                 addrs.len()
             ]
@@ -273,8 +273,8 @@ fn test_get_operations_overflow() {
 //                     vec![
 //                         (
 //                             // Operations need to be paid for
-//                             Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
-//                             Some(Amount::from_mantissa_scale(1_000_000_000, 0)),
+//                             Some(Amount::const_init(1_000_000_000, 0)),
+//                             Some(Amount::const_init(1_000_000_000, 0)),
 //                         );
 //                         addrs.len()
 //                     ]

--- a/massa-versioning/src/versioning.rs
+++ b/massa-versioning/src/versioning.rs
@@ -899,7 +899,7 @@ impl MipStoreRaw {
 
             let vote_ratio_ = 100.0 * network_version_count / block_count_considered;
 
-            let vote_ratio = Amount::from_mantissa_scale(vote_ratio_.round() as u64, 0);
+            let vote_ratio = Amount::const_init(vote_ratio_.round() as u64, 0);
 
             debug!("[VERSIONING STATS] vote_ratio = {} (from version counter = {} and blocks considered = {})", vote_ratio, network_version_count, block_count_considered);
 


### PR DESCRIPTION
This PR corrects the parsing of Amounts (adds "exact" to string parsing).
It also adds a non-panicking from_mantissa_scale

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification