### PR TITLE
Switch to gh merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - uses: actions-rust-lang/audit@v1
         name: Audit Rust Dependencies
 
-  # Full cross-platform tests required by bors to merge on main branch
+  # Full cross-platform tests required to merge on main branch
   full:
     name: full
     needs: sanity
@@ -221,7 +221,7 @@ jobs:
           files: lcov.info
           fail_ci_if_error: false
 
-  build: # quick hack because bors wrongly detect matrix jobs status
+  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed with HitHub Merge Queues.
     needs: full
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     - reopened
     - synchronize
     - ready_for_review
+  merge_group:
+    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           files: lcov.info
           fail_ci_if_error: false
 
-  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed with HitHub Merge Queues.
+  build: # quick hack because bors wrongly detect matrix jobs status. Note: May not be needed with GitHub Merge Queues.
     needs: full
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 # Massa: The Decentralized and Scaled Blockchain
 
 [![CI](https://github.com/massalabs/massa/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/massalabs/massa/actions/workflows/ci.yml?query=branch%3Amain)
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/39543)
 [![Docs](https://img.shields.io/static/v1?label=docs&message=massa&color=&style=flat)](https://massalabs.github.io/massa/massa_node/)
 [![Open in Gitpod](https://shields.io/badge/Gitpod-contribute-brightgreen?logo=gitpod&style=flat)](https://gitpod.io/#https://github.com/massalabs/massa)
 [![codecov](https://codecov.io/gh/massalabs/massa/graph/badge.svg?token=598URC32TV)](https://codecov.io/gh/massalabs/massa)

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,0 @@
-status = ["build"]
-delete_merged_branches = false
-timeout_sec = 36000 # ten hours


### PR DESCRIPTION
Blocked: needs repo configuration

On massa and massa-sc-runtime :
- [x] Remove access to the no longer running Bors App: https://github.com/apps/bors
- [x] Configure merge queues: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue
  - [x] Check "Require merge queue" in the branch protection rule page.
  - [x] Set "Merge method" to squash
  - [x] Set "Build concurrency" to ? ( 5 ? )
  - [x] Check "Only merge non-failing pull requests"
  - [x] Set "Status check timeout" to ? (36000 = 10 hours ?)
  - [x] Set "Merge limits":
    - [x] Set "Minimum pull requests to merge" to 1
    - [x] Set "Maximum pull requests to merge" to ? ( 5 ? )
- [x] Merge PRs that configure the Merge queues:
  - [x] Massa: https://github.com/massalabs/massa/pull/4597
  - [x] Massa-sc-runtime: https://github.com/massalabs/massa-sc-runtime/pull/322
