### PR TITLE
Remove not necessary clone in consensus

### DIFF
--- a/massa-consensus-worker/src/controller.rs
+++ b/massa-consensus-worker/src/controller.rs
@@ -1,10 +1,10 @@
 use massa_channel::sender::MassaSender;
+use massa_consensus_exports::ConsensusBroadcasts;
 use massa_consensus_exports::{
     block_graph_export::BlockGraphExport, block_status::BlockStatus,
     bootstrapable_graph::BootstrapableGraph, error::ConsensusError,
-    export_active_block::ExportActiveBlock, ConsensusChannels, ConsensusController,
+    export_active_block::ExportActiveBlock, ConsensusController,
 };
-use massa_models::denunciation::DenunciationPrecursor;
 use massa_models::{
     block::{BlockGraphStatus, FilledBlock},
     block_header::BlockHeader,
@@ -34,7 +34,7 @@ use crate::{commands::ConsensusCommand, state::ConsensusState};
 #[derive(Clone)]
 pub struct ConsensusControllerImpl {
     command_sender: MassaSender<ConsensusCommand>,
-    channels: ConsensusChannels,
+    broadcasts: ConsensusBroadcasts,
     shared_state: Arc<RwLock<ConsensusState>>,
     bootstrap_part_size: u64,
     broadcast_enabled: bool,
@@ -43,14 +43,14 @@ pub struct ConsensusControllerImpl {
 impl ConsensusControllerImpl {
     pub fn new(
         command_sender: MassaSender<ConsensusCommand>,
-        channels: ConsensusChannels,
+        broadcasts: ConsensusBroadcasts,
         shared_state: Arc<RwLock<ConsensusState>>,
         bootstrap_part_size: u64,
         broadcast_enabled: bool,
     ) -> Self {
         Self {
             command_sender,
-            channels,
+            broadcasts,
             shared_state,
             bootstrap_part_size,
             broadcast_enabled,
@@ -248,12 +248,7 @@ impl ConsensusController for ConsensusControllerImpl {
                         })
                         .collect();
 
-                if let Err(err) = self
-                    .channels
-                    .broadcasts
-                    .block_sender
-                    .send(verifiable_block.clone())
-                {
+                if let Err(err) = self.broadcasts.block_sender.send(verifiable_block.clone()) {
                     trace!(
                         "error, failed to broadcast block with id {} due to: {}",
                         block_id,
@@ -261,15 +256,10 @@ impl ConsensusController for ConsensusControllerImpl {
                     );
                 }
 
-                if let Err(err) = self
-                    .channels
-                    .broadcasts
-                    .filled_block_sender
-                    .send(FilledBlock {
-                        header: verifiable_block.content.header.clone(),
-                        operations,
-                    })
-                {
+                if let Err(err) = self.broadcasts.filled_block_sender.send(FilledBlock {
+                    header: verifiable_block.content.header.clone(),
+                    operations,
+                }) {
                     trace!(
                         "error, failed to broadcast filled block with id {} due to: {}",
                         block_id,
@@ -282,13 +272,6 @@ impl ConsensusController for ConsensusControllerImpl {
                     block_id
                 );
             };
-        }
-
-        if let Some(verifiable_block) = block_storage.read_blocks().get(&block_id) {
-            let de_p = DenunciationPrecursor::from(&verifiable_block.content.header);
-            self.channels
-                .pool_controller
-                .add_denunciation_precursor(de_p);
         }
 
         if let Err(err) = self
@@ -306,12 +289,7 @@ impl ConsensusController for ConsensusControllerImpl {
 
     fn register_block_header(&self, block_id: BlockId, header: SecureShare<BlockHeader, BlockId>) {
         if self.broadcast_enabled {
-            if let Err(err) = self
-                .channels
-                .broadcasts
-                .block_header_sender
-                .send(header.clone())
-            {
+            if let Err(err) = self.broadcasts.block_header_sender.send(header.clone()) {
                 trace!(
                     "error, failed to broadcast block header with block id {}: {}",
                     block_id,
@@ -319,11 +297,6 @@ impl ConsensusController for ConsensusControllerImpl {
                 );
             }
         }
-
-        let de_p = DenunciationPrecursor::from(&header);
-        self.channels
-            .pool_controller
-            .add_denunciation_precursor(de_p);
 
         if let Err(err) = self
             .command_sender

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -48,15 +48,10 @@ fn test_unsorted_block() {
         .expect_update_blockclique_status()
         .return_once(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    let mut pool_controller_2 = Box::new(MockPoolController::new());
     //TODO: Improve checks here
-    pool_controller_2
+    pool_controller
         .expect_notify_final_cs_periods()
         .returning(|_| {});
-    //TODO: To be deleted when channels will be well used instead of clones
-    pool_controller
-        .expect_clone_box()
-        .return_once(move || pool_controller_2);
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -164,13 +159,9 @@ fn test_parallel_incompatibility() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});

--- a/massa-consensus-worker/src/tests/three_four_threads_scenarios.rs
+++ b/massa-consensus-worker/src/tests/three_four_threads_scenarios.rs
@@ -35,13 +35,9 @@ fn test_fts_latest_blocks_as_parents() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -248,13 +244,9 @@ fn test_fts_multiple_max_cliques_1() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -580,13 +572,9 @@ fn test_fts_multiple_max_cliques_2() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});

--- a/massa-consensus-worker/src/tests/tools.rs
+++ b/massa-consensus-worker/src/tests/tools.rs
@@ -24,48 +24,26 @@ use massa_storage::Storage;
 
 pub fn consensus_test<F>(
     cfg: ConsensusConfig,
-    defined_execution_controller: Box<MockExecutionController>,
+    execution_controller: Box<MockExecutionController>,
     pool_controller: Box<MockPoolController>,
-    defined_selector_controller: Box<MockSelectorController>,
+    selector_controller: Box<MockSelectorController>,
     test: F,
 ) where
     F: FnOnce(Box<dyn ConsensusController>),
 {
     let storage: Storage = Storage::create_root();
-    // mock protocol & pool
+    // mock protocol
     let mut protocol_controller = Box::new(MockProtocolController::new());
-    let mut protocol_controller_2 = MockProtocolController::default();
-    let mut protocol_controller_3 = MockProtocolController::default();
     //TODO: Test better here for example number of times
-    protocol_controller_3
+    protocol_controller
         .expect_integrated_block()
         .returning(|_, _| Ok(()));
-    protocol_controller_2
-        .expect_integrated_block()
-        .returning(|_, _| Ok(()));
-    protocol_controller_2
+    protocol_controller
         .expect_send_wishlist_delta()
         .returning(|_, _| Ok(()));
-    protocol_controller_2
-        .expect_notify_block_attack()
-        .returning(|_| Ok(()));
-    protocol_controller_3
-        .expect_notify_block_attack()
-        .returning(|_| Ok(()));
-    protocol_controller_2
-        .expect_clone_box()
-        .return_once(move || Box::new(protocol_controller_3));
     protocol_controller
-        .expect_clone_box()
-        .return_once(move || Box::new(protocol_controller_2));
-    let mut execution_controller = Box::new(MockExecutionController::new());
-    execution_controller
-        .expect_clone_box()
-        .return_once(move || defined_execution_controller);
-    let mut selector_controller = Box::new(MockSelectorController::new());
-    selector_controller
-        .expect_clone_box()
-        .return_once(move || defined_selector_controller);
+        .expect_notify_block_attack()
+        .returning(|_| Ok(()));
     // launch consensus controller
     let (consensus_event_sender, _) = MassaChannel::new(String::from("consensus_event"), Some(10));
 

--- a/massa-consensus-worker/src/tests/two_threads_scenarios.rs
+++ b/massa-consensus-worker/src/tests/two_threads_scenarios.rs
@@ -35,13 +35,9 @@ fn test_tts_latest_blocks_as_parents() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -221,13 +217,9 @@ fn test_tts_latest_period_blocks_as_parents() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -388,13 +380,9 @@ fn test_tts_mixed_blocks_as_parents() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -579,13 +567,9 @@ fn test_tts_p2_depends_on_p0_1() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -735,13 +719,9 @@ fn test_tts_p2_depends_on_p0_2() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -877,13 +857,9 @@ fn test_tts_p3_depends_on_p0() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -984,13 +960,9 @@ fn test_tts_multiple_blocks_depend_on_p0_no_incomp() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -1173,13 +1145,9 @@ fn test_tts_multiple_blocks_depend_on_p0_parallel_incomp() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -1303,13 +1271,9 @@ fn test_tts_parent_registered_later() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});
@@ -1449,13 +1413,9 @@ fn test_tts_incompatible_parents() {
         .expect_update_blockclique_status()
         .returning(|_, _, _| {});
     let mut pool_controller = Box::new(MockPoolController::new());
-    pool_controller.expect_clone_box().returning(move || {
-        let mut pool_controller = Box::new(MockPoolController::new());
-        pool_controller
-            .expect_notify_final_cs_periods()
-            .returning(|_| {});
-        pool_controller
-    });
+    pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
     pool_controller
         .expect_add_denunciation_precursor()
         .returning(|_| {});

--- a/massa-consensus-worker/src/worker/mod.rs
+++ b/massa-consensus-worker/src/worker/mod.rs
@@ -63,10 +63,11 @@ pub fn start_consensus_worker(
     let bootstrap_part_size = config.bootstrap_part_size;
     let stats_desync_detection_timespan =
         config.t0.checked_mul(config.periods_per_cycle * 2).unwrap();
+    let broadcasts = channels.broadcasts.clone();
     let shared_state = Arc::new(RwLock::new(ConsensusState {
         storage: storage.clone(),
         config: config.clone(),
-        channels: channels.clone(),
+        channels,
         max_cliques: vec![Clique {
             block_ids: PreHashSet::<BlockId>::default(),
             fitness: 0,
@@ -113,7 +114,7 @@ pub fn start_consensus_worker(
 
     let controller = ConsensusControllerImpl::new(
         tx,
-        channels,
+        broadcasts,
         shared_state,
         bootstrap_part_size,
         config.broadcast_enabled,


### PR DESCRIPTION
The communications with channels should only be done in the worker. The controller should only gather data from the state. By removing the communications with channels in the controller to place them to the worker we avoid making a clone of all the channels.