### PR TITLE
Fix call stack inconsistency

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1123,7 +1123,7 @@ impl ExecutionState {
             context.stack = vec![
                 ExecutionStackElement {
                     address: message.sender,
-                    coins: message.coins,
+                    coins: Default::default(),
                     owned_addresses: vec![message.sender],
                     operation_datastore: None,
                 },


### PR DESCRIPTION
The stack set in execute_async_message and in execute_callsc_op were inconsistent.

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification