### PR TITLE
Refactor/launch loop ctrl

### DIFF
--- a/massa-api/src/lib.rs
+++ b/massa-api/src/lib.rs
@@ -86,7 +86,8 @@ pub struct Private {
     pub execution_controller: Box<dyn ExecutionController>,
     /// API settings
     pub api_settings: APIConfig,
-    /// Condition-variable pair to stop the system
+    /// Mechanism by which to gracefully shut down.
+    /// To be a clone of the same pair provided to the ctrlc handler.
     pub stop_cv: Arc<(Mutex<bool>, Condvar)>,
     /// User wallet
     pub node_wallet: Arc<RwLock<Wallet>>,

--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -106,7 +106,7 @@ impl RpcServer for API<Public> {
 #[doc(hidden)]
 #[async_trait]
 impl MassaRpcServer for API<Public> {
-    async fn stop_node(&self) -> RpcResult<()> {
+    fn stop_node(&self) -> RpcResult<()> {
         crate::wrong_api::<()>()
     }
 

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -11,7 +11,6 @@ use crate::operation_injector::start_operation_injector;
 use crate::settings::SETTINGS;
 
 use crossbeam_channel::TryRecvError;
-// use ctrlc as _;
 use dialoguer::Password;
 use massa_api::{ApiServer, ApiV2, Private, Public, RpcServer, StopHandle, API};
 use massa_api_exports::config::APIConfig;

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -94,11 +94,10 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
-use std::thread::sleep;
 use std::time::Duration;
 use std::{path::Path, process, sync::Arc};
 use structopt::StructOpt;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 use tracing_subscriber::filter::{filter_fn, LevelFilter};
 
@@ -119,7 +118,6 @@ async fn launch(
     Box<dyn PoolManager>,
     Box<dyn ProtocolManager>,
     Box<dyn FactoryManager>,
-    mpsc::Receiver<()>,
     StopHandle,
     StopHandle,
     StopHandle,
@@ -370,7 +368,7 @@ async fn launch(
         *GENESIS_TIMESTAMP,
         *END_TIMESTAMP,
         args.restart_from_snapshot_at_period,
-        sig_int_toggled,
+        sig_int_toggled.clone(),
     ) {
         Ok(vals) => vals,
         Err(BootstrapError::Interupted(msg)) => {
@@ -907,10 +905,11 @@ async fn launch(
     );
 
     // spawn private API
-    let (api_private, api_private_stop_rx) = API::<Private>::new(
+    let api_private = API::<Private>::new(
         protocol_controller.clone(),
         execution_controller.clone(),
         api_config.clone(),
+        sig_int_toggled,
         node_wallet,
     );
     let api_private_handle = api_private
@@ -983,7 +982,6 @@ async fn launch(
         pool_manager,
         protocol_manager,
         factory_manager,
-        api_private_stop_rx,
         api_private_handle,
         api_public_handle,
         api_handle,
@@ -1182,9 +1180,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let sig_int_toggled = Arc::new((Mutex::new(false), Condvar::new()));
 
     let sig_int_toggled_clone = Arc::clone(&sig_int_toggled);
-    let (tx, rx) = crossbeam_channel::bounded(1);
     ctrlc::set_handler(move || {
-        tx.send(()).unwrap();
         *sig_int_toggled_clone
             .0
             .lock()
@@ -1193,11 +1189,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
     })
     .expect("Error setting Ctrl-C handler");
 
-    // // interrupt signal listener
-    // let interrupt_signal_listener = tokio::spawn(async move {
-    //     signal::ctrl_c().await.unwrap();
-    //     tx.send(()).unwrap();
-    // });
     loop {
         let (
             consensus_event_receiver,
@@ -1208,7 +1199,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
             pool_manager,
             protocol_manager,
             factory_manager,
-            mut api_private_stop_rx,
             api_private_handle,
             api_public_handle,
             api_handle,
@@ -1235,29 +1225,18 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 _ => {}
             };
 
-            match api_private_stop_rx.try_recv() {
-                Ok(_) => {
-                    info!("stop command received from private API");
-                    break false;
-                }
-                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
-                    error!("api_private_stop_rx disconnected");
-                    break false;
-                }
-                _ => {}
+            let int_sig = sig_int_toggled
+                .0
+                .lock()
+                .expect("double-lock() on interupted signal mutex");
+            let wake = sig_int_toggled
+                .1
+                .wait_timeout(int_sig, Duration::from_millis(100))
+                .expect("interupt signal mutex poisoned");
+            if *wake.0 {
+                info!("interrupt signal received");
+                break false;
             }
-            match rx.try_recv() {
-                Ok(_) => {
-                    info!("interrupt signal received");
-                    break false;
-                }
-                Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                    error!("interrupt_signal_listener disconnected");
-                    break false;
-                }
-                _ => {}
-            }
-            sleep(Duration::from_millis(100));
         };
         stop(
             consensus_event_receiver,

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -98,7 +98,6 @@ use std::thread::sleep;
 use std::time::Duration;
 use std::{path::Path, process, sync::Arc};
 use structopt::StructOpt;
-use tokio::signal;
 use tokio::sync::{broadcast, mpsc};
 use tracing::{error, info, warn};
 use tracing_subscriber::filter::{filter_fn, LevelFilter};
@@ -1183,6 +1182,7 @@ async fn run(args: Args) -> anyhow::Result<()> {
     let sig_int_toggled = Arc::new((Mutex::new(false), Condvar::new()));
 
     let sig_int_toggled_clone = Arc::clone(&sig_int_toggled);
+    let (tx, rx) = crossbeam_channel::bounded(1);
     ctrlc::set_handler(move || {
         tx.send(()).unwrap();
         *sig_int_toggled_clone
@@ -1194,7 +1194,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
     .expect("Error setting Ctrl-C handler");
 
     // // interrupt signal listener
-    // let (tx, rx) = crossbeam_channel::bounded(1);
     // let interrupt_signal_listener = tokio::spawn(async move {
     //     signal::ctrl_c().await.unwrap();
     //     tx.send(()).unwrap();
@@ -1283,7 +1282,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
         }
         // If we restart because of a desync, then we do not want to restart from a snapshot
         cur_args.restart_from_snapshot_at_period = None;
-        interrupt_signal_listener.abort();
     }
     Ok(())
 }

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -1225,6 +1225,8 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 _ => {}
             };
 
+            // every 100ms/or when alerted, check if sigint toggled
+            // if toggled, break loop
             let int_sig = sig_int_toggled
                 .0
                 .lock()


### PR DESCRIPTION
The launch loop control can lead to a particular bug, where if a resync is performed, there is no ctrl-c handler active. This will cause ctrl-c to be unresponsive during launch  following a resync

This PR does several things.

- Resolves unresponsive launch process following resync.
- Single, one-off ctrl-c handler initialization.
- Uses Condvar: A single `Arc<(Mutex<bool>, Condvar)>`, cloned as appropriate, serve the role of both ends of a signal channel.
- Reduces the use of async code.
- This arc can now be used globally. Where a system want's to be sleep and/or be aware of the system being directed to shutdown, a read/conditional sleep of this Arc is all that's needed.

Should a sigint/shutdown occur during the bootstrap retry-wait, the system will invoke `std::sys::exit(0)` without a graceful shutdown. This is a legacy of bootstraps async days:


```rust
    // bootstrap
    let bootstrap_state = tokio::select! {
        _ = &mut stop_signal => {
            info!("interrupt signal received in bootstrap loop");
            process::exit(0);
        },
        res = get_state(/*...*/) => match res {
            Ok(vals) => vals,
            Err(err) => panic!("critical error detected in the bootstrap process: {}", err)
        }
    };
```
but now, get_state will can detect the interupt directly while waiting for the next retry:

```rust
    let bootstrap_state = match get_state(/*...*/) {
        Ok(vals) => vals,
        Err(BootstrapError::Interupted(msg)) => {
            info!("{}", msg);
            process::exit(0);
        }
        Err(err) => panic!("critical error detected in the bootstrap process: {}", err),
    };
```




* [x] document all added functions
* [x] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification