### PR TITLE
Use XOF hash in the DB

### DIFF
--- a/massa-bootstrap/src/tests/scenarios.rs
+++ b/massa-bootstrap/src/tests/scenarios.rs
@@ -337,7 +337,7 @@ fn test_bootstrap_server() {
             .write()
             .write_batch(batch, Default::default(), Some(next));
 
-        let final_state_hash = final_write.db.read().get_db_hash();
+        let final_state_hash = final_write.db.read().get_xof_db_hash();
         let cycle = next.get_cycle(final_state_local_config.periods_per_cycle.clone());
         final_write
             .pos_state
@@ -480,7 +480,7 @@ fn test_bootstrap_server() {
                     .write()
                     .write_batch(batch, Default::default(), Some(next));
 
-                let final_state_hash = final_write.db.read().get_db_hash();
+                let final_state_hash = final_write.db.read().get_xof_db_hash();
                 let cycle = next.get_cycle(final_state_local_config.periods_per_cycle.clone());
                 final_write
                     .pos_state

--- a/massa-db-exports/src/constants.rs
+++ b/massa-db-exports/src/constants.rs
@@ -6,7 +6,7 @@ pub const STATE_CF: &str = "state";
 pub const VERSIONING_CF: &str = "versioning";
 
 // Hash
-pub const STATE_HASH_BYTES_LEN: usize = 32;
+pub const STATE_HASH_BYTES_LEN: usize = 512;
 pub const STATE_HASH_KEY: &[u8; 1] = b"h";
 pub const STATE_HASH_INITIAL_BYTES: &[u8; STATE_HASH_BYTES_LEN] = &[0; STATE_HASH_BYTES_LEN];
 

--- a/massa-db-exports/src/controller.rs
+++ b/massa-db-exports/src/controller.rs
@@ -1,5 +1,5 @@
 use crate::{DBBatch, Key, MassaDBError, StreamBatch, Value};
-use massa_hash::{Hash, HashXof, XOF_HASH_SIZE_BYTES};
+use massa_hash::{HashXof, HASH_XOF_SIZE_BYTES};
 use massa_models::{error::ModelsError, slot::Slot, streaming_step::StreamingStep};
 use parking_lot::RwLock;
 use std::{fmt::Debug, sync::Arc};
@@ -52,11 +52,8 @@ pub trait MassaDBController: Send + Sync + Debug {
         prefix: &[u8],
     ) -> Box<dyn Iterator<Item = (Key, Value)> + '_>;
 
-    /// Get the current state hash of the database
-    fn get_db_hash(&self) -> Hash;
-
     /// Get the current extended state hash of the database
-    fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES>;
+    fn get_xof_db_hash(&self) -> HashXof<HASH_XOF_SIZE_BYTES>;
 
     /// Flushes the underlying db.
     fn flush(&self) -> Result<(), MassaDBError>;

--- a/massa-db-exports/src/controller.rs
+++ b/massa-db-exports/src/controller.rs
@@ -1,5 +1,5 @@
 use crate::{DBBatch, Key, MassaDBError, StreamBatch, Value};
-use massa_hash::Hash;
+use massa_hash::{Hash, HashXof};
 use massa_models::{error::ModelsError, slot::Slot, streaming_step::StreamingStep};
 use parking_lot::RwLock;
 use std::{fmt::Debug, sync::Arc};
@@ -54,6 +54,9 @@ pub trait MassaDBController: Send + Sync + Debug {
 
     /// Get the current state hash of the database
     fn get_db_hash(&self) -> Hash;
+
+    /// Get the current extended state hash of the database
+    fn get_xof_db_hash(&self) -> HashXof;
 
     /// Flushes the underlying db.
     fn flush(&self) -> Result<(), MassaDBError>;

--- a/massa-db-exports/src/controller.rs
+++ b/massa-db-exports/src/controller.rs
@@ -1,5 +1,5 @@
 use crate::{DBBatch, Key, MassaDBError, StreamBatch, Value};
-use massa_hash::{Hash, HashXof};
+use massa_hash::{Hash, HashXof, XOF_HASH_SIZE_BYTES};
 use massa_models::{error::ModelsError, slot::Slot, streaming_step::StreamingStep};
 use parking_lot::RwLock;
 use std::{fmt::Debug, sync::Arc};
@@ -56,7 +56,7 @@ pub trait MassaDBController: Send + Sync + Debug {
     fn get_db_hash(&self) -> Hash;
 
     /// Get the current extended state hash of the database
-    fn get_xof_db_hash(&self) -> HashXof;
+    fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES>;
 
     /// Flushes the underlying db.
     fn flush(&self) -> Result<(), MassaDBError>;

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -4,7 +4,7 @@ use massa_db_exports::{
     CHANGE_ID_SER_ERROR, CRUD_ERROR, METADATA_CF, OPEN_ERROR, STATE_CF, STATE_HASH_ERROR,
     STATE_HASH_INITIAL_BYTES, STATE_HASH_KEY, VERSIONING_CF,
 };
-use massa_hash::{Hash, HashXof};
+use massa_hash::{Hash, HashXof, XOF_HASH_SIZE_BYTES};
 use massa_models::{
     error::ModelsError,
     slot::{Slot, SlotDeserializer, SlotSerializer},
@@ -531,13 +531,13 @@ where
     }
 
     /// Get the current XOF state hash of the database
-    pub fn get_xof_db_hash(&self) -> HashXof {
+    pub fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES> {
         self.get_xof_db_hash_opt()
             .unwrap_or(HashXof(*STATE_HASH_INITIAL_BYTES))
     }
 
     /// Get the current XOF state hash of the database
-    fn get_xof_db_hash_opt(&self) -> Option<HashXof> {
+    fn get_xof_db_hash_opt(&self) -> Option<HashXof<XOF_HASH_SIZE_BYTES>> {
         let db = &self.db;
         let handle = db.cf_handle(METADATA_CF).expect(CF_ERROR);
 
@@ -735,7 +735,7 @@ impl MassaDBController for RawMassaDB<Slot, SlotSerializer, SlotDeserializer> {
     }
 
     /// Get the current extended state hash of the database
-    fn get_xof_db_hash(&self) -> HashXof {
+    fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES> {
         self.get_xof_db_hash()
     }
 

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -331,8 +331,7 @@ where
 
                 // Compute the XOR in all cases
                 if let Ok(Some(prev_value)) = self.db.get_cf(handle_state, key) {
-                    let prev_hash =
-                        HashXof::compute_from_kv(key.as_slice(), prev_value.as_slice());
+                    let prev_hash = HashXof::compute_from_kv(key.as_slice(), prev_value.as_slice());
                     current_xor_hash ^= prev_hash;
                 };
                 let new_hash = HashXof::compute_from_kv(key.as_slice(), value.as_slice());
@@ -342,8 +341,7 @@ where
 
                 // Compute the XOR in all cases
                 if let Ok(Some(prev_value)) = self.db.get_cf(handle_state, key) {
-                    let prev_hash =
-                        HashXof::compute_from_kv(key.as_slice(), prev_value.as_slice());
+                    let prev_hash = HashXof::compute_from_kv(key.as_slice(), prev_value.as_slice());
                     current_xor_hash ^= prev_hash;
                 };
             }
@@ -366,11 +364,9 @@ where
         }
 
         // Update the hash entry
-        self.current_batch.lock().put_cf(
-            handle_metadata,
-            STATE_HASH_KEY,
-            current_xor_hash.0,
-        );
+        self.current_batch
+            .lock()
+            .put_cf(handle_metadata, STATE_HASH_KEY, current_xor_hash.0);
 
         {
             let mut current_batch_guard = self.current_batch.lock();
@@ -517,11 +513,9 @@ where
         }
 
         // Update the hash entry
-        self.current_batch.lock().put_cf(
-            handle_metadata,
-            STATE_HASH_KEY,
-            current_xor_hash.0,
-        );
+        self.current_batch
+            .lock()
+            .put_cf(handle_metadata, STATE_HASH_KEY, current_xor_hash.0);
 
         {
             let mut current_batch_guard = self.current_batch.lock();

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -4,7 +4,7 @@ use massa_db_exports::{
     CHANGE_ID_SER_ERROR, CRUD_ERROR, METADATA_CF, OPEN_ERROR, STATE_CF, STATE_HASH_ERROR,
     STATE_HASH_INITIAL_BYTES, STATE_HASH_KEY, VERSIONING_CF,
 };
-use massa_hash::{Hash, HashXof, XOF_HASH_SIZE_BYTES};
+use massa_hash::{HashXof, HASH_XOF_SIZE_BYTES};
 use massa_models::{
     error::ModelsError,
     slot::{Slot, SlotDeserializer, SlotSerializer},
@@ -531,13 +531,13 @@ where
     }
 
     /// Get the current XOF state hash of the database
-    pub fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES> {
+    pub fn get_xof_db_hash(&self) -> HashXof<HASH_XOF_SIZE_BYTES> {
         self.get_xof_db_hash_opt()
             .unwrap_or(HashXof(*STATE_HASH_INITIAL_BYTES))
     }
 
     /// Get the current XOF state hash of the database
-    fn get_xof_db_hash_opt(&self) -> Option<HashXof<XOF_HASH_SIZE_BYTES>> {
+    fn get_xof_db_hash_opt(&self) -> Option<HashXof<HASH_XOF_SIZE_BYTES>> {
         let db = &self.db;
         let handle = db.cf_handle(METADATA_CF).expect(CF_ERROR);
 
@@ -545,14 +545,6 @@ where
             .expect(CRUD_ERROR)
             .as_deref()
             .map(|state_hash_bytes| HashXof(state_hash_bytes.try_into().expect(STATE_HASH_ERROR)))
-    }
-
-    /// Get the current state hash of the database
-    pub fn get_db_hash(&self) -> Hash {
-        let hash_xof = self
-            .get_xof_db_hash_opt()
-            .unwrap_or(HashXof(*STATE_HASH_INITIAL_BYTES));
-        Hash::compute_from(&hash_xof.0)
     }
 }
 
@@ -730,12 +722,7 @@ impl MassaDBController for RawMassaDB<Slot, SlotSerializer, SlotDeserializer> {
     }
 
     /// Get the current extended state hash of the database
-    fn get_db_hash(&self) -> Hash {
-        self.get_db_hash()
-    }
-
-    /// Get the current extended state hash of the database
-    fn get_xof_db_hash(&self) -> HashXof<XOF_HASH_SIZE_BYTES> {
+    fn get_xof_db_hash(&self) -> HashXof<HASH_XOF_SIZE_BYTES> {
         self.get_xof_db_hash()
     }
 

--- a/massa-executed-ops/src/executed_ops.rs
+++ b/massa-executed-ops/src/executed_ops.rs
@@ -266,6 +266,7 @@ fn test_executed_ops_hash_computing() {
     use massa_db_exports::{MassaDBConfig, MassaDBController, STATE_HASH_INITIAL_BYTES};
     use massa_db_worker::MassaDB;
     use massa_hash::Hash;
+    use massa_hash::HashXof;
     use massa_models::prehash::PreHashMap;
     use massa_models::secure_share::Id;
     use parking_lot::RwLock;
@@ -346,12 +347,12 @@ fn test_executed_ops_hash_computing() {
 
     // check that a.hash ^ $(change_b) = c.hash
     assert_ne!(
-        db_a.read().get_db_hash(),
-        Hash::from_bytes(STATE_HASH_INITIAL_BYTES)
+        db_a.read().get_xof_db_hash(),
+        HashXof(*STATE_HASH_INITIAL_BYTES)
     );
     assert_eq!(
-        db_a.read().get_db_hash(),
-        db_c.read().get_db_hash(),
+        db_a.read().get_xof_db_hash(),
+        db_c.read().get_xof_db_hash(),
         "'a' and 'c' hashes are not equal"
     );
 
@@ -366,8 +367,8 @@ fn test_executed_ops_hash_computing() {
 
     // at this point the hash should have been reset to its original value
     assert_eq!(
-        db_a.read().get_db_hash(),
-        Hash::from_bytes(STATE_HASH_INITIAL_BYTES),
+        db_a.read().get_xof_db_hash(),
+        HashXof(*STATE_HASH_INITIAL_BYTES),
         "'a' was not reset to its initial value"
     );
 }

--- a/massa-final-state/src/final_state.rs
+++ b/massa-final-state/src/final_state.rs
@@ -129,7 +129,7 @@ impl FinalState {
         info!(
             "final_state hash at slot {}: {}",
             slot,
-            final_state.db.read().get_db_hash()
+            final_state.db.read().get_xof_db_hash()
         );
 
         // create the final state
@@ -221,7 +221,7 @@ impl FinalState {
         info!(
             "final_state hash at slot {}: {}",
             recovered_slot,
-            final_state.db.read().get_db_hash()
+            final_state.db.read().get_xof_db_hash()
         );
 
         // Then, interpolate the downtime, to attach at end_slot;
@@ -266,7 +266,7 @@ impl FinalState {
         }
 
         // Recompute the hash with the updated data and feed it to POS_state.
-        let final_state_hash = self.db.read().get_db_hash();
+        let final_state_hash = self.db.read().get_xof_db_hash();
 
         info!(
             "final_state hash at slot {}: {}",
@@ -484,7 +484,7 @@ impl FinalState {
         &mut self,
         cycle: u64,
     ) -> Result<(), FinalStateError> {
-        let final_state_hash = self.db.read().get_db_hash();
+        let final_state_hash = self.db.read().get_xof_db_hash();
 
         self.pos_state
             .feed_cycle_state_hash(cycle, final_state_hash);
@@ -568,7 +568,7 @@ impl FinalState {
             .write()
             .write_batch(db_batch, Default::default(), Some(slot));
 
-        let final_state_hash = self.db.read().get_db_hash();
+        let final_state_hash = self.db.read().get_xof_db_hash();
 
         // compute the final state hash
         info!("final_state hash at slot {}: {}", slot, final_state_hash);

--- a/massa-final-state/src/test_exports/bootstrap.rs
+++ b/massa-final-state/src/test_exports/bootstrap.rs
@@ -113,8 +113,8 @@ pub fn assert_eq_final_state(v1: &FinalState, v2: &FinalState) {
 /// asserts that two `FinalState` hashes are equal
 pub fn assert_eq_final_state_hash(v1: &FinalState, v2: &FinalState) {
     assert_eq!(
-        v1.db.read().get_db_hash(),
-        v2.db.read().get_db_hash(),
+        v1.db.read().get_xof_db_hash(),
+        v2.db.read().get_xof_db_hash(),
         "rocks_db hash mismatch"
     );
 }

--- a/massa-final-state/src/tests/scenarios.rs
+++ b/massa-final-state/src/tests/scenarios.rs
@@ -207,7 +207,7 @@ fn test_final_state() {
 
         fs.write().finalize(slot, state_changes);
 
-        hash = fs.read().db.read().get_db_hash();
+        hash = fs.read().db.read().get_xof_db_hash();
 
         fs.write().db.write().flush().unwrap();
     }
@@ -215,7 +215,7 @@ fn test_final_state() {
     copy_dir_all(temp_dir.path(), &temp_dir2.path()).unwrap();
 
     let fs2 = create_final_state(&temp_dir2, false);
-    let hash2 = fs2.read().db.read().get_db_hash();
+    let hash2 = fs2.read().db.read().get_xof_db_hash();
 
     assert_eq!(hash, hash2);
 }

--- a/massa-hash/src/hash.rs
+++ b/massa-hash/src/hash.rs
@@ -7,12 +7,7 @@ use nom::{
     error::{context, ContextError, ParseError},
     IResult,
 };
-use std::{
-    cmp::Ordering,
-    convert::TryInto,
-    ops::{BitXor, BitXorAssign},
-    str::FromStr,
-};
+use std::{cmp::Ordering, convert::TryInto, str::FromStr};
 
 /// Hash wrapper, the underlying hash type is `Blake3`
 ///
@@ -71,38 +66,6 @@ impl std::fmt::Display for Hash {
 impl std::fmt::Debug for Hash {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.to_bs58_check())
-    }
-}
-
-/// Previously, the final state hash was a XOR of various hashses.
-/// However, this is vulnerable: https://github.com/massalabs/massa/discussions/3852
-/// As a result, we use lsmtree's Sparse Merkle Tree instead, which is not vulnerable to this.
-/// We still use bitwise XOR for fingerprinting on some structures.
-/// TODO: Remove every usage if this?
-impl BitXorAssign for Hash {
-    fn bitxor_assign(&mut self, rhs: Self) {
-        *self = *self ^ rhs;
-    }
-}
-
-/// Previously, the final state hash was a XOR of various hashses.
-/// However, this is vulnerable: https://github.com/massalabs/massa/discussions/3852
-/// As a result, we use lsmtree's Sparse Merkle Tree instead, which is not vulnerable to this.
-/// We still use bitwise XOR for fingerprinting on some structures.
-/// TODO: Remove every usage if this?
-impl BitXor for Hash {
-    type Output = Self;
-
-    fn bitxor(self, other: Self) -> Self {
-        let xored_bytes: Vec<u8> = self
-            .to_bytes()
-            .iter()
-            .zip(other.to_bytes())
-            .map(|(x, y)| x ^ y)
-            .collect();
-        // unwrap won't fail because of the initial byte arrays size
-        let input_bytes: [u8; HASH_SIZE_BYTES] = xored_bytes.try_into().unwrap();
-        Hash::from_bytes(&input_bytes)
     }
 }
 

--- a/massa-hash/src/hash_xof.rs
+++ b/massa-hash/src/hash_xof.rs
@@ -57,12 +57,16 @@ impl<const SIZE: usize> HashXof<SIZE> {
     }
 }
 
+// To use this xor operator you must ensure that you have all the criteria listed here : 
+// https://github.com/massalabs/massa/discussions/3852#discussioncomment-6188158
 impl<const SIZE: usize> BitXorAssign for HashXof<SIZE> {
     fn bitxor_assign(&mut self, rhs: Self) {
         *self = *self ^ rhs;
     }
 }
 
+// To use this xor operator you must ensure that you have all the criteria listed here : 
+// https://github.com/massalabs/massa/discussions/3852#discussioncomment-6188158
 impl<const SIZE: usize> BitXor for HashXof<SIZE> {
     type Output = Self;
 

--- a/massa-hash/src/hash_xof.rs
+++ b/massa-hash/src/hash_xof.rs
@@ -1,46 +1,46 @@
 use std::ops::{BitXor, BitXorAssign};
 
-use crate::{Hash, XOF_HASH_SIZE_BYTES};
+use crate::Hash;
 
 /// Extended Hash
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct HashXof(pub [u8; XOF_HASH_SIZE_BYTES]);
+pub struct HashXof<const SIZE: usize>(pub [u8; SIZE]);
 
-impl HashXof {
+impl<const SIZE: usize> HashXof<SIZE> {
     /// Truncate the extended hash to a regular hash
     pub fn clip_to_massa_hash(&self) -> Hash {
         Hash::from_bytes(&self.0[..32].try_into().unwrap())
     }
 
     /// Compute from raw data
-    pub fn compute_from(data: &[u8]) -> HashXof {
+    pub fn compute_from(data: &[u8]) -> HashXof<SIZE> {
         let mut hasher = blake3::Hasher::new();
         hasher.update(data);
-        let mut hash = [0u8; XOF_HASH_SIZE_BYTES];
+        let mut hash = [0u8; SIZE];
         let mut output_reader = hasher.finalize_xof();
         output_reader.fill(&mut hash);
         HashXof(hash)
     }
 
     /// Compute from key and value
-    pub fn compute_from_kv(key: &[u8], value: &[u8]) -> HashXof {
+    pub fn compute_from_kv(key: &[u8], value: &[u8]) -> HashXof<SIZE> {
         let mut hasher = blake3::Hasher::new();
         hasher.update(key);
         hasher.update(value);
-        let mut hash = [0u8; XOF_HASH_SIZE_BYTES];
+        let mut hash = [0u8; SIZE];
         let mut output_reader = hasher.finalize_xof();
         output_reader.fill(&mut hash);
         HashXof(hash)
     }
 }
 
-impl BitXorAssign for HashXof {
+impl<const SIZE: usize> BitXorAssign for HashXof<SIZE> {
     fn bitxor_assign(&mut self, rhs: Self) {
         *self = *self ^ rhs;
     }
 }
 
-impl BitXor for HashXof {
+impl<const SIZE: usize> BitXor for HashXof<SIZE> {
     type Output = Self;
 
     fn bitxor(self, other: Self) -> Self {

--- a/massa-hash/src/hash_xof.rs
+++ b/massa-hash/src/hash_xof.rs
@@ -1,15 +1,24 @@
 use std::ops::{BitXor, BitXorAssign};
 
-use crate::Hash;
+use massa_serialization::{Deserializer, SerializeError, Serializer};
+use nom::{
+    error::{context, ContextError, ParseError},
+    IResult,
+};
 
 /// Extended Hash
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct HashXof<const SIZE: usize>(pub [u8; SIZE]);
 
 impl<const SIZE: usize> HashXof<SIZE> {
-    /// Truncate the extended hash to a regular hash
-    pub fn clip_to_massa_hash(&self) -> Hash {
-        Hash::from_bytes(&self.0[..32].try_into().unwrap())
+    /// From bytes
+    pub fn from_bytes(bytes: &[u8; SIZE]) -> Self {
+        HashXof(*bytes)
+    }
+
+    /// Transform into bytes
+    pub fn to_bytes(&self) -> &[u8; SIZE] {
+        &self.0
     }
 
     /// Compute from raw data
@@ -25,12 +34,26 @@ impl<const SIZE: usize> HashXof<SIZE> {
     /// Compute from key and value
     pub fn compute_from_kv(key: &[u8], value: &[u8]) -> HashXof<SIZE> {
         let mut hasher = blake3::Hasher::new();
+        hasher.update(&(key.len() as u64).to_be_bytes());
         hasher.update(key);
         hasher.update(value);
         let mut hash = [0u8; SIZE];
         let mut output_reader = hasher.finalize_xof();
         output_reader.fill(&mut hash);
         HashXof(hash)
+    }
+
+    /// Serialize a Hash using `bs58` encoding with checksum.
+    /// Motivations for using base58 encoding:
+    ///
+    /// base58_check is like base64 but-
+    /// * fully standardized (no = vs /)
+    /// * no weird characters (eg. +) only alphanumeric
+    /// * ambiguous letters combined (eg. O vs 0, or l vs 1)
+    /// * contains a checksum at the end to detect typing errors
+    ///    
+    pub fn to_bs58_check(&self) -> String {
+        bs58::encode(self.0).with_check().into_string()
     }
 }
 
@@ -53,5 +76,82 @@ impl<const SIZE: usize> BitXor for HashXof<SIZE> {
             .try_into()
             .unwrap();
         HashXof(xored)
+    }
+}
+
+impl<const SIZE: usize> std::fmt::Display for HashXof<SIZE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_bs58_check())
+    }
+}
+
+impl<const SIZE: usize> std::fmt::Debug for HashXof<SIZE> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.to_bs58_check())
+    }
+}
+
+/// Serializer for `HashXof`
+#[derive(Default, Clone)]
+pub struct HashXofSerializer;
+
+impl HashXofSerializer {
+    /// Creates a serializer for `HashXof`
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl<const SIZE: usize> Serializer<HashXof<SIZE>> for HashXofSerializer {
+    fn serialize(&self, value: &HashXof<SIZE>, buffer: &mut Vec<u8>) -> Result<(), SerializeError> {
+        buffer.extend(value.to_bytes());
+        Ok(())
+    }
+}
+
+/// Deserializer for `HashXof`
+#[derive(Default, Clone)]
+pub struct HashXofDeserializer;
+
+impl HashXofDeserializer {
+    /// Creates a deserializer for `HashXof`
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl<const SIZE: usize> Deserializer<HashXof<SIZE>> for HashXofDeserializer {
+    /// ## Example
+    /// ```rust
+    /// use massa_hash::{HashXof, HASH_XOF_SIZE_BYTES, HashXofDeserializer};
+    /// use massa_serialization::{Serializer, Deserializer, DeserializeError};
+    ///
+    /// let hash_deserializer = HashXofDeserializer::new();
+    /// let hash: HashXof<HASH_XOF_SIZE_BYTES> = HashXof::compute_from(&"hello world".as_bytes());
+    /// let (rest, deserialized) = hash_deserializer.deserialize::<DeserializeError>(hash.to_bytes()).unwrap();
+    /// assert_eq!(deserialized, hash);
+    /// assert_eq!(rest.len(), 0);
+    /// ```
+    fn deserialize<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        &self,
+        buffer: &'a [u8],
+    ) -> IResult<&'a [u8], HashXof<SIZE>, E> {
+        context("Failed hashxof deserialization", |input: &'a [u8]| {
+            if buffer.len() < SIZE {
+                return Err(nom::Err::Error(ParseError::from_error_kind(
+                    input,
+                    nom::error::ErrorKind::LengthValue,
+                )));
+            }
+            Ok((
+                &buffer[SIZE..],
+                HashXof::from_bytes(&buffer[..SIZE].try_into().map_err(|_| {
+                    nom::Err::Error(ParseError::from_error_kind(
+                        input,
+                        nom::error::ErrorKind::Fail,
+                    ))
+                })?),
+            ))
+        })(buffer)
     }
 }

--- a/massa-hash/src/hash_xof.rs
+++ b/massa-hash/src/hash_xof.rs
@@ -1,0 +1,57 @@
+use std::ops::{BitXor, BitXorAssign};
+
+use crate::{Hash, XOF_HASH_SIZE_BYTES};
+
+/// Extended Hash
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashXof(pub [u8; XOF_HASH_SIZE_BYTES]);
+
+impl HashXof {
+    /// Truncate the extended hash to a regular hash
+    pub fn clip_to_massa_hash(&self) -> Hash {
+        Hash::from_bytes(&self.0[..32].try_into().unwrap())
+    }
+
+    /// Compute from raw data
+    pub fn compute_from(data: &[u8]) -> HashXof {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(data);
+        let mut hash = [0u8; XOF_HASH_SIZE_BYTES];
+        let mut output_reader = hasher.finalize_xof();
+        output_reader.fill(&mut hash);
+        HashXof(hash)
+    }
+
+    /// Compute from key and value
+    pub fn compute_from_kv(key: &[u8], value: &[u8]) -> HashXof {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(key);
+        hasher.update(value);
+        let mut hash = [0u8; XOF_HASH_SIZE_BYTES];
+        let mut output_reader = hasher.finalize_xof();
+        output_reader.fill(&mut hash);
+        HashXof(hash)
+    }
+}
+
+impl BitXorAssign for HashXof {
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self = *self ^ rhs;
+    }
+}
+
+impl BitXor for HashXof {
+    type Output = Self;
+
+    fn bitxor(self, other: Self) -> Self {
+        let xored = self
+            .0
+            .iter()
+            .zip(other.0.iter())
+            .map(|(a, b)| a ^ b)
+            .collect::<Vec<u8>>()
+            .try_into()
+            .unwrap();
+        HashXof(xored)
+    }
+}

--- a/massa-hash/src/hash_xof.rs
+++ b/massa-hash/src/hash_xof.rs
@@ -57,7 +57,7 @@ impl<const SIZE: usize> HashXof<SIZE> {
     }
 }
 
-// To use this xor operator you must ensure that you have all the criteria listed here : 
+// To use this xor operator you must ensure that you have all the criteria listed here :
 // https://github.com/massalabs/massa/discussions/3852#discussioncomment-6188158
 impl<const SIZE: usize> BitXorAssign for HashXof<SIZE> {
     fn bitxor_assign(&mut self, rhs: Self) {
@@ -65,7 +65,7 @@ impl<const SIZE: usize> BitXorAssign for HashXof<SIZE> {
     }
 }
 
-// To use this xor operator you must ensure that you have all the criteria listed here : 
+// To use this xor operator you must ensure that you have all the criteria listed here :
 // https://github.com/massalabs/massa/discussions/3852#discussioncomment-6188158
 impl<const SIZE: usize> BitXor for HashXof<SIZE> {
     type Output = Self;

--- a/massa-hash/src/lib.rs
+++ b/massa-hash/src/lib.rs
@@ -9,5 +9,7 @@ pub use settings::XOF_HASH_SIZE_BYTES;
 
 mod error;
 mod hash;
+mod hash_xof;
 pub use hash::*;
+pub use hash_xof::*;
 mod settings;

--- a/massa-hash/src/lib.rs
+++ b/massa-hash/src/lib.rs
@@ -5,7 +5,7 @@
 #![warn(unused_crate_dependencies)]
 pub use error::MassaHashError;
 pub use settings::HASH_SIZE_BYTES;
-pub use settings::XOF_HASH_SIZE_BYTES;
+pub use settings::HASH_XOF_SIZE_BYTES;
 
 mod error;
 mod hash;

--- a/massa-hash/src/settings.rs
+++ b/massa-hash/src/settings.rs
@@ -3,4 +3,4 @@
 /// Hash size
 pub const HASH_SIZE_BYTES: usize = 32;
 /// Extended hash size
-pub const XOF_HASH_SIZE_BYTES: usize = 512;
+pub const HASH_XOF_SIZE_BYTES: usize = 512;

--- a/massa-ledger-worker/src/ledger_db.rs
+++ b/massa-ledger-worker/src/ledger_db.rs
@@ -467,7 +467,7 @@ mod tests {
     use super::*;
     use massa_db_exports::{MassaDBConfig, MassaDBController, STATE_HASH_INITIAL_BYTES};
     use massa_db_worker::MassaDB;
-    use massa_hash::Hash;
+    use massa_hash::HashXof;
     use massa_ledger_exports::{LedgerEntry, LedgerEntryUpdate, SetOrKeep};
     use massa_models::{
         address::Address,
@@ -555,8 +555,8 @@ mod tests {
         assert_eq!(data, ledger_db.get_entire_datastore(&addr));
 
         assert_ne!(
-            Hash::from_bytes(STATE_HASH_INITIAL_BYTES),
-            ledger_db.db.read().get_db_hash()
+            HashXof(*STATE_HASH_INITIAL_BYTES),
+            ledger_db.db.read().get_xof_db_hash()
         );
 
         // delete entry
@@ -569,8 +569,8 @@ mod tests {
 
         // check deleted address and ledger hash
         assert_eq!(
-            Hash::from_bytes(STATE_HASH_INITIAL_BYTES),
-            ledger_db.db.read().get_db_hash()
+            HashXof(*STATE_HASH_INITIAL_BYTES),
+            ledger_db.db.read().get_xof_db_hash()
         );
         assert!(ledger_db
             .get_sub_entry(&addr, LedgerSubEntry::Balance)

--- a/massa-pos-exports/src/cycle_info.rs
+++ b/massa-pos-exports/src/cycle_info.rs
@@ -61,6 +61,7 @@ impl CycleInfoHashComputer {
         Hash::compute_from(&buffer)
     }
 
+    // TODO: Remove hash from cycle and deferred credits as it's not saved in the DB.
     fn compute_roll_entry_hash(
         &self,
         address: &Address,

--- a/massa-pos-exports/src/cycle_info.rs
+++ b/massa-pos-exports/src/cycle_info.rs
@@ -1,5 +1,5 @@
 use bitvec::vec::BitVec;
-use massa_hash::{Hash, HashDeserializer, HashSerializer, HASH_SIZE_BYTES};
+use massa_hash::{Hash, HashXof, HashXofDeserializer, HashXofSerializer, HASH_XOF_SIZE_BYTES};
 use massa_models::{
     address::{Address, AddressDeserializer, AddressSerializer},
     prehash::PreHashMap,
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, VecDeque};
 use std::ops::Bound::Included;
 
-const CYCLE_INFO_HASH_INITIAL_BYTES: &[u8; 32] = &[0; HASH_SIZE_BYTES];
+const CYCLE_INFO_HASH_INITIAL_BYTES: &[u8; HASH_XOF_SIZE_BYTES] = &[0; HASH_XOF_SIZE_BYTES];
 
 struct CycleInfoHashComputer {
     u64_ser: U64VarIntSerializer,
@@ -61,18 +61,22 @@ impl CycleInfoHashComputer {
         Hash::compute_from(&buffer)
     }
 
-    fn compute_roll_entry_hash(&self, address: &Address, roll_count: u64) -> Hash {
+    fn compute_roll_entry_hash(
+        &self,
+        address: &Address,
+        roll_count: u64,
+    ) -> HashXof<HASH_XOF_SIZE_BYTES> {
         let mut buffer = Vec::new();
         self.address_ser.serialize(address, &mut buffer).unwrap();
         self.u64_ser.serialize(&roll_count, &mut buffer).unwrap();
-        Hash::compute_from(&buffer)
+        HashXof::compute_from(&buffer)
     }
 
     fn compute_prod_stats_entry_hash(
         &self,
         address: &Address,
         prod_stats: &ProductionStats,
-    ) -> Hash {
+    ) -> HashXof<HASH_XOF_SIZE_BYTES> {
         let mut buffer = Vec::new();
         self.address_ser.serialize(address, &mut buffer).unwrap();
         self.u64_ser
@@ -81,7 +85,7 @@ impl CycleInfoHashComputer {
         self.u64_ser
             .serialize(&prod_stats.block_failure_count, &mut buffer)
             .unwrap();
-        Hash::compute_from(&buffer)
+        HashXof::compute_from(&buffer)
     }
 }
 
@@ -99,14 +103,14 @@ pub struct CycleInfo {
     /// Per-address production statistics
     pub production_stats: PreHashMap<Address, ProductionStats>,
     /// Hash of the roll counts
-    pub roll_counts_hash: Hash,
+    pub roll_counts_hash: HashXof<HASH_XOF_SIZE_BYTES>,
     /// Hash of the production statistics
-    pub production_stats_hash: Hash,
+    pub production_stats_hash: HashXof<HASH_XOF_SIZE_BYTES>,
     /// Hash of the cycle state
-    pub cycle_global_hash: Hash,
+    pub cycle_global_hash: HashXof<HASH_XOF_SIZE_BYTES>,
     /// Snapshot of the final state hash
     /// Used for PoS selections
-    pub final_state_hash_snapshot: Option<Hash>,
+    pub final_state_hash_snapshot: Option<HashXof<HASH_XOF_SIZE_BYTES>>,
 }
 
 impl CycleInfo {
@@ -119,8 +123,8 @@ impl CycleInfo {
         production_stats: PreHashMap<Address, ProductionStats>,
     ) -> Self {
         let hash_computer = CycleInfoHashComputer::new();
-        let mut roll_counts_hash = Hash::from_bytes(CYCLE_INFO_HASH_INITIAL_BYTES);
-        let mut production_stats_hash = Hash::from_bytes(CYCLE_INFO_HASH_INITIAL_BYTES);
+        let mut roll_counts_hash = HashXof::from_bytes(CYCLE_INFO_HASH_INITIAL_BYTES);
+        let mut production_stats_hash = HashXof::from_bytes(CYCLE_INFO_HASH_INITIAL_BYTES);
 
         // compute the cycle hash
         let mut hash_concat: Vec<u8> = Vec::new();
@@ -137,7 +141,7 @@ impl CycleInfo {
         hash_concat.extend(production_stats_hash.to_bytes());
 
         // compute the global hash
-        let cycle_global_hash = Hash::compute_from(&hash_concat);
+        let cycle_global_hash = HashXof::compute_from(&hash_concat);
 
         // create the new cycle
         CycleInfo {
@@ -162,7 +166,7 @@ pub struct CycleInfoSerializer {
     pub bitvec_ser: BitVecSerializer,
     pub production_stats_ser: ProductionStatsSerializer,
     pub address_ser: AddressSerializer,
-    pub opt_hash_ser: OptionSerializer<Hash, HashSerializer>,
+    pub opt_hash_ser: OptionSerializer<HashXof<HASH_XOF_SIZE_BYTES>, HashXofSerializer>,
 }
 
 impl Default for CycleInfoSerializer {
@@ -179,7 +183,7 @@ impl CycleInfoSerializer {
             bitvec_ser: BitVecSerializer::new(),
             production_stats_ser: ProductionStatsSerializer::new(),
             address_ser: AddressSerializer::new(),
-            opt_hash_ser: OptionSerializer::new(HashSerializer::new()),
+            opt_hash_ser: OptionSerializer::new(HashXofSerializer::new()),
         }
     }
 }
@@ -223,7 +227,7 @@ pub struct CycleInfoDeserializer {
     pub rolls_deser: RollsDeserializer,
     pub bitvec_deser: BitVecDeserializer,
     pub production_stats_deser: ProductionStatsDeserializer,
-    pub opt_hash_deser: OptionDeserializer<Hash, HashDeserializer>,
+    pub opt_hash_deser: OptionDeserializer<HashXof<HASH_XOF_SIZE_BYTES>, HashXofDeserializer>,
 }
 
 impl CycleInfoDeserializer {
@@ -234,7 +238,7 @@ impl CycleInfoDeserializer {
             rolls_deser: RollsDeserializer::new(max_rolls_length),
             bitvec_deser: BitVecDeserializer::new(),
             production_stats_deser: ProductionStatsDeserializer::new(max_production_stats_length),
-            opt_hash_deser: OptionDeserializer::new(HashDeserializer::new()),
+            opt_hash_deser: OptionDeserializer::new(HashXofDeserializer::new()),
         }
     }
 }
@@ -270,7 +274,7 @@ impl Deserializer<CycleInfo> for CycleInfoDeserializer {
                 Vec<(Address, u64)>,                  // roll_counts
                 BitVec<u8>,                           // rng_seed
                 PreHashMap<Address, ProductionStats>, // production_stats (address, n_success, n_fail)
-                Option<Hash>,                         // final_state_hash_snapshot
+                Option<HashXof<HASH_XOF_SIZE_BYTES>>, // final_state_hash_snapshot
             )| {
                 let mut cycle = CycleInfo::new_with_hash(
                     cycle,

--- a/massa-pos-exports/src/pos_final_state.rs
+++ b/massa-pos-exports/src/pos_final_state.rs
@@ -10,7 +10,7 @@ use massa_db_exports::{
     CYCLE_HISTORY_DESER_ERROR, CYCLE_HISTORY_PREFIX, CYCLE_HISTORY_SER_ERROR,
     DEFERRED_CREDITS_DESER_ERROR, DEFERRED_CREDITS_PREFIX, DEFERRED_CREDITS_SER_ERROR, STATE_CF,
 };
-use massa_hash::Hash;
+use massa_hash::{Hash, HashXof, HASH_XOF_SIZE_BYTES};
 use massa_models::amount::Amount;
 use massa_models::{address::Address, prehash::PreHashMap, slot::Slot};
 use massa_serialization::{DeserializeError, Deserializer, Serializer, U64VarIntSerializer};
@@ -544,7 +544,11 @@ impl PoSFinalState {
     }
 
     /// Feeds the selector targeting a given draw cycle
-    pub fn feed_cycle_state_hash(&self, cycle: u64, final_state_hash: Hash) {
+    pub fn feed_cycle_state_hash(
+        &self,
+        cycle: u64,
+        final_state_hash: HashXof<HASH_XOF_SIZE_BYTES>,
+    ) {
         if self.get_cycle_index(cycle).is_some() {
             let mut batch = DBBatch::new();
             self.put_cycle_history_final_state_hash_snapshot(
@@ -846,7 +850,10 @@ impl PoSFinalState {
     /// Getter for the final_state_hash_snapshot of a given cycle.
     ///
     /// Panics if the cycle is not in the history.
-    fn get_cycle_history_final_state_hash_snapshot(&self, cycle: u64) -> Option<Hash> {
+    fn get_cycle_history_final_state_hash_snapshot(
+        &self,
+        cycle: u64,
+    ) -> Option<HashXof<HASH_XOF_SIZE_BYTES>> {
         let db = self.db.read();
 
         let serialized_state_hash = db
@@ -1063,7 +1070,7 @@ impl PoSFinalState {
     fn put_cycle_history_final_state_hash_snapshot(
         &self,
         cycle: u64,
-        value: Option<Hash>,
+        value: Option<HashXof<HASH_XOF_SIZE_BYTES>>,
         batch: &mut DBBatch,
     ) {
         let db = self.db.read();


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

TODO: Check every instance of get_db_hash() calls, we probably want to replaced them with the xof alternative.