### PR TITLE
Fix typo dependancy

### DIFF
--- a/massa-wallet/Cargo.toml
+++ b/massa-wallet/Cargo.toml
@@ -19,4 +19,4 @@ massa_hash = {workspace = true}
 massa_models = {workspace = true}
 massa_signature = {workspace = true}
 serde_yaml = {workspace = true}
-zeroize = { worksapce = true }
+zeroize = { workspace = true }


### PR DESCRIPTION
Typo leads to a warning when building massa on main.

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification