### PR TITLE
Feature gate db backups

### DIFF
--- a/massa-final-state/Cargo.toml
+++ b/massa-final-state/Cargo.toml
@@ -44,3 +44,4 @@ testing = [
     "massa_pos_exports/testing",
 ]
 sandbox = ["massa_async_pool/sandbox"]
+bootstrap_server = []

--- a/massa-final-state/src/final_state.rs
+++ b/massa-final-state/src/final_state.rs
@@ -16,11 +16,13 @@ use massa_db_exports::{
 use massa_executed_ops::ExecutedDenunciations;
 use massa_executed_ops::ExecutedOps;
 use massa_ledger_exports::LedgerController;
-use massa_models::config::PERIODS_BETWEEN_BACKUPS;
 use massa_models::slot::Slot;
 use massa_pos_exports::{PoSFinalState, SelectorController};
 use massa_versioning::versioning::MipStore;
 use tracing::{debug, info, warn};
+
+#[cfg(feature = "bootstrap_server")]
+use massa_models::config::PERIODS_BETWEEN_BACKUPS;
 
 /// Represents a final state `(ledger, async pool, executed_ops, executed_de and the state of the PoS)`
 pub struct FinalState {
@@ -574,6 +576,7 @@ impl FinalState {
         info!("final_state hash at slot {}: {}", slot, final_state_hash);
 
         // Backup DB if needed
+        #[cfg(feature = "bootstrap_server")]
         if slot.period % PERIODS_BETWEEN_BACKUPS == 0 && slot.period != 0 && slot.thread == 0 {
             let state_slot = self.db.read().get_change_id();
             match state_slot {

--- a/massa-node/Cargo.toml
+++ b/massa-node/Cargo.toml
@@ -63,6 +63,6 @@ massa_signature = { path = "../massa-signature", optional = true }
 beta = []
 deadlock_detection = []
 op_spammer = ["rand", "massa_signature"]
-bootstrap_server = ["massa_consensus_worker/bootstrap_server"]
+bootstrap_server = ["massa_consensus_worker/bootstrap_server", "massa_final_state/bootstrap_server"]
 sandbox = ["massa_bootstrap/sandbox", "massa_consensus_worker/sandbox", "massa_execution_worker/sandbox", "massa_final_state/sandbox", "massa_models/sandbox"]
 testing = ["massa_metrics/testing"]


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Backups are only useful for nodes that would want to restart the network from a snapshot.
As it can duplicate data, it's better to feature-gate it with the bootstrap_server feature.