### PR TITLE
Fix massa db change history handling

### DIFF
--- a/massa-db-exports/src/error.rs
+++ b/massa-db-exports/src/error.rs
@@ -13,6 +13,8 @@ pub enum MassaDBError {
     InvalidChangeID(String),
     /// time error: {0}
     TimeError(String),
+    /// cache miss error: {0}
+    CacheMissError(String),
     /// rocks db error: {0}
     RocksDBError(String),
     /// hash error: {0}

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -121,7 +121,10 @@ where
                             {
                                 let mut updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
                                     BTreeMap::new();
-                                // TODO_PR: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
+                                // TODO: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
+                                // NOTE: We send again the changes associated to last_change_id (Bound::Included),
+                                // in case multiple writes happened in the same slot.
+                                // This should not happen in the current codebase, but it may be done in the future.
                                 let iter = self
                                     .change_history
                                     .range((Bound::Included(last_change_id), Bound::Unbounded));
@@ -138,6 +141,9 @@ where
                                 updates
                             }
                             _ => {
+                                // Here, we have been asked for the changes associated to a change_id that is not in our history.
+                                // More than `max_history_length` slots have happen since last_change_id, and we have deleted the changes associated to this change_id.
+                                // This can happen if the client has a poor connection, or if the network is unstable.
                                 return Err(MassaDBError::CacheMissError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
                                 )));
@@ -228,7 +234,10 @@ where
                             {
                                 let mut updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
                                     BTreeMap::new();
-                                // TODO_PR: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
+                                // TODO: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
+                                // NOTE: We send again the changes associated to last_change_id (Bound::Included),
+                                // in case multiple writes happened in the same slot.
+                                // This should not happen in the current codebase, but it may be done in the future.
                                 let iter = self
                                     .change_history_versioning
                                     .range((Bound::Included(last_change_id), Bound::Unbounded));
@@ -245,6 +254,9 @@ where
                                 updates
                             }
                             _ => {
+                                // Here, we have been asked for the changes associated to a change_id that is not in our history.
+                                // More than `max_history_length` slots have happen since last_change_id, and we have deleted the changes associated to this change_id.
+                                // This can happen if the client has a poor connection, or if the network is unstable.
                                 return Err(MassaDBError::CacheMissError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
                                 )));

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -1332,7 +1332,7 @@ mod test {
             .read()
             .get_batch_to_stream(&StreamingStep::Ongoing(vec![]), Some(Slot::new(5, 0)));
         // println!("stream_batch: {:?}", stream_batch);
-        assert_matches!(stream_batch, Err(TimeError(..)));
+        assert_matches!(stream_batch, Err(MassaDBError::CacheMissError(..)));
         assert!(stream_batch.err().unwrap().to_string().contains("future"));
 
         //

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -116,7 +116,9 @@ where
                         // We should send all the new updates since last_change_id
                         // We check that last_change_id is in our history
                         match self.change_history.keys().next() {
-                            Some(first_change_id_in_history) if first_change_id_in_history <= &last_change_id => {
+                            Some(first_change_id_in_history)
+                                if first_change_id_in_history <= &last_change_id =>
+                            {
                                 let mut updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
                                     BTreeMap::new();
                                 // TODO_PR: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
@@ -134,7 +136,7 @@ where
                                     );
                                 }
                                 updates
-                            },
+                            }
                             _ => {
                                 return Err(MassaDBError::TimeError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
@@ -221,7 +223,9 @@ where
                         // We should send all the new updates since last_change_id
                         // We check that last_change_id is in our history
                         match self.change_history_versioning.keys().next() {
-                            Some(first_change_id_in_history) if first_change_id_in_history <= &last_change_id => {
+                            Some(first_change_id_in_history)
+                                if first_change_id_in_history <= &last_change_id =>
+                            {
                                 let mut updates: BTreeMap<Vec<u8>, Option<Vec<u8>>> =
                                     BTreeMap::new();
                                 // TODO_PR: check if / how we want to limit the number of updates we send. It may be needed but tricky to implement.
@@ -239,7 +243,7 @@ where
                                     );
                                 }
                                 updates
-                            },
+                            }
                             _ => {
                                 return Err(MassaDBError::TimeError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
@@ -410,7 +414,10 @@ where
             self.change_history_versioning.pop_first();
         }
 
-        println!("change_history keys: {:?}", self.change_history.keys().collect::<Vec<_>>());
+        println!(
+            "change_history keys: {:?}",
+            self.change_history.keys().collect::<Vec<_>>()
+        );
 
         Ok(())
     }
@@ -1624,7 +1631,7 @@ mod test {
             max_versioning_elements_size: 7,
             thread_count: THREAD_COUNT,
         };
-        
+
         let slot_1 = Slot::new(1, 0);
         let slot_2 = Slot::new(1, 2);
         let slot_3 = Slot::new(1, 8);
@@ -1675,15 +1682,18 @@ mod test {
         let mut cur_slot = slot_1.get_next_slot(THREAD_COUNT).unwrap();
         while cur_slot <= slot_2 {
             let batch_key = vec![(cur_slot.period % 256) as u8];
-            let batch_value = vec![cur_slot.thread as u8];
+            let batch_value = vec![cur_slot.thread];
             let batch = DBBatch::from([(batch_key.clone(), Some(batch_value.clone()))]);
-            let versioning_batch = DBBatch::from([(vec![(cur_slot.period % 256) as u8], Some(vec![cur_slot.thread as u8]))]);
+            let versioning_batch = DBBatch::from([(
+                vec![(cur_slot.period % 256) as u8],
+                Some(vec![cur_slot.thread]),
+            )]);
             let mut guard = db.write();
             guard.write_batch(batch, versioning_batch, Some(cur_slot));
             drop(guard);
             cur_slot = cur_slot.get_next_slot(THREAD_COUNT).unwrap();
         }
-        
+
         // Stream using StreamingStep::Finished
         let last_state_step: StreamingStep<Vec<u8>> =
             StreamingStep::Finished(Some(batch_key_2.clone()));
@@ -1697,15 +1707,18 @@ mod test {
         let mut cur_slot = slot_2.get_next_slot(THREAD_COUNT).unwrap();
         while cur_slot <= slot_3 {
             let batch_key = vec![(cur_slot.period % 256) as u8];
-            let batch_value = vec![cur_slot.thread as u8];
+            let batch_value = vec![cur_slot.thread];
             let batch = DBBatch::from([(batch_key.clone(), Some(batch_value.clone()))]);
-            let versioning_batch = DBBatch::from([(vec![(cur_slot.period % 256) as u8], Some(vec![cur_slot.thread as u8]))]);
+            let versioning_batch = DBBatch::from([(
+                vec![(cur_slot.period % 256) as u8],
+                Some(vec![cur_slot.thread]),
+            )]);
             let mut guard = db.write();
             guard.write_batch(batch, versioning_batch, Some(cur_slot));
             drop(guard);
             cur_slot = cur_slot.get_next_slot(THREAD_COUNT).unwrap();
         }
-        
+
         // Stream using StreamingStep::Finished
         let last_state_step: StreamingStep<Vec<u8>> =
             StreamingStep::Finished(Some(batch_key_2.clone()));
@@ -1714,6 +1727,5 @@ mod test {
             .get_batch_to_stream(&last_state_step, Some(slot_2));
         assert!(stream_batch_.is_err());
         assert!(stream_batch_.unwrap_err().to_string().contains("all our changes are strictly after last_change_id, we can't be sure we did not miss any"));
-
     }
 }

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -1619,8 +1619,8 @@ mod test {
         // Stream Slot 1, should succeed
         // Add changes for N slots, N <= max_history_length
         // Stream Slot 2, should succeed
-        // Add changes for M slots, N > max_history_length
-        // Stream Slot 3, should return error
+        // Add changes for M slots, M > max_history_length
+        // Stream Slot 3, should return error because we don't have changes for slot 2
 
         let temp_dir_db = tempdir().expect("Unable to create a temp folder");
         // println!("temp_dir_db: {:?}", temp_dir_db);

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -105,7 +105,7 @@ where
 
                 match last_change_id.cmp(&self.get_change_id().expect(CHANGE_ID_DESER_ERROR)) {
                     std::cmp::Ordering::Greater => {
-                        return Err(MassaDBError::TimeError(String::from(
+                        return Err(MassaDBError::CacheMissError(String::from(
                             "we don't have this change yet on this node (it's in the future for us)",
                         )));
                     }
@@ -138,7 +138,7 @@ where
                                 updates
                             }
                             _ => {
-                                return Err(MassaDBError::TimeError(String::from(
+                                return Err(MassaDBError::CacheMissError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
                                 )));
                             }
@@ -212,7 +212,7 @@ where
 
                 match last_change_id.cmp(&self.get_change_id().expect(CHANGE_ID_DESER_ERROR)) {
                     std::cmp::Ordering::Greater => {
-                        return Err(MassaDBError::TimeError(String::from(
+                        return Err(MassaDBError::CacheMissError(String::from(
                             "we don't have this change yet on this node (it's in the future for us)",
                         )));
                     }
@@ -245,7 +245,7 @@ where
                                 updates
                             }
                             _ => {
-                                return Err(MassaDBError::TimeError(String::from(
+                                return Err(MassaDBError::CacheMissError(String::from(
                                     "all our changes are strictly after last_change_id, we can't be sure we did not miss any",
                                 )));
                             }
@@ -1676,11 +1676,11 @@ mod test {
         // Now updates some values for each slot until slot 2 (included)
         let mut cur_slot = slot_1.get_next_slot(THREAD_COUNT).unwrap();
         while cur_slot <= slot_2 {
-            let batch_key = vec![(cur_slot.period % 256) as u8];
+            let batch_key = vec![(cur_slot.period % u8::MAX as u64) as u8];
             let batch_value = vec![cur_slot.thread];
             let batch = DBBatch::from([(batch_key.clone(), Some(batch_value.clone()))]);
             let versioning_batch = DBBatch::from([(
-                vec![(cur_slot.period % 256) as u8],
+                vec![(cur_slot.period % u8::MAX as u64) as u8],
                 Some(vec![cur_slot.thread]),
             )]);
             let mut guard = db.write();

--- a/massa-db-worker/src/massa_db.rs
+++ b/massa-db-worker/src/massa_db.rs
@@ -414,11 +414,6 @@ where
             self.change_history_versioning.pop_first();
         }
 
-        println!(
-            "change_history keys: {:?}",
-            self.change_history.keys().collect::<Vec<_>>()
-        );
-
         Ok(())
     }
 
@@ -1700,7 +1695,6 @@ mod test {
         let stream_batch_ = db
             .read()
             .get_batch_to_stream(&last_state_step, Some(slot_1));
-        println!("stream_batch_: {:?}", stream_batch_);
         assert!(stream_batch_.is_ok());
 
         // Now updates some values for each slot until slot 2 (included)


### PR DESCRIPTION
* [ ] document all added functions
* [x] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Tested that:
- Labnet with a 1Go ledger successfully bootstrap with final_history_length at 100
- Labnet with a 1Go ledger fails bootstrap with error message (instead of desync) with final_history_length at 8
- Without this PR, Labnet with a 1Go ledger "successfully bootstrap" and desync much more often with final_history_length at 8
