### PR TITLE
Use new version of PeerNet with the `stream_limiter` set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3713,7 +3713,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "peernet"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/PeerNet?branch=use_stream_limiter#b7f43a4a8fdfedbfd04de82cc16635bd7d8dbfc0"
+source = "git+https://github.com/massalabs/PeerNet?rev=7b2a1a9#7b2a1a93e993df61b8b1288c2847be2d6488e805"
 dependencies = [
  "crossbeam",
  "enum_delegate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
  "serde_json",
  "serial_test 2.0.0",
  "socket2",
- "stream_limiter 3.2.0",
+ "stream_limiter",
  "substruct",
  "tempfile",
  "thiserror",
@@ -3723,7 +3723,7 @@ dependencies = [
  "quiche",
  "rand 0.8.5",
  "serde",
- "stream_limiter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream_limiter",
  "thiserror",
 ]
 
@@ -4906,10 +4906,6 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
-
-[[package]]
-name = "stream_limiter"
-version = "3.2.0"
 
 [[package]]
 name = "stream_limiter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
  "serde_json",
  "serial_test 2.0.0",
  "socket2",
- "stream_limiter 3.0.1",
+ "stream_limiter",
  "substruct",
  "tempfile",
  "thiserror",
@@ -3713,16 +3713,17 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 [[package]]
 name = "peernet"
 version = "0.1.0"
-source = "git+https://github.com/massalabs/PeerNet?rev=4929687ed69946482cc3bffddf2162fbe02f734f#4929687ed69946482cc3bffddf2162fbe02f734f"
+source = "git+https://github.com/massalabs/PeerNet?branch=use_stream_limiter#b7f43a4a8fdfedbfd04de82cc16635bd7d8dbfc0"
 dependencies = [
  "crossbeam",
  "enum_delegate",
+ "log",
  "mio",
  "parking_lot",
  "quiche",
  "rand 0.8.5",
  "serde",
- "stream_limiter 2.0.0",
+ "stream_limiter",
  "thiserror",
 ]
 
@@ -4908,15 +4909,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "stream_limiter"
-version = "2.0.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b85d49eee44700a8dc9a3e2d316e8e1f7d661d3eccd606ad9d02e9969e04bc"
-
-[[package]]
-name = "stream_limiter"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69948d952569e5ba3c6a3ab4a373cb53a13b7d505a17344380acdf98d9846dab"
+checksum = "89acdb288f530d175bbeb1344aab11cfa0e0ee5b4e63d75c204001568dcf90cf"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2586,7 +2586,7 @@ dependencies = [
  "serde_json",
  "serial_test 2.0.0",
  "socket2",
- "stream_limiter",
+ "stream_limiter 3.2.0",
  "substruct",
  "tempfile",
  "thiserror",
@@ -3723,7 +3723,7 @@ dependencies = [
  "quiche",
  "rand 0.8.5",
  "serde",
- "stream_limiter",
+ "stream_limiter 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -4906,6 +4906,10 @@ name = "str-buf"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
+
+[[package]]
+name = "stream_limiter"
+version = "3.2.0"
 
 [[package]]
 name = "stream_limiter"

--- a/massa-bootstrap/Cargo.toml
+++ b/massa-bootstrap/Cargo.toml
@@ -21,7 +21,7 @@ substruct = { git = "https://github.com/sydhds/substruct" }
 socket2 = "0.4.7"
 crossbeam = "0.8.2"
 mio =  { version = "0.8", features = ["net", "os-poll"] }
-stream_limiter = "3.0.1"
+stream_limiter = "3.2.0"
 
 # custom modules
 massa_consensus_exports = { path = "../massa-consensus-exports" }

--- a/massa-bootstrap/src/bindings/client.rs
+++ b/massa-bootstrap/src/bindings/client.rs
@@ -49,9 +49,8 @@ impl BootstrapClientBinder {
         cfg: BootstrapClientConfig,
         limit: Option<u64>,
     ) -> Self {
-        let limit_opts = limit.map(|limit| {
-            LimiterOptions::new(limit, Duration::from_millis(1000), limit)
-        });
+        let limit_opts =
+            limit.map(|limit| LimiterOptions::new(limit, Duration::from_millis(1000), limit));
         let duplex = Limiter::new(duplex, limit_opts.clone(), limit_opts);
         BootstrapClientBinder {
             remote_pubkey,

--- a/massa-bootstrap/src/bindings/client.rs
+++ b/massa-bootstrap/src/bindings/client.rs
@@ -216,6 +216,9 @@ impl BootstrapClientBinder {
 
 impl crate::bindings::BindingReadExact for BootstrapClientBinder {
     fn set_read_timeout(&mut self, duration: Option<Duration>) -> Result<(), std::io::Error> {
+        if let Some(ref mut opts) = self.duplex.read_opt {
+            opts.timeout = duration;
+        }
         self.duplex.stream.set_read_timeout(duration)
     }
 }
@@ -228,6 +231,9 @@ impl std::io::Read for BootstrapClientBinder {
 
 impl crate::bindings::BindingWriteExact for BootstrapClientBinder {
     fn set_write_timeout(&mut self, duration: Option<Duration>) -> Result<(), std::io::Error> {
+        if let Some(ref mut opts) = self.duplex.write_opt {
+            opts.timeout = duration;
+        }
         self.duplex.stream.set_write_timeout(duration)
     }
 }

--- a/massa-bootstrap/src/bindings/client.rs
+++ b/massa-bootstrap/src/bindings/client.rs
@@ -50,7 +50,7 @@ impl BootstrapClientBinder {
         limit: Option<u64>,
     ) -> Self {
         let limit_opts = limit.map(|limit| {
-            LimiterOptions::new(limit, Duration::from_millis(1000), limit.saturating_mul(2))
+            LimiterOptions::new(limit, Duration::from_millis(1000), limit)
         });
         let duplex = Limiter::new(duplex, limit_opts.clone(), limit_opts);
         BootstrapClientBinder {

--- a/massa-bootstrap/src/bindings/server.rs
+++ b/massa-bootstrap/src/bindings/server.rs
@@ -74,7 +74,7 @@ impl BootstrapServerBinder {
         } = cfg;
 
         let limit_opts = rw_limit.map(|limit| -> LimiterOptions {
-            LimiterOptions::new(limit, Duration::from_millis(1000), limit.saturating_mul(2))
+            LimiterOptions::new(limit, Duration::from_millis(1000), limit)
         });
         let duplex = Limiter::new(duplex, limit_opts.clone(), limit_opts);
         BootstrapServerBinder {

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -705,6 +705,7 @@ fn test_bandwidth() {
 
                 server.handshake_timeout(version, None).unwrap();
 
+                std::thread::sleep(Duration::from_secs(1));
                 let before = Instant::now();
                 let message = server.next_timeout(None).unwrap();
                 match message {
@@ -714,9 +715,10 @@ fn test_bandwidth() {
                     _ => panic!("Bad message receive: Expected a peers list message"),
                 }
                 let dur = before.elapsed();
-                assert!(dur > Duration::from_secs(10));
+                assert!(dur > Duration::from_secs(9));
                 assert!(dur < Duration::from_millis(millis_limit));
 
+                std::thread::sleep(Duration::from_secs(1));
                 let before = Instant::now();
                 server
                     .send_timeout(
@@ -725,7 +727,7 @@ fn test_bandwidth() {
                     )
                     .unwrap();
                 let dur = before.elapsed();
-                assert!(dur > Duration::from_secs(10));
+                assert!(dur > Duration::from_secs(9), "{dur:?}");
                 assert!(dur < Duration::from_millis(millis_limit));
             }
         })
@@ -739,6 +741,7 @@ fn test_bandwidth() {
 
                 client.handshake(version).unwrap();
 
+                std::thread::sleep(Duration::from_secs(1));
                 let before = Instant::now();
                 client
                     .send_timeout(
@@ -749,9 +752,10 @@ fn test_bandwidth() {
                     )
                     .unwrap();
                 let dur = before.elapsed();
-                assert!(dbg!(dur) > Duration::from_secs(10));
+                assert!(dbg!(dur) > Duration::from_secs(9), "{dur:?}");
                 assert!(dur < Duration::from_millis(millis_limit));
 
+                std::thread::sleep(Duration::from_secs(1));
                 let before = Instant::now();
                 let message = client.next_timeout(None).unwrap();
                 match message {
@@ -761,7 +765,7 @@ fn test_bandwidth() {
                     _ => panic!("Bad message receive: Expected a peers list message"),
                 }
                 let dur = before.elapsed();
-                assert!(dur > Duration::from_secs(10));
+                assert!(dur > Duration::from_secs(9));
                 assert!(dur < Duration::from_millis(millis_limit));
             }
         })

--- a/massa-node/src/operation_injector.rs
+++ b/massa-node/src/operation_injector.rs
@@ -83,6 +83,7 @@ pub fn start_operation_injector(
         use rand::Rng;
         let mut rng = rand::thread_rng();
         loop {
+            let now = std::time::Instant::now();
             let mut storage = storage.clone_without_refs();
             let txps = nb_op / 32;
             let final_slot = get_closest_slot_to_timestamp(
@@ -113,7 +114,7 @@ pub fn start_operation_injector(
             protocol_controller
                 .propagate_operations(storage.clone())
                 .unwrap();
-            std::thread::sleep(Duration::from_secs(1));
+            std::thread::sleep(Duration::from_secs(1).saturating_sub(now.elapsed()));
         }
     });
 }

--- a/massa-node/src/operation_injector.rs
+++ b/massa-node/src/operation_injector.rs
@@ -83,7 +83,6 @@ pub fn start_operation_injector(
         use rand::Rng;
         let mut rng = rand::thread_rng();
         loop {
-            let now = std::time::Instant::now();
             let mut storage = storage.clone_without_refs();
             let txps = nb_op / 32;
             let final_slot = get_closest_slot_to_timestamp(
@@ -114,7 +113,7 @@ pub fn start_operation_injector(
             protocol_controller
                 .propagate_operations(storage.clone())
                 .unwrap();
-            std::thread::sleep(Duration::from_secs(1).saturating_sub(now.elapsed()));
+            std::thread::sleep(Duration::from_secs(1));
         }
     });
 }

--- a/massa-protocol-exports/Cargo.toml
+++ b/massa-protocol-exports/Cargo.toml
@@ -11,7 +11,7 @@ nom = "=7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # TODO tag peernet version
-peernet = { git = "https://github.com/massalabs/PeerNet", rev = "4929687ed69946482cc3bffddf2162fbe02f734f" }
+peernet = { git = "https://github.com/massalabs/PeerNet", branch = "use_stream_limiter" } #rev = "bf8adf5" }
 tempfile = { version = "3.3", optional = true } # use with testing feature
 mockall = "0.11.4"
 

--- a/massa-protocol-exports/Cargo.toml
+++ b/massa-protocol-exports/Cargo.toml
@@ -11,7 +11,7 @@ nom = "=7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # TODO tag peernet version
-peernet = { git = "https://github.com/massalabs/PeerNet", branch = "use_stream_limiter" } #rev = "bf8adf5" }
+peernet = { git = "https://github.com/massalabs/PeerNet", rev = "7b2a1a9" }
 tempfile = { version = "3.3", optional = true } # use with testing feature
 mockall = "0.11.4"
 

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 nom = "=7.1"
 num_enum = "0.5"
 # TODO tag peernet version
-peernet = { git = "https://github.com/massalabs/PeerNet", rev = "4929687ed69946482cc3bffddf2162fbe02f734f" }
+peernet = { git = "https://github.com/massalabs/PeerNet", branch = "use_stream_limiter" } #rev = "bf8adf5" }
 tempfile = { version = "3.3", optional = true } # use with testing feature
 rayon = "1.7.0"
 schnellru = "0.2.1"

--- a/massa-protocol-worker/Cargo.toml
+++ b/massa-protocol-worker/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1.0"
 nom = "=7.1"
 num_enum = "0.5"
 # TODO tag peernet version
-peernet = { git = "https://github.com/massalabs/PeerNet", branch = "use_stream_limiter" } #rev = "bf8adf5" }
+peernet = { git = "https://github.com/massalabs/PeerNet", rev = "7b2a1a9" }
 tempfile = { version = "3.3", optional = true } # use with testing feature
 rayon = "1.7.0"
 schnellru = "0.2.1"

--- a/massa-protocol-worker/src/worker.rs
+++ b/massa-protocol-worker/src/worker.rs
@@ -296,6 +296,7 @@ pub fn start_protocol_controller(
                     PeerNetCategoryInfo {
                         max_in_connections: infos.max_in_connections,
                         max_in_connections_per_ip: infos.max_in_connections_per_ip,
+                        max_out_connections: infos.target_out_connections,
                     },
                 ),
             )
@@ -305,6 +306,7 @@ pub fn start_protocol_controller(
     peernet_config.default_category_info = PeerNetCategoryInfo {
         max_in_connections: config.default_category_info.max_in_connections,
         max_in_connections_per_ip: config.default_category_info.max_in_connections_per_ip,
+        max_out_connections: config.default_category_info.target_out_connections,
     };
     peernet_config.max_in_connections = config.max_in_connections;
 


### PR DESCRIPTION
Uses the changes from https://github.com/massalabs/PeerNet/pull/55 inside the `massa_protocol_{worker,exports}`

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification
