### PR TITLE
Increase bootstrap read/write timeouts to 3 mins

### DIFF
--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -375,9 +375,9 @@
     # if ping is too high bootstrap will be interrupted after max_ping milliseconds
     max_ping = 10000
     # timeout for incoming message readout
-    read_timeout = 60000
+    read_timeout = 180000
     # timeout for message sending
-    write_timeout = 60000
+    write_timeout = 180000
     # timeout for incoming error message readout
     read_error_timeout = 200
     # timeout for message error sending


### PR DESCRIPTION
When bootstraping max sized bootstrap message, it is easy to hit the timeouts.

1Gio with a timeout of 3 mins means we need at least ~5Mo/s connection to run a node.

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification