### PR TITLE
Fix get_slot_abi_call_stacks GRPC endpoint

### DIFF
--- a/massa-api/src/tests/public.rs
+++ b/massa-api/src/tests/public.rs
@@ -490,7 +490,7 @@ async fn send_operations_low_fee() {
     let keypair = KeyPair::generate(0).unwrap();
 
     // send transaction
-    let operation = create_operation_with_expire_period(&keypair, 500000);
+    let operation = create_operation_with_expire_period(&keypair, u64::MAX);
 
     let input: OperationInput = OperationInput {
         creator_public_key: keypair.get_public_key(),
@@ -551,7 +551,7 @@ async fn send_operations() {
 
     ////
     // send transaction
-    let operation = create_operation_with_expire_period(&keypair, 500000);
+    let operation = create_operation_with_expire_period(&keypair, u64::MAX);
 
     let input: OperationInput = OperationInput {
         creator_public_key: keypair.get_public_key(),

--- a/massa-grpc/src/public.rs
+++ b/massa-grpc/src/public.rs
@@ -653,7 +653,7 @@ pub(crate) fn get_slot_abi_call_stacks(
 ) -> Result<grpc_api::GetSlotAbiCallStacksResponse, GrpcError> {
     let slots = request.into_inner().slots;
 
-    let slot_elements = vec![];
+    let mut slot_elements = vec![];
     for slot in slots {
         let call_stack_ = grpc
             .execution_controller
@@ -680,6 +680,7 @@ pub(crate) fn get_slot_abi_call_stacks(
                     })
             }
         }
+        slot_elements.push(slot_abi_call_stacks);
     }
 
     let resp = GetSlotAbiCallStacksResponse {


### PR DESCRIPTION
The returned array was always empty.