### PR TITLE
Asc message execution - requery message bytecode after each message execution

### DIFF
--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -364,12 +364,9 @@ impl ExecutionContext {
         &mut self,
         max_gas: u64,
         async_msg_cst_gas_cost: u64,
-    ) -> Vec<(Option<Bytecode>, AsyncMessage)> {
+    ) -> Vec<(AsyncMessageId, AsyncMessage)> {
         self.speculative_async_pool
             .take_batch_to_execute(self.slot, max_gas, async_msg_cst_gas_cost)
-            .into_iter()
-            .map(|(_id, msg)| (self.get_bytecode(&msg.destination), msg))
-            .collect()
     }
 
     /// Create a new `ExecutionContext` for executing an active slot.

--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -365,8 +365,11 @@ impl ExecutionContext {
         max_gas: u64,
         async_msg_cst_gas_cost: u64,
     ) -> Vec<(AsyncMessageId, AsyncMessage)> {
-        self.speculative_async_pool
-            .take_batch_to_execute(self.slot, max_gas, async_msg_cst_gas_cost)
+        self.speculative_async_pool.take_batch_to_execute(
+            self.slot,
+            max_gas,
+            async_msg_cst_gas_cost,
+        )
     }
 
     /// Create a new `ExecutionContext` for executing an active slot.

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1272,9 +1272,8 @@ impl ExecutionState {
         // Try executing asynchronous messages.
         // Effects are cancelled on failure and the sender is reimbursed.
         for (_message_id, message) in messages {
-            
             let opt_bytecode = context_guard!(self).get_bytecode(&message.destination);
-            
+
             match self.execute_async_message(message, opt_bytecode) {
                 Ok(_message_return) => {
                     cfg_if::cfg_if! {

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1271,7 +1271,10 @@ impl ExecutionState {
 
         // Try executing asynchronous messages.
         // Effects are cancelled on failure and the sender is reimbursed.
-        for (opt_bytecode, message) in messages {
+        for (_message_id, message) in messages {
+            
+            let opt_bytecode = context_guard!(self).get_bytecode(&message.destination);
+            
             match self.execute_async_message(message, opt_bytecode) {
                 Ok(_message_return) => {
                     cfg_if::cfg_if! {


### PR DESCRIPTION
Sandbox testing has shown this fixes the issue of two async message in the same slot, where the 1st updates the bytecode of the target contract.

Before this fix, if the 1st async message updates the bytecode, then the second async message will take into account an out of date bytecode for the target address.

* [ ] document all added functions
* [x] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification