### PR TITLE
Remove some dependencies in massa-api-exports so massa-sdk have only …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2623,12 +2623,9 @@ version = "0.26.1"
 dependencies = [
  "displaydoc",
  "jsonrpsee",
- "massa_consensus_exports",
- "massa_execution_exports",
  "massa_final_state",
  "massa_hash",
  "massa_models",
- "massa_protocol_exports",
  "massa_signature",
  "massa_time",
  "massa_versioning",

--- a/massa-api-exports/Cargo.toml
+++ b/massa-api-exports/Cargo.toml
@@ -19,10 +19,10 @@ massa_signature = {workspace = true}
 massa_time = {workspace = true}
 massa_models = {workspace = true}
 massa_final_state = {workspace = true}
-massa_consensus_exports = {workspace = true}
+# massa_consensus_exports = {workspace = true}
 massa_hash = {workspace = true}
-massa_protocol_exports = {workspace = true}
-massa_execution_exports = {workspace = true}
+# massa_protocol_exports = {workspace = true}
+# massa_execution_exports = {workspace = true}
 massa_wallet = {workspace = true}
 massa_versioning = {workspace = true}
 

--- a/massa-api-exports/Cargo.toml
+++ b/massa-api-exports/Cargo.toml
@@ -19,10 +19,7 @@ massa_signature = {workspace = true}
 massa_time = {workspace = true}
 massa_models = {workspace = true}
 massa_final_state = {workspace = true}
-# massa_consensus_exports = {workspace = true}
 massa_hash = {workspace = true}
-# massa_protocol_exports = {workspace = true}
-# massa_execution_exports = {workspace = true}
 massa_wallet = {workspace = true}
 massa_versioning = {workspace = true}
 

--- a/massa-api-exports/src/error.rs
+++ b/massa-api-exports/src/error.rs
@@ -3,11 +3,11 @@
 use displaydoc::Display;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 
-use massa_consensus_exports::error::ConsensusError;
-use massa_execution_exports::ExecutionError;
+// use massa_consensus_exports::error::ConsensusError;
+// use massa_execution_exports::ExecutionError;
 use massa_hash::MassaHashError;
 use massa_models::error::ModelsError;
-use massa_protocol_exports::ProtocolError;
+// use massa_protocol_exports::ProtocolError;
 use massa_time::TimeError;
 use massa_versioning::versioning_factory::FactoryError;
 use massa_wallet::WalletError;
@@ -23,11 +23,11 @@ pub enum ApiError {
     /// `massa_hash` error: {0}
     MassaHashError(#[from] MassaHashError),
     /// consensus error: {0}
-    ConsensusError(#[from] ConsensusError),
+    ConsensusError(String),
     /// execution error: {0}
-    ExecutionError(#[from] ExecutionError),
+    ExecutionError(String),
     /// Protocol error: {0}
-    ProtocolError(#[from] ProtocolError),
+    ProtocolError(String),
     /// Models error: {0}
     ModelsError(#[from] ModelsError),
     /// Time error: {0}
@@ -48,7 +48,7 @@ pub enum ApiError {
     BadRequest(String),
     /// Internal server error: {0}
     InternalServerError(String),
-    /// Factory error: {0}
+    /// Versioning Factory error: {0}
     FactoryError(#[from] FactoryError),
 }
 

--- a/massa-api-exports/src/error.rs
+++ b/massa-api-exports/src/error.rs
@@ -3,11 +3,8 @@
 use displaydoc::Display;
 use jsonrpsee::types::{ErrorObject, ErrorObjectOwned};
 
-// use massa_consensus_exports::error::ConsensusError;
-// use massa_execution_exports::ExecutionError;
 use massa_hash::MassaHashError;
 use massa_models::error::ModelsError;
-// use massa_protocol_exports::ProtocolError;
 use massa_time::TimeError;
 use massa_versioning::versioning_factory::FactoryError;
 use massa_wallet::WalletError;

--- a/massa-api/src/private.rs
+++ b/massa-api/src/private.rs
@@ -168,7 +168,7 @@ impl MassaRpcServer for API<Private> {
             .collect();
         protocol_controller
             .ban_peers(peer_ids)
-            .map_err(|e| ApiError::ProtocolError(e).into())
+            .map_err(|e| ApiError::ProtocolError(e.to_string()).into())
     }
 
     async fn node_unban_by_id(&self, ids: Vec<NodeId>) -> RpcResult<()> {
@@ -180,7 +180,7 @@ impl MassaRpcServer for API<Private> {
             .collect();
         protocol_controller
             .unban_peers(peer_ids)
-            .map_err(|e| ApiError::ProtocolError(e).into())
+            .map_err(|e| ApiError::ProtocolError(e.to_string()).into())
     }
 
     async fn node_unban_by_ip(&self, _ips: Vec<IpAddr>) -> RpcResult<()> {

--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -362,12 +362,12 @@ impl MassaRpcServer for API<Public> {
         let consensus_stats_result = self.0.consensus_controller.get_stats();
         let consensus_stats = match consensus_stats_result {
             Ok(consensus_stats) => consensus_stats,
-            Err(e) => return Err(ApiError::ConsensusError(e).into()),
+            Err(e) => return Err(ApiError::ConsensusError(e.to_string()).into()),
         };
 
         let (network_stats, peers) = match self.0.protocol_controller.get_stats() {
             Ok((stats, peers)) => (stats, peers),
-            Err(e) => return Err(ApiError::ProtocolError(e).into()),
+            Err(e) => return Err(ApiError::ProtocolError(e.to_string()).into()),
         };
 
         let pool_stats = (
@@ -754,7 +754,7 @@ impl MassaRpcServer for API<Public> {
             .get_block_graph_status(start_slot, end_slot)
         {
             Ok(graph) => graph,
-            Err(e) => return Err(ApiError::ConsensusError(e).into()),
+            Err(e) => return Err(ApiError::ConsensusError(e.to_string()).into()),
         };
 
         let mut res = Vec::with_capacity(graph.active_blocks.len());


### PR DESCRIPTION
…the minimum dependencies

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification