### PR TITLE
Compute hash at the end of bootstrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "massa-proto-rs"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/massa-proto-rs?branch=main#84e907d9a2f0dcdfe3149fe5348970f90bfa127b"
+source = "git+https://github.com/massalabs/massa-proto-rs?rev=18ec02f#18ec02ff5bccedc64b3788964e9d78ccb9559567"
 dependencies = [
  "glob",
  "prost",

--- a/massa-async-pool/Cargo.toml
+++ b/massa-async-pool/Cargo.toml
@@ -20,7 +20,7 @@ massa_serialization = { path = "../massa-serialization" }
 massa_signature = { path = "../massa-signature" }
 massa_db = { path = "../massa-db" }
 massa_time = { path = "../massa-time" }
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -1,5 +1,5 @@
 use humantime::format_duration;
-use massa_db::DBBatch;
+use massa_db::{DBBatch, CHANGE_ID_DESER_ERROR};
 use massa_final_state::{FinalState, FinalStateError};
 use massa_logging::massa_trace;
 use massa_models::{node::NodeId, slot::Slot, streaming_step::StreamingStep, version::Version};
@@ -161,6 +161,25 @@ fn stream_final_state_and_consensus(
                         .map_err(|e| BootstrapError::from(FinalStateError::from(e)))?;
 
                     warn_user_about_versioning_updates(updated, added);
+
+                    // Compute the db hash
+                    info!("Computing the db hash");
+                    let slot = guard
+                        .db
+                        .read()
+                        .get_change_id()
+                        .expect(CHANGE_ID_DESER_ERROR);
+                    let only_use_xor = guard.get_only_use_xor(&slot);
+                    guard
+                        .db
+                        .write()
+                        .recompute_db_hash(only_use_xor)
+                        .map_err(|e| {
+                            BootstrapError::from(FinalStateError::LedgerError(format!(
+                                "Can't recompute hashes: {}",
+                                e
+                            )))
+                        })?;
 
                     return Ok(());
                 }

--- a/massa-client/Cargo.toml
+++ b/massa-client/Cargo.toml
@@ -28,7 +28,7 @@ massa_signature = { path = "../massa-signature" }
 massa_time = { path = "../massa-time" }
 massa_sdk = { path = "../massa-sdk" }
 massa_wallet = { path = "../massa-wallet" }
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 
 [dev-dependencies]
 toml_edit = "0.19"

--- a/massa-execution-exports/Cargo.toml
+++ b/massa-execution-exports/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1.23", features = ["sync"] }
 mockall = { version = "0.11.4",  optional = true}
 
 # custom modules
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }
 massa_time = { path = "../massa-time" }

--- a/massa-final-state/Cargo.toml
+++ b/massa-final-state/Cargo.toml
@@ -23,7 +23,7 @@ massa_async_pool = { path = "../massa-async-pool" }
 massa_serialization = { path = "../massa-serialization" }
 massa_pos_exports = { path = "../massa-pos-exports" }
 massa_db = { path = "../massa-db" }
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 massa_versioning = { path = "../massa-versioning" }
 massa_time = { path = "../massa-time" }
 

--- a/massa-grpc/Cargo.toml
+++ b/massa-grpc/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://massa.net"
 documentation = "https://docs.massa.net/"
 
 [dependencies]
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 displaydoc = "0.2"
 thiserror = "1.0"
 tonic = { version = "0.9.2", features = ["gzip", "tls"] }

--- a/massa-grpc/src/api.rs
+++ b/massa-grpc/src/api.rs
@@ -139,33 +139,7 @@ pub(crate) fn get_blocks_by_slots(
         };
 
         let res = storage.read_blocks().get(&block_id).map(|b| {
-            // TODO rework ?
-            let header = b.clone().content.header;
-            // transform to grpc struct
-            let parents = header
-                .content
-                .parents
-                .into_iter()
-                .map(|p| p.to_string())
-                .collect();
-
-            let endorsements = header
-                .content
-                .endorsements
-                .into_iter()
-                .map(|endorsement| endorsement.into())
-                .collect();
-
-            let block_header = grpc_model::BlockHeader {
-                slot: Some(grpc_model::Slot {
-                    period: header.content.slot.period,
-                    thread: header.content.slot.thread as u32,
-                }),
-                parents,
-                operation_merkle_root: header.content.operation_merkle_root.to_string(),
-                endorsements,
-            };
-
+            let massa_header = b.clone().content.header;
             let operations: Vec<String> = b
                 .content
                 .operations
@@ -173,16 +147,7 @@ pub(crate) fn get_blocks_by_slots(
                 .map(|ope| ope.to_string())
                 .collect();
 
-            (
-                grpc_model::SignedBlockHeader {
-                    content: Some(block_header),
-                    signature: header.signature.to_string(),
-                    content_creator_pub_key: header.content_creator_pub_key.to_string(),
-                    content_creator_address: header.content_creator_address.to_string(),
-                    id: header.id.to_string(),
-                },
-                operations,
-            )
+            (massa_header.into(), operations)
         });
 
         if let Some(block) = res {

--- a/massa-ledger-exports/Cargo.toml
+++ b/massa-ledger-exports/Cargo.toml
@@ -15,7 +15,7 @@ rocksdb = "0.20"
 num_enum = "0.5.10"
 
 # custom modules
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 massa_hash = { path = "../massa-hash" }
 massa_models = { path = "../massa-models" }
 massa_serialization = { path = "../massa-serialization" }

--- a/massa-models/Cargo.toml
+++ b/massa-models/Cargo.toml
@@ -18,7 +18,7 @@ config = "0.13"
 bs58 = { version = "=0.4", features = ["check"] }
 bitvec = { version = "=1.0", features = ["serde"] }
 nom = "=7.1"
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 
 # custom modules
 massa_hash = { path = "../massa-hash" }

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -78,9 +78,9 @@ lazy_static::lazy_static! {
     /// node version
     pub static ref VERSION: Version = {
         if cfg!(feature = "sandbox") {
-            "SAND.23.1"
+            "SAND.23.2"
         } else {
-            "TEST.23.1"
+            "TEST.23.2"
         }
         .parse()
         .unwrap()

--- a/massa-models/src/mapping_grpc.rs
+++ b/massa-models/src/mapping_grpc.rs
@@ -64,24 +64,28 @@ impl From<FilledBlock> for grpc_model::FilledBlock {
 
 impl From<SecureShareBlock> for grpc_model::SignedBlock {
     fn from(value: SecureShareBlock) -> Self {
+        let serialized_size = value.serialized_size() as u64;
         grpc_model::SignedBlock {
             content: Some(value.content.into()),
-            signature: value.signature.to_bs58_check(),
+            signature: value.signature.to_string(),
             content_creator_pub_key: value.content_creator_pub_key.to_string(),
             content_creator_address: value.content_creator_address.to_string(),
             id: value.id.to_string(),
+            serialized_size,
         }
     }
 }
 
 impl From<SecuredHeader> for grpc_model::SignedBlockHeader {
     fn from(value: SecuredHeader) -> Self {
+        let serialized_size = value.serialized_size() as u64;
         grpc_model::SignedBlockHeader {
             content: Some(value.content.into()),
-            signature: value.signature.to_bs58_check(),
+            signature: value.signature.to_string(),
             content_creator_pub_key: value.content_creator_pub_key.to_string(),
             content_creator_address: value.content_creator_address.to_string(),
             id: value.id.to_string(),
+            serialized_size,
         }
     }
 }
@@ -98,12 +102,14 @@ impl From<Endorsement> for grpc_model::Endorsement {
 
 impl From<SecureShareEndorsement> for grpc_model::SignedEndorsement {
     fn from(value: SecureShareEndorsement) -> Self {
+        let serialized_size = value.serialized_size() as u64;
         grpc_model::SignedEndorsement {
             content: Some(value.content.into()),
-            signature: value.signature.to_bs58_check(),
+            signature: value.signature.to_string(),
             content_creator_pub_key: value.content_creator_pub_key.to_string(),
             content_creator_address: value.content_creator_address.to_string(),
             id: value.id.to_string(),
+            serialized_size,
         }
     }
 }
@@ -198,12 +204,14 @@ impl From<OperationType> for grpc_api::OpType {
 
 impl From<SecureShareOperation> for grpc_model::SignedOperation {
     fn from(value: SecureShareOperation) -> Self {
+        let serialized_size = value.serialized_size() as u64;
         grpc_model::SignedOperation {
             content: Some(value.content.into()),
-            signature: value.signature.to_bs58_check(),
+            signature: value.signature.to_string(),
             content_creator_pub_key: value.content_creator_pub_key.to_string(),
             content_creator_address: value.content_creator_address.to_string(),
             id: value.id.to_string(),
+            serialized_size,
         }
     }
 }

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -132,7 +132,7 @@
     # max number of blocks waiting for dependencies
     max_dependency_blocks = 2048
     # number of final periods that must be kept without operations (increase improve bootstrap process, high values will increase RAM usage.)
-    force_keep_final_periods_without_ops = 128
+    force_keep_final_periods_without_ops = 32
     # number of final periods that must be kept with operations (increase to more resilience to short network disconnections, high values will increase RAM usage.)
     force_keep_final_periods = 10
 

--- a/massa-node/base_config/openrpc.json
+++ b/massa-node/base_config/openrpc.json
@@ -2,7 +2,7 @@
     "openrpc": "1.2.4",
     "info": {
         "title": "Massa OpenRPC Specification",
-        "version": "TEST.23.1",
+        "version": "TEST.23.2",
         "description": "Massa OpenRPC Specification document. Find more information on https://docs.massa.net/en/latest/technical-doc/api.html",
         "termsOfService": "https://open-rpc.org",
         "contact": {

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -279,8 +279,8 @@ async fn launch(
     let mip_0001_timeout = MassaTime::from_utc_ymd_hms(2023, 6, 14, 16, 0, 0).unwrap();
     let mip_0001_defined_start = MassaTime::from_utc_ymd_hms(2023, 2, 14, 14, 30, 0).unwrap();
     let mip_0002_start = MassaTime::from_utc_ymd_hms(2023, 6, 16, 13, 0, 0).unwrap();
-    let mip_0002_timeout = MassaTime::from_utc_ymd_hms(2023, 6, 16, 16, 0, 0).unwrap();
-    let mip_0002_defined_start = MassaTime::from_utc_ymd_hms(2023, 2, 19, 12, 0, 0).unwrap();
+    let mip_0002_timeout = MassaTime::from_utc_ymd_hms(2023, 6, 19, 14, 0, 0).unwrap();
+    let mip_0002_defined_start = MassaTime::from_utc_ymd_hms(2023, 6, 16, 10, 0, 0).unwrap();
     let mip_list_1: [(MipInfo, MipState); 2] = [
         (
             MipInfo {

--- a/massa-protocol-exports/src/test_exports/config.rs
+++ b/massa-protocol-exports/src/test_exports/config.rs
@@ -86,7 +86,7 @@ impl Default for ProtocolConfig {
                 target_out_connections: 10,
                 max_in_connections_per_ip: 0,
             },
-            version: "TEST.22.2".parse().unwrap(),
+            version: "TEST.23.2".parse().unwrap(),
         }
     }
 }

--- a/massa-sdk/Cargo.toml
+++ b/massa-sdk/Cargo.toml
@@ -14,4 +14,4 @@ tracing = {version =  "0.1", features = ["log"]}
 massa_api_exports = { path = "../massa-api-exports" }
 massa_models = { path = "../massa-models" }
 massa_time = { path = "../massa-time" }
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }

--- a/massa-versioning/Cargo.toml
+++ b/massa-versioning/Cargo.toml
@@ -19,7 +19,7 @@ massa_models = { path = "../massa-models" }
 massa_serialization = { path = "../massa-serialization" }
 massa_hash = { path = "../massa-hash" }
 massa_signature = { path = "../massa-signature" }
-massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", branch = "main", features = ["tonic"] }
+massa-proto-rs = { git = "https://github.com/massalabs/massa-proto-rs", rev = "18ec02f", features = ["tonic"] }
 massa_db = { path = "../massa-db" }
 
 [dev-dependencies]


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

This PR fixes an issue where we compute the lsm_tree updates on bootstrap even if the xor version is active. If there are a lot of operations, we may never catch up to them and bootstrap will fail.