### PR TITLE
Fixup erratic tester behavior

### DIFF
--- a/massa-protocol-worker/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/models.rs
@@ -6,6 +6,7 @@ use peernet::transports::TransportType;
 use rand::seq::SliceRandom;
 use rand::{thread_rng, Rng};
 use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::time::Duration;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tracing::log::info;
@@ -208,15 +209,23 @@ impl PeerDB {
     }
 
     /// Retrieve the peer with the oldest test date.
-    pub fn get_oldest_peer(&self, cooldown: Duration) -> Option<SocketAddr> {
+    pub fn get_oldest_peer(
+        &self,
+        cooldown: Duration,
+        in_test: &HashSet<SocketAddr>,
+    ) -> Option<SocketAddr> {
         match self
             .tested_addresses
             .iter()
             .min_by_key(|(_, timestamp)| *(*timestamp))
         {
             Some((addr, timestamp)) => {
-                if timestamp.estimate_instant().ok()?.elapsed() > cooldown {
-                    Some(*addr)
+                if !in_test.contains(addr) {
+                    if timestamp.estimate_instant().ok()?.elapsed() > cooldown {
+                        Some(*addr)
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }

--- a/massa-protocol-worker/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/tester.rs
@@ -428,11 +428,21 @@ impl Tester {
                     default(Duration::from_secs(2)) => {
                         // If no message in 2 seconds they will test a peer that hasn't been tested for long time
 
-                        let Some(listener) = db.read().get_oldest_peer(protocol_config.test_oldest_peer_cooldown.into()) else {
-                            continue;
+                        let listener = {
+                            let mut peers_in_test = peers_in_test.write();
+
+                            let res = db.read().get_oldest_peer(
+                                protocol_config.test_oldest_peer_cooldown.into(),
+                                &peers_in_test,
+                            );
+                            if let Some(listener) = res {
+                                peers_in_test.insert(listener);
+                                listener
+                            } else {
+                                continue;
+                            }
                         };
 
-                        peers_in_test.write().insert(listener);
                         {
                             let mut db = db.write();
                             db.tested_addresses.insert(listener, MassaTime::now().unwrap());

--- a/massa-protocol-worker/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/tester.rs
@@ -452,6 +452,7 @@ impl Tester {
                         // we try to connect to all peer listener (For now we have only one listener)
                         let ip_canonical = listener.ip().to_canonical();
                         if active_connections.get_peers_connected().iter().any(|(_, (addr, _, _))| addr.ip().to_canonical() == ip_canonical) {
+                            peers_in_test.write().remove(&listener);
                             continue;
                         }
                         //Don't test our local addresses


### PR DESCRIPTION
Close #4323 

Filter out oldest peers if they are currently tested by another tester thread

Should close the issue, running tests to confirm