### PR TITLE
Add a timeout on the tester's `read` and `write` operations

### DIFF
--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -162,6 +162,8 @@
     read_write_limit_bytes_per_second = 2_000_000_000
     # timeout after which without answer a hanshake is ended
     message_timeout = 5000
+    # timeout after which a peer tester will consider the peer unreachable
+    tester_timeout = 500
     # timeout after whick we consider a node does not have the block we asked for
     ask_block_timeout = 10000
     # max cache size for which blocks our node knows about

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -621,6 +621,7 @@ async fn launch(
         max_in_connections: SETTINGS.protocol.max_in_connections,
         timeout_connection: SETTINGS.protocol.timeout_connection,
         message_timeout: SETTINGS.protocol.message_timeout,
+        tester_timeout: SETTINGS.protocol.tester_timeout,
         routable_ip: SETTINGS
             .protocol
             .routable_ip

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -249,6 +249,8 @@ pub struct ProtocolSettings {
     pub timeout_connection: MassaTime,
     /// Message timeout
     pub message_timeout: MassaTime,
+    /// Timeout for the tester operations
+    pub tester_timeout: MassaTime,
     /// Nb in connections
     pub max_in_connections: usize,
     /// Peers limits per category

--- a/massa-node/src/tests/config.toml
+++ b/massa-node/src/tests/config.toml
@@ -25,6 +25,7 @@
 
 [protocol]
     message_timeout = 5000
+    tester_timeout = 500
     ask_block_timeout = 10000
     max_known_blocks_size = 1024
     max_node_known_blocks_size = 1024

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -152,6 +152,8 @@ pub struct ProtocolConfig {
     pub timeout_connection: MassaTime,
     /// Timeout message
     pub message_timeout: MassaTime,
+    /// Timeout for the tester operations
+    pub tester_timeout: MassaTime,
     /// Number of bytes per second that can be read/write in a connection (should be a 10 multiplier)
     pub read_write_limit_bytes_per_second: u128,
     /// Optional routable ip

--- a/massa-protocol-exports/src/test_exports/config.rs
+++ b/massa-protocol-exports/src/test_exports/config.rs
@@ -73,6 +73,7 @@ impl Default for ProtocolConfig {
             max_size_listeners_per_peer: 100,
             max_size_peers_announcement: 100,
             message_timeout: MassaTime::from_millis(10000),
+            tester_timeout: MassaTime::from_millis(500),
             last_start_period: 0,
             read_write_limit_bytes_per_second: 1024 * 1000,
             timeout_connection: MassaTime::from_millis(1000),


### PR DESCRIPTION
When `SIGINT`ing the node, the testers can get blocked during their testing process, and this is why they are too slow to exit their thread, and quitting the node.

Adding the timeout allows to cut short these operations