### PR TITLE
Feature/node resync check flag

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 * [ ] document all added functions
 * [ ] try in sandbox /simulation/labnet
+  * [ ] if part of node-launch, checked using the `resync_check` flag
 * [ ] unit tests on the added/changed features
   * [ ] make tests compile
   * [ ] make tests pass 

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -61,6 +61,8 @@ massa_signature = { path = "../massa-signature", optional = true }
 # for more information on what are the following features used for, see the cargo.toml at workspace level
 [features]
 beta = []
+# 10s after initiating the first launch, will re-launch as if the node was signalled with `NeedsResync`
+resync_check = []
 deadlock_detection = []
 op_spammer = ["rand", "massa_signature"]
 bootstrap_server = ["massa_consensus_worker/bootstrap_server"]

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -1195,6 +1195,9 @@ async fn run(args: Args) -> anyhow::Result<()> {
     // })
     // .expect("Error setting Ctrl-C handler");
 
+    #[cfg(feature = "resync_check")]
+    let mut resync_check = Some(std::time::Instant::now() + std::time::Duration::from_secs(10));
+
     loop {
         let (
             consensus_event_receiver,
@@ -1261,6 +1264,15 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 }
                 _ => {}
             }
+            #[cfg(feature = "resync_check")]
+            if let Some(resync_moment) = resync_check {
+                if resync_moment < std::time::Instant::now() {
+                    warn!("resync check triggered");
+                    resync_check = None;
+                    break true;
+                }
+            }
+
             sleep(Duration::from_millis(100));
         };
         stop(

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -1259,6 +1259,10 @@ async fn run(args: Args) -> anyhow::Result<()> {
                 info!("interrupt signal received");
                 break false;
             }
+
+            // Elements of the system that involve stopping and restarting should be checked by forcing a relaunch.
+            // This check allows the system to start up as normal, wait 10s, then force a relaunch. If Things take too long
+            // to shutdown, or does not allow for a clean relaunch, this feature flag can expose those issues.
             #[cfg(feature = "resync_check")]
             if let Some(resync_moment) = resync_check {
                 if resync_moment < std::time::Instant::now() {

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -4,7 +4,6 @@
 #![warn(missing_docs)]
 #![warn(unused_crate_dependencies)]
 #![feature(ip)]
-use std::thread::sleep;
 extern crate massa_logging;
 
 #[cfg(feature = "op_spammer")]

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -93,7 +93,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Condvar, Mutex};
-use std::thread::sleep;
 use std::time::Duration;
 use std::{path::Path, process, sync::Arc};
 use structopt::StructOpt;
@@ -1268,8 +1267,6 @@ async fn run(args: Args) -> anyhow::Result<()> {
                     break true;
                 }
             }
-
-            sleep(Duration::from_millis(100));
         };
         stop(
             consensus_event_receiver,


### PR DESCRIPTION
Adds a feature flag that forces a "resync" of a node after a short wait. Follow-up to #4148 

* [ ] document all added functions
* [x] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [x] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification