### PR TITLE
Reduce memory usage

### DIFF
--- a/massa-metrics/src/lib.rs
+++ b/massa-metrics/src/lib.rs
@@ -56,8 +56,6 @@ pub struct MassaMetrics {
     active_in_connections: IntGauge,
     active_out_connections: IntGauge,
 
-    retrieval_thread_stored_operations_sum: IntGauge,
-
     // block_cache
     block_cache_checked_headers_size: IntGauge,
     block_cache_blocks_known_by_peer: IntGauge,
@@ -174,13 +172,6 @@ impl MassaMetrics {
         )
         .unwrap();
 
-        // from retrieval thread of operation_handler
-        let retrieval_thread_stored_operations_sum = IntGauge::new(
-            "retrieval_thread_stored_operations_sum_size",
-            "sum of retrieval_thread_stored_operations",
-        )
-        .unwrap();
-
         // consensus state from tick.rs
         let consensus_state_active_index = IntGauge::new(
             "consensus_state_active_index",
@@ -249,8 +240,6 @@ impl MassaMetrics {
                 let _ = prometheus::register(Box::new(operation_cache_checked_operations.clone()));
                 let _ = prometheus::register(Box::new(active_in_connections.clone()));
                 let _ = prometheus::register(Box::new(operation_cache_ops_know_by_peer.clone()));
-                let _ =
-                    prometheus::register(Box::new(retrieval_thread_stored_operations_sum.clone()));
                 let _ = prometheus::register(Box::new(consensus_state_active_index.clone()));
                 let _ = prometheus::register(Box::new(
                     consensus_state_active_index_without_ops.clone(),
@@ -275,7 +264,6 @@ impl MassaMetrics {
             block_graph_ms,
             active_in_connections,
             active_out_connections,
-            retrieval_thread_stored_operations_sum,
             block_cache_checked_headers_size,
             block_cache_blocks_known_by_peer,
             operation_cache_checked_operations,
@@ -367,10 +355,6 @@ impl MassaMetrics {
             .set(checked_header_size as i64);
         self.block_cache_blocks_known_by_peer
             .set(blocks_known_by_peer as i64);
-    }
-
-    pub fn set_retrieval_thread_stored_operations_sum(&self, sum: usize) {
-        self.retrieval_thread_stored_operations_sum.set(sum as i64);
     }
 
     pub fn set_operations_cache_metrics(

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -192,7 +192,7 @@
     # start processing batches in the buffer each `operation_batch_proc_period` in millisecond
     operation_batch_proc_period = 500
     # all operations asked are prune each `operation_asked_pruning_period` millisecond
-    asked_operations_pruning_period = 16000
+    asked_operations_pruning_period = 32000
     # interval at which operations are announced in batches.
     operation_announcement_interval = 300
     # max number of operation per message, same as network param but can be smaller
@@ -202,9 +202,9 @@
     # Number of millis seconds that create a timeout for out connections
     timeout_connection = 1000
     # time threshold after which operation are not propagated
-    max_operations_propagation_time = 16000
+    max_operations_propagation_time = 32000
     # time threshold after which endorsement are not propagated
-    max_endorsements_propagation_time = 16000
+    max_endorsements_propagation_time = 32000
     # number of thread tester
     thread_tester_count = 25
     # Nb max in connections that we accept

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -191,8 +191,6 @@
     operation_announcement_buffer_capacity = 2000
     # start processing batches in the buffer each `operation_batch_proc_period` in millisecond
     operation_batch_proc_period = 500
-    # all operations asked are prune each `operation_asked_pruning_period` millisecond
-    asked_operations_pruning_period = 32000
     # interval at which operations are announced in batches.
     operation_announcement_interval = 300
     # max number of operation per message, same as network param but can be smaller
@@ -201,6 +199,8 @@
     try_connection_timer = 5000
     # Number of millis seconds that create a timeout for out connections
     timeout_connection = 1000
+    # max number of operations kept for propagation
+    max_ops_kept_for_propagation = 320000
     # time threshold after which operation are not propagated
     max_operations_propagation_time = 32000
     # time threshold after which endorsement are not propagated

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -192,7 +192,7 @@
     # start processing batches in the buffer each `operation_batch_proc_period` in millisecond
     operation_batch_proc_period = 500
     # all operations asked are prune each `operation_asked_pruning_period` millisecond
-    asked_operations_pruning_period = 100000
+    asked_operations_pruning_period = 16000
     # interval at which operations are announced in batches.
     operation_announcement_interval = 300
     # max number of operation per message, same as network param but can be smaller

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -134,7 +134,7 @@
     # number of final periods that must be kept without operations (increase improve bootstrap process, high values will increase RAM usage.)
     force_keep_final_periods_without_ops = 32
     # number of final periods that must be kept with operations (increase to more resilience to short network disconnections, high values will increase RAM usage.)
-    force_keep_final_periods = 10
+    force_keep_final_periods = 5
 
     # useless blocks are pruned every block_db_prune_interval ms
     block_db_prune_interval = 5000

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -202,9 +202,9 @@
     # Number of millis seconds that create a timeout for out connections
     timeout_connection = 1000
     # time threshold after which operation are not propagated
-    max_operations_propagation_time = 32000
+    max_operations_propagation_time = 16000
     # time threshold after which endorsement are not propagated
-    max_endorsements_propagation_time = 48000
+    max_endorsements_propagation_time = 16000
     # number of thread tester
     thread_tester_count = 25
     # Nb max in connections that we accept

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -587,7 +587,6 @@ async fn launch(
             .protocol
             .operation_announcement_buffer_capacity,
         operation_batch_proc_period: SETTINGS.protocol.operation_batch_proc_period,
-        asked_operations_pruning_period: SETTINGS.protocol.asked_operations_pruning_period,
         operation_announcement_interval: SETTINGS.protocol.operation_announcement_interval,
         max_operations_per_message: SETTINGS.protocol.max_operations_per_message,
         max_serialized_operations_size_per_block: MAX_BLOCK_SIZE as usize,
@@ -598,6 +597,7 @@ async fn launch(
         t0: T0,
         endorsement_count: ENDORSEMENT_COUNT,
         max_message_size: MAX_MESSAGE_SIZE as usize,
+        max_ops_kept_for_propagation: SETTINGS.protocol.max_ops_kept_for_propagation,
         max_operations_propagation_time: SETTINGS.protocol.max_operations_propagation_time,
         max_endorsements_propagation_time: SETTINGS.protocol.max_endorsements_propagation_time,
         last_start_period: final_state.read().last_start_period,

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -209,12 +209,12 @@ pub struct ProtocolSettings {
     pub operation_announcement_buffer_capacity: usize,
     /// Start processing batches in the buffer each `operation_batch_proc_period` in millisecond
     pub operation_batch_proc_period: MassaTime,
-    /// All operations asked are prune each `operation_asked_pruning_period` millisecond
-    pub asked_operations_pruning_period: MassaTime,
     /// Interval at which operations are announced in batches.
     pub operation_announcement_interval: MassaTime,
     /// Maximum of operations sent in one message.
     pub max_operations_per_message: u64,
+    /// MAx number of operations kept for propagation
+    pub max_ops_kept_for_propagation: usize,
     /// Time threshold after which operation are not propagated
     pub max_operations_propagation_time: MassaTime,
     /// Time threshold after which operation are not propagated

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -60,8 +60,6 @@ pub struct ProtocolConfig {
     pub operation_batch_proc_period: MassaTime,
     /// Maximum number of asked operations in the memory buffer.
     pub asked_operations_buffer_capacity: usize,
-    /// All operations asked are prune each `operation_asked_pruning_period` millisecond
-    pub asked_operations_pruning_period: MassaTime,
     /// Interval at which operations are announced in batches.
     pub operation_announcement_interval: MassaTime,
     /// Maximum time we keep an operation in the storage
@@ -80,6 +78,8 @@ pub struct ProtocolConfig {
     pub t0: MassaTime,
     /// Genesis timestamp
     pub genesis_timestamp: MassaTime,
+    /// max number of operations kept in memory for propagation
+    pub max_ops_kept_for_propagation: usize,
     /// max time we propagate operations
     pub max_operations_propagation_time: MassaTime,
     /// max time we propagate endorsements

--- a/massa-protocol-exports/src/test_exports/config.rs
+++ b/massa-protocol-exports/src/test_exports/config.rs
@@ -37,6 +37,7 @@ impl Default for ProtocolConfig {
             event_channel_size: 1024,
             genesis_timestamp: MassaTime::now().unwrap(),
             t0: MassaTime::from_millis(16000),
+            max_ops_kept_for_propagation: 10000,
             max_operations_propagation_time: MassaTime::from_millis(30000),
             max_endorsements_propagation_time: MassaTime::from_millis(60000),
             initial_peers: NamedTempFile::new()

--- a/massa-protocol-exports/src/test_exports/config.rs
+++ b/massa-protocol-exports/src/test_exports/config.rs
@@ -28,7 +28,6 @@ impl Default for ProtocolConfig {
             max_operation_storage_time: MassaTime::from_millis(60000),
             operation_batch_proc_period: MassaTime::from_millis(200),
             asked_operations_buffer_capacity: 10000,
-            asked_operations_pruning_period: MassaTime::from_millis(500),
             operation_announcement_interval: MassaTime::from_millis(150),
             max_operations_per_message: 1024,
             max_operations_per_block: 5000,

--- a/massa-protocol-worker/src/controller.rs
+++ b/massa-protocol-worker/src/controller.rs
@@ -112,12 +112,10 @@ impl ProtocolController for ProtocolControllerImpl {
     ///
     /// note: Full `OperationId` is replaced by a `OperationPrefixId` later by the worker.
     fn propagate_operations(&self, operations: Storage) -> Result<(), ProtocolError> {
-        //TODO: Change when send will be in propagation
-        let operations = operations.get_op_refs().clone();
         self.sender_operation_handler
             .as_ref()
             .unwrap()
-            .try_send(OperationHandlerPropagationCommand::AnnounceOperations(
+            .try_send(OperationHandlerPropagationCommand::PropagateOperations(
                 operations,
             ))
             .map_err(|_| {

--- a/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
@@ -1102,32 +1102,54 @@ impl RetrievalThread {
         source_peer_id: &PeerId,
     ) -> Result<(), ProtocolError> {
         massa_trace!("protocol.protocol_worker.note_operations_from_peer", { "peer": source_peer_id, "operations": operations });
-        let length = operations.len();
-        let mut new_operations = PreHashMap::with_capacity(length);
-        let mut received_ids = PreHashSet::with_capacity(length);
+        let now = MassaTime::now().expect("could not get current time");
+
+        let mut new_operations = PreHashMap::with_capacity(operations.len());
         for operation in operations {
-            let operation_id = operation.id;
+            // ignore if op is too old
+            let expire_period_timestamp = get_block_slot_timestamp(
+                self.config.thread_count,
+                self.config.t0,
+                self.config.genesis_timestamp,
+                Slot::new(
+                    operation.content.expire_period,
+                    operation
+                        .content_creator_address
+                        .get_thread(self.config.thread_count),
+                ),
+            );
+            match expire_period_timestamp {
+                Ok(slot_timestamp) => {
+                    if slot_timestamp.saturating_add(self.config.max_operations_propagation_time)
+                        < now
+                    {
+                        continue;
+                    }
+                }
+                Err(_) => continue,
+            }
+
+            // quit if op is too big
             if operation.serialized_size() > self.config.max_serialized_operations_size_per_block {
                 return Err(ProtocolError::InvalidOperationError(format!(
                     "Operation {} exceeds max block size,  maximum authorized {} bytes but found {} bytes",
-                    operation_id,
+                    operation.id,
                     operation.serialized_size(),
                     self.config.max_serialized_operations_size_per_block
                 )));
             };
-            received_ids.insert(operation_id);
 
-            // Check operation signature only if not already checked.
-            if self
-                .operation_cache
-                .read()
-                .checked_operations
-                .peek(&operation_id)
-                .is_none()
-            {
-                // check signature if the operation wasn't in `checked_operation`
-                new_operations.insert(operation_id, operation);
-            };
+            // add to new operations
+            new_operations.insert(operation.id, operation);
+        }
+
+        // all valid received ids (not only new ones) for knowledge marking
+        let all_received_ids: PreHashSet<_> = new_operations.keys().copied().collect();
+
+        // retain only new ops that are not already known
+        {
+            let cache_read = self.operation_cache.read();
+            new_operations.retain(|op_id, _| cache_read.checked_operations.peek(op_id).is_none());
         }
 
         // optimized signature verification
@@ -1160,54 +1182,22 @@ impl RetrievalThread {
                     warn!("ops_known_by_peer limitation reached");
                     break 'write_cache;
                 };
-            for id in received_ids {
+            for id in all_received_ids {
                 known_ops.insert(id.prefix(), ());
             }
         }
 
         if !new_operations.is_empty() {
-            // Store operation, claim locally
+            // Store new operations, claim locally
             let mut ops = self.storage.clone_without_refs();
             ops.store_operations(new_operations.into_values().collect());
 
-            // Propagate operations when their expire period isn't `max_operations_propagation_time` old.
-            let mut ops_to_propagate = ops.clone();
-            let operations_to_not_propagate = {
-                let now = MassaTime::now()?;
-                let read_operations = ops_to_propagate.read_operations();
-                ops_to_propagate
-                    .get_op_refs()
-                    .iter()
-                    .filter(|op_id| {
-                        let expire_period =
-                            read_operations.get(op_id).unwrap().content.expire_period;
-                        let expire_period_timestamp = get_block_slot_timestamp(
-                            self.config.thread_count,
-                            self.config.t0,
-                            self.config.genesis_timestamp,
-                            Slot::new(expire_period, 0),
-                        );
-                        match expire_period_timestamp {
-                            Ok(slot_timestamp) => {
-                                slot_timestamp
-                                    .saturating_add(self.config.max_operations_propagation_time)
-                                    < now
-                            }
-                            Err(_) => true,
-                        }
-                    })
-                    .copied()
-                    .collect()
-            };
-            ops_to_propagate.drop_operation_refs(&operations_to_not_propagate);
-            let to_announce: PreHashSet<OperationId> =
-                ops_to_propagate.get_op_refs().iter().copied().collect();
-            self.storage.extend(ops_to_propagate);
             self.sender_propagation_ops
-                .try_send(OperationHandlerPropagationCommand::AnnounceOperations(
-                    to_announce,
+                .try_send(OperationHandlerPropagationCommand::PropagateOperations(
+                    ops.clone(),
                 ))
                 .map_err(|err| ProtocolError::SendError(err.to_string()))?;
+
             // Add to pool
             self.pool_controller.add_operations(ops);
         }

--- a/massa-protocol-worker/src/handlers/operation_handler/commands_propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/commands_propagation.rs
@@ -1,8 +1,8 @@
-use massa_models::{operation::OperationId, prehash::PreHashSet};
+use massa_storage::Storage;
 
 #[derive(Clone)]
 pub enum OperationHandlerPropagationCommand {
     Stop,
     /// operations ids
-    AnnounceOperations(PreHashSet<OperationId>),
+    PropagateOperations(Storage),
 }

--- a/massa-protocol-worker/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/mod.rs
@@ -62,11 +62,17 @@ impl OperationHandler {
             receiver_retrieval_ext,
             local_sender.clone(),
             peer_cmd_sender,
-            massa_metrics,
+            massa_metrics.clone(),
         );
 
-        let operation_propagation_thread =
-            start_propagation_thread(local_receiver, active_connections, config, cache);
+        let operation_propagation_thread = start_propagation_thread(
+            local_receiver,
+            active_connections,
+            config,
+            cache,
+            storage.clone_without_refs(),
+            massa_metrics,
+        );
         Self {
             operation_retrieval_thread: Some((sender_retrieval_ext, operation_retrieval_thread)),
             operation_propagation_thread: Some((local_sender, operation_propagation_thread)),

--- a/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
@@ -1,11 +1,16 @@
+use std::collections::VecDeque;
 use std::{mem, thread::JoinHandle};
 
 use crossbeam::channel::RecvTimeoutError;
 use massa_channel::receiver::MassaReceiver;
 use massa_logging::massa_trace;
+use massa_metrics::MassaMetrics;
 use massa_models::operation::OperationId;
+use massa_models::prehash::CapacityAllocator;
+use massa_models::prehash::PreHashSet;
 use massa_protocol_exports::PeerId;
 use massa_protocol_exports::ProtocolConfig;
+use massa_storage::Storage;
 use tracing::{debug, info, log::warn};
 
 use crate::{
@@ -21,39 +26,55 @@ use super::{
 struct PropagationThread {
     internal_receiver: MassaReceiver<OperationHandlerPropagationCommand>,
     active_connections: Box<dyn ActiveConnectionsTrait>,
-    operations_to_announce: Vec<OperationId>,
+    // times at which previous ops were announced
+    stored_for_propagation: VecDeque<(std::time::Instant, PreHashSet<OperationId>)>,
+    op_storage: Storage,
+    next_batch: PreHashSet<OperationId>,
     config: ProtocolConfig,
     cache: SharedOperationCache,
     operation_message_serializer: MessagesSerializer,
+    _massa_metrics: MassaMetrics,
 }
 
 impl PropagationThread {
     fn run(&mut self) {
-        let mut next_announce = std::time::Instant::now()
+        let mut batch_deadline = std::time::Instant::now()
             .checked_add(self.config.operation_announcement_interval.to_duration())
             .expect("Can't init interval op propagation");
         loop {
-            match self.internal_receiver.recv_deadline(next_announce) {
+            match self.internal_receiver.recv_deadline(batch_deadline) {
                 Ok(internal_message) => {
                     match internal_message {
-                        OperationHandlerPropagationCommand::AnnounceOperations(operations_ids) => {
+                        OperationHandlerPropagationCommand::PropagateOperations(operations) => {
                             // Note operations as checked.
                             {
                                 let mut cache_write = self.cache.write();
-                                for op_id in operations_ids.iter().copied() {
+                                for op_id in operations.get_op_refs().iter().copied() {
                                     cache_write.insert_checked_operation(op_id);
                                 }
                             }
-                            self.operations_to_announce.extend(operations_ids);
-                            if self.operations_to_announce.len()
-                                > self.config.operation_announcement_buffer_capacity
-                            {
-                                self.announce_ops();
-                                next_announce = std::time::Instant::now()
-                                    .checked_add(
-                                        self.config.operation_announcement_interval.to_duration(),
-                                    )
-                                    .expect("Can't init interval op propagation");
+
+                            // add to propagation storage
+                            let new_ops = operations.get_op_refs().clone();
+                            self.stored_for_propagation
+                                .push_back((std::time::Instant::now(), new_ops.clone()));
+                            self.op_storage.extend(operations);
+                            self.prune_propagation_storage();
+
+                            for op_id in new_ops {
+                                self.next_batch.insert(op_id);
+                                if self.next_batch.len()
+                                    >= self.config.operation_announcement_buffer_capacity
+                                {
+                                    self.announce_ops();
+                                    batch_deadline = std::time::Instant::now()
+                                        .checked_add(
+                                            self.config
+                                                .operation_announcement_interval
+                                                .to_duration(),
+                                        )
+                                        .expect("Can't init interval op propagation");
+                                }
                             }
                         }
                         OperationHandlerPropagationCommand::Stop => {
@@ -64,7 +85,7 @@ impl PropagationThread {
                 }
                 Err(RecvTimeoutError::Timeout) => {
                     self.announce_ops();
-                    next_announce = std::time::Instant::now()
+                    batch_deadline = std::time::Instant::now()
                         .checked_add(self.config.operation_announcement_interval.to_duration())
                         .expect("Can't init interval op propagation");
                 }
@@ -75,12 +96,39 @@ impl PropagationThread {
         }
     }
 
+    /// Prune the list of operations kept for propagation.
+    fn prune_propagation_storage(&mut self) {
+        let mut removed = PreHashSet::default();
+
+        // cap cache size
+        while self.stored_for_propagation.len() > self.config.max_ops_kept_for_propagation {
+            if let Some((_t, op_ids)) = self.stored_for_propagation.pop_front() {
+                removed.extend(op_ids);
+            } else {
+                break;
+            }
+        }
+
+        // remove expired
+        let max_op_prop_time = self.config.max_operations_propagation_time.to_duration();
+        while let Some((t, op_ids)) = self.stored_for_propagation.front() {
+            if t.elapsed() > max_op_prop_time {
+                removed.extend(op_ids);
+            } else {
+                break;
+            }
+        }
+
+        // remove from storage
+        self.op_storage.drop_operation_refs(&removed);
+    }
+
     fn announce_ops(&mut self) {
         // Quit if empty  to avoid iterating on nodes
-        if self.operations_to_announce.is_empty() {
+        if self.next_batch.is_empty() {
             return;
         }
-        let operation_ids = mem::take(&mut self.operations_to_announce);
+        let operation_ids = mem::take(&mut self.next_batch);
         massa_trace!("protocol.protocol_worker.announce_ops.begin", {
             "operation_ids": operation_ids
         });
@@ -140,6 +188,8 @@ pub fn start_propagation_thread(
     active_connections: Box<dyn ActiveConnectionsTrait>,
     config: ProtocolConfig,
     cache: SharedOperationCache,
+    op_storage: Storage,
+    massa_metrics: MassaMetrics,
 ) -> JoinHandle<()> {
     std::thread::Builder::new()
         .name("protocol-operation-handler-propagation".to_string())
@@ -147,9 +197,18 @@ pub fn start_propagation_thread(
             let mut propagation_thread = PropagationThread {
                 internal_receiver,
                 active_connections,
-                operations_to_announce: Vec::new(),
+                stored_for_propagation: VecDeque::with_capacity(
+                    config.max_ops_kept_for_propagation,
+                ),
+                op_storage,
+                next_batch: PreHashSet::with_capacity(
+                    config
+                        .operation_announcement_buffer_capacity
+                        .saturating_add(1),
+                ),
                 config,
                 cache,
+                _massa_metrics: massa_metrics,
                 operation_message_serializer: MessagesSerializer::new()
                     .with_operation_message_serializer(OperationMessageSerializer::new()),
             };

--- a/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
@@ -111,8 +111,12 @@ impl PropagationThread {
 
         // remove expired
         let max_op_prop_time = self.config.max_operations_propagation_time.to_duration();
-        while let Some((t, op_ids)) = self.stored_for_propagation.front() {
+        while let Some((t, _)) = self.stored_for_propagation.front() {
             if t.elapsed() > max_op_prop_time {
+                let (_, op_ids) = self
+                    .stored_for_propagation
+                    .pop_front()
+                    .expect("there should be at least one element, checked above");
                 removed.extend(op_ids);
             } else {
                 break;

--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -187,32 +187,49 @@ impl RetrievalThread {
         source_peer_id: &PeerId,
     ) -> Result<(), ProtocolError> {
         massa_trace!("protocol.protocol_worker.note_operations_from_peer", { "peer": source_peer_id, "operations": operations });
-        let length = operations.len();
-        let mut new_operations = PreHashMap::with_capacity(length);
-        let mut received_ids = PreHashSet::with_capacity(length);
+        let now = MassaTime::now().expect("could not get current time");
+
+        let mut new_operations = PreHashMap::with_capacity(operations.len());
         for operation in operations {
-            let operation_id = operation.id;
+            // ignore if op is too old
+            let expire_period_timestamp = get_block_slot_timestamp(
+                self.config.thread_count,
+                self.config.t0,
+                self.config.genesis_timestamp,
+                Slot::new(operation.content.expire_period, 0),
+            );
+            match expire_period_timestamp {
+                Ok(slot_timestamp) => {
+                    if slot_timestamp.saturating_add(self.config.max_operations_propagation_time)
+                        > now
+                    {
+                        continue;
+                    }
+                }
+                Err(_) => continue,
+            }
+
+            // quit if op is too big
             if operation.serialized_size() > self.config.max_serialized_operations_size_per_block {
                 return Err(ProtocolError::InvalidOperationError(format!(
                     "Operation {} exceeds max block size,  maximum authorized {} bytes but found {} bytes",
-                    operation_id,
+                    operation.id,
                     operation.serialized_size(),
                     self.config.max_serialized_operations_size_per_block
                 )));
             };
-            received_ids.insert(operation_id);
 
-            // Check operation signature only if not already checked.
-            if self
-                .cache
-                .read()
-                .checked_operations
-                .peek(&operation_id)
-                .is_none()
-            {
-                // check signature if the operation wasn't in `checked_operation`
-                new_operations.insert(operation_id, operation);
-            };
+            // add to new operations
+            new_operations.insert(operation.id, operation);
+        }
+
+        // all valid received ids (not only new ones) for knowledge marking
+        let all_received_ids: PreHashSet<_> = new_operations.keys().copied().collect();
+
+        // retain only new ops that are not already known
+        {
+            let cache_read = self.cache.read();
+            new_operations.retain(|op_id, _| cache_read.checked_operations.peek(op_id).is_none());
         }
 
         // optimized signature verification
@@ -245,56 +262,27 @@ impl RetrievalThread {
                     warn!("ops_known_by_peer limitation reached");
                     break 'write_cache;
                 };
-            for id in received_ids {
+            for id in all_received_ids {
                 known_ops.insert(id.prefix(), ());
             }
         }
 
         if !new_operations.is_empty() {
-            // Store operation, claim locally
+            // Store new operations, claim locally
             let mut ops = self.storage.clone_without_refs();
             ops.store_operations(new_operations.into_values().collect());
 
             // Propagate operations when their expire period isn't `max_operations_propagation_time` old.
-            let mut ops_to_propagate = ops.clone();
-            let operations_to_not_propagate = {
-                let now = MassaTime::now()?;
-                let read_operations = ops_to_propagate.read_operations();
-                ops_to_propagate
-                    .get_op_refs()
-                    .iter()
-                    .filter(|op_id| {
-                        let expire_period =
-                            read_operations.get(op_id).unwrap().content.expire_period;
-                        let expire_period_timestamp = get_block_slot_timestamp(
-                            self.config.thread_count,
-                            self.config.t0,
-                            self.config.genesis_timestamp,
-                            Slot::new(expire_period, 0),
-                        );
-                        match expire_period_timestamp {
-                            Ok(slot_timestamp) => {
-                                slot_timestamp
-                                    .saturating_add(self.config.max_operations_propagation_time)
-                                    < now
-                            }
-                            Err(_) => true,
-                        }
-                    })
-                    .copied()
-                    .collect()
-            };
-            ops_to_propagate.drop_operation_refs(&operations_to_not_propagate);
-            let to_announce: PreHashSet<OperationId> =
-                ops_to_propagate.get_op_refs().iter().copied().collect();
             self.stored_operations
-                .insert(Instant::now(), to_announce.clone());
-            self.storage.extend(ops_to_propagate);
+                .insert(Instant::now(), ops.get_op_refs().clone());
+            self.storage.claim_operation_refs(ops.get_op_refs());
+
             self.internal_sender
                 .try_send(OperationHandlerPropagationCommand::AnnounceOperations(
-                    to_announce,
+                    ops.get_op_refs().clone(),
                 ))
                 .map_err(|err| ProtocolError::SendError(err.to_string()))?;
+
             // Add to pool
             self.pool_controller.add_operations(ops);
         }

--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -196,12 +196,17 @@ impl RetrievalThread {
                 self.config.thread_count,
                 self.config.t0,
                 self.config.genesis_timestamp,
-                Slot::new(operation.content.expire_period, 0),
+                Slot::new(
+                    operation.content.expire_period,
+                    operation
+                        .content_creator_address
+                        .get_thread(self.config.thread_count),
+                ),
             );
             match expire_period_timestamp {
                 Ok(slot_timestamp) => {
                     if slot_timestamp.saturating_add(self.config.max_operations_propagation_time)
-                        > now
+                        < now
                     {
                         continue;
                     }

--- a/massa-storage/src/block_indexes.rs
+++ b/massa-storage/src/block_indexes.rs
@@ -15,7 +15,7 @@ use massa_models::{
 #[derive(Default)]
 pub struct BlockIndexes {
     /// Blocks structure container
-    blocks: PreHashMap<BlockId, SecureShareBlock>,
+    blocks: PreHashMap<BlockId, Box<SecureShareBlock>>,
     /// Structure mapping creators with the created blocks
     index_by_creator: PreHashMap<Address, PreHashSet<BlockId>>,
     /// Structure mapping slot with their block id
@@ -32,7 +32,7 @@ impl BlockIndexes {
     /// - block: the block to insert
 
     pub(crate) fn insert(&mut self, block: SecureShareBlock) {
-        if let Ok(b) = self.blocks.try_insert(block.id, block) {
+        if let Ok(b) = self.blocks.try_insert(block.id, Box::new(block)) {
             // update creator index
             self.index_by_creator
                 .entry(b.content_creator_address)
@@ -65,7 +65,7 @@ impl BlockIndexes {
     /// Remove a block, remove from the indexes and do some clean-up in indexes if necessary.
     /// Arguments:
     /// * `block_id`: the block id to remove
-    pub(crate) fn remove(&mut self, block_id: &BlockId) -> Option<SecureShareBlock> {
+    pub(crate) fn remove(&mut self, block_id: &BlockId) -> Option<Box<SecureShareBlock>> {
         if let Some(b) = self.blocks.remove(block_id) {
             // update creator index
             if let hash_map::Entry::Occupied(mut occ) =
@@ -119,7 +119,7 @@ impl BlockIndexes {
     /// Returns:
     /// - a reference to the block, or None if not found
     pub fn get(&self, id: &BlockId) -> Option<&SecureShareBlock> {
-        self.blocks.get(id)
+        self.blocks.get(id).map(|v| v.as_ref())
     }
 
     /// Checks whether a block exists in global storage.

--- a/massa-storage/src/operation_indexes.rs
+++ b/massa-storage/src/operation_indexes.rs
@@ -11,7 +11,7 @@ use massa_models::{
 #[derive(Default)]
 pub struct OperationIndexes {
     /// Operations structure container
-    operations: PreHashMap<OperationId, SecureShareOperation>,
+    operations: PreHashMap<OperationId, Box<SecureShareOperation>>,
     /// Structure mapping creators with the created operations
     index_by_creator: PreHashMap<Address, PreHashSet<OperationId>>,
     /// Structure indexing operations by ID prefix
@@ -23,7 +23,10 @@ impl OperationIndexes {
     /// Arguments:
     /// * `operation`: the operation to insert
     pub(crate) fn insert(&mut self, operation: SecureShareOperation) {
-        if let Ok(o) = self.operations.try_insert(operation.id, operation) {
+        if let Ok(o) = self
+            .operations
+            .try_insert(operation.id, Box::new(operation))
+        {
             massa_metrics::inc_operations_counter();
 
             // update creator index
@@ -42,7 +45,10 @@ impl OperationIndexes {
     /// Remove a operation, remove from the indexes and made some clean-up in indexes if necessary.
     /// Arguments:
     /// * `operation_id`: the operation id to remove
-    pub(crate) fn remove(&mut self, operation_id: &OperationId) -> Option<SecureShareOperation> {
+    pub(crate) fn remove(
+        &mut self,
+        operation_id: &OperationId,
+    ) -> Option<Box<SecureShareOperation>> {
         if let Some(o) = self.operations.remove(operation_id) {
             massa_metrics::dec_operations_counter();
 
@@ -69,7 +75,7 @@ impl OperationIndexes {
 
     /// Gets a reference to a stored operation, if any.
     pub fn get(&self, id: &OperationId) -> Option<&SecureShareOperation> {
-        self.operations.get(id)
+        self.operations.get(id).map(|v| v.as_ref())
     }
 
     /// Checks whether an operation exists in global storage.


### PR DESCRIPTION
## Contents

* [x] reduce the number of force-kept final periods to 5 (1min20s)
* [x] in protocol, when retrieving block ops, they were added to `Storage` but not to `stored_operations` so they were not cleaned by `clear_storage` => refactor this to not use `self.storage`, to make better use of Storage instances in general, and move the responsibility of keeping ops temporarily alive during propagation to the op propagation handler instead of the retrievers
* [x] box heavy elements in Storage to avoid huge allocations on HashMap growth
* [x] cap the number of operations kept for propagation
* [x] reduce the endorsement propagation time to 2 periods
* [x] make operation batch announcement more robust
* [x] achieve stable 3GB RAM usage at 4ktxps on testnet

## Checklist

* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [x] if the API has changed, update the API specification
* [ ] after merging in main, merge main to branch testnet24 