### PR TITLE
Update MIP timings for MAIN.2.5 release

### DIFF
--- a/massa-versioning/src/mips.rs
+++ b/massa-versioning/src/mips.rs
@@ -10,7 +10,7 @@ use crate::versioning::{MipComponent, MipInfo, MipState};
 #[cfg(not(feature = "test-exports"))]
 pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
     // When the MIP becomes defined, e.g. when merged to main branch
-    let defined = MassaTime::from_utc_ymd_hms(2025, 5, 7, 10, 0, 0).unwrap(); // Wednesday 7th May 2025 10:00:00 UTC
+    let defined = MassaTime::from_utc_ymd_hms(2025, 5, 12, 10, 0, 0).unwrap(); // Monday 12th May 2025 10:00:00 UTC
 
     let mip_list = [(
         MipInfo {
@@ -20,8 +20,8 @@ pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
                 (MipComponent::Execution, 1),
                 (MipComponent::FinalState, 1),
             ]),
-            start: MassaTime::from_utc_ymd_hms(2025, 5, 14, 10, 0, 0).unwrap(), // Wednesday 14th May 2025 10:00:00 UTC
-            timeout: MassaTime::from_utc_ymd_hms(2025, 6, 14, 10, 0, 0).unwrap(), // Saturday 14th June 2025 10:00:00 UTC
+            start: MassaTime::from_utc_ymd_hms(2025, 5, 19, 10, 0, 0).unwrap(), // Monday 19th May 2025 10:00:00 UTC
+            timeout: MassaTime::from_utc_ymd_hms(2025, 6, 19, 10, 0, 0).unwrap(), // Thursday 19th June 2025 10:00:00 UTC
             activation_delay: MassaTime::from_millis(7 * 24 * 60 * 60 * 1000),    // 7 days
         },
         MipState::new(defined),

--- a/massa-versioning/src/mips.rs
+++ b/massa-versioning/src/mips.rs
@@ -9,22 +9,23 @@ use crate::versioning::{MipComponent, MipInfo, MipState};
 
 #[cfg(not(feature = "test-exports"))]
 pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
-    let mip_list = [
-        (
-            MipInfo {
-                name: "MIP-0001-DeferredCalls-And-Execution-BugFix".to_string(),
-                version: 1,
-                components: BTreeMap::from([
-                    (MipComponent::Execution, 1),
-                    (MipComponent::FinalState, 1),
-                ]),
-                start: MassaTime::from_utc_ymd_hms(2025, 2, 5, 10, 0, 0).unwrap(), // TODO: set when known (ex: Wednesday 5th February 2025 10:00:00 UTC)
-                timeout: MassaTime::from_utc_ymd_hms(2025, 4, 5, 10, 0, 0).unwrap(), // TODO: set when known (ex: 2 months after start date)
-                activation_delay: MassaTime::from_millis(3 * 24 * 60 * 60 * 1000), // TODO: set when known (ex: 3 days)
-            },
-            MipState::new(MassaTime::from_utc_ymd_hms(2025, 2, 4, 10, 0, 0).unwrap()),
-        ), // TODO: set when known, (when the MIP becomes defined, e.g. when merged to main branch, ex: Tuesday 4th February 2025 10:00:00 UTC)
-    ];
+    // When the MIP becomes defined, e.g. when merged to main branch
+    let defined = MassaTime::from_utc_ymd_hms(2025, 5, 7, 10, 0, 0).unwrap(); // Wednesday 7th May 2025 10:00:00 UTC
+
+    let mip_list = [(
+        MipInfo {
+            name: "MIP-0001-DeferredCalls-And-Execution-BugFix".to_string(),
+            version: 1,
+            components: BTreeMap::from([
+                (MipComponent::Execution, 1),
+                (MipComponent::FinalState, 1),
+            ]),
+            start: MassaTime::from_utc_ymd_hms(2025, 5, 14, 10, 0, 0).unwrap(), // Wednesday 14th May 2025 10:00:00 UTC
+            timeout: MassaTime::from_utc_ymd_hms(2025, 6, 14, 10, 0, 0).unwrap(), // Saturday 14th June 2025 10:00:00 UTC
+            activation_delay: MassaTime::from_millis(7 * 24 * 60 * 60 * 1000),    // 7 days
+        },
+        MipState::new(defined),
+    )];
 
     // debug!("MIP list: {:?}", mip_list);
     #[allow(clippy::let_and_return)]
@@ -44,9 +45,9 @@ pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
         name: "MIP-0001-DeferredCalls-And-Execution-BugFix".to_string(),
         version: 1,
         components: BTreeMap::from([(MipComponent::Execution, 1), (MipComponent::FinalState, 1)]),
-        start: MassaTime::from_millis(2), // TODO: set when known, ex: MassaTime::from_utc_ymd_hms(2024, 7, 10, 15, 0, 0).unwrap();
-        timeout: MassaTime::from_millis(10), // TODO: set when known
-        activation_delay: MassaTime::from_millis(2), // TODO: set when known, 3 days as an example
+        start: MassaTime::from_millis(2),
+        timeout: MassaTime::from_millis(10),
+        activation_delay: MassaTime::from_millis(2),
     };
     let mip_state_1 = advance_state_until(
         ComponentState::Active(Active {

--- a/massa-versioning/src/mips.rs
+++ b/massa-versioning/src/mips.rs
@@ -18,12 +18,12 @@ pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
                     (MipComponent::Execution, 1),
                     (MipComponent::FinalState, 1),
                 ]),
-                start: MassaTime::from_utc_ymd_hms(2024, 11, 28, 2, 0, 0).unwrap(), // TODO: set when known, ex: MassaTime::from_utc_ymd_hms(2024, 7, 10, 15, 0, 0).unwrap();
-                timeout: MassaTime::from_utc_ymd_hms(2025, 11, 28, 2, 0, 0).unwrap(), // TODO: set when known
-                activation_delay: MassaTime::from_millis(3 * 24 * 60 * 60 * 1000), // TODO: set when known, 3 days as an example
+                start: MassaTime::from_utc_ymd_hms(2025, 2, 5, 10, 0, 0).unwrap(), // TODO: set when known (ex: Wednesday 5th February 2025 10:00:00 UTC)
+                timeout: MassaTime::from_utc_ymd_hms(2025, 4, 5, 10, 0, 0).unwrap(), // TODO: set when known (ex: 2 months after start date)
+                activation_delay: MassaTime::from_millis(3 * 24 * 60 * 60 * 1000), // TODO: set when known (ex: 3 days)
             },
-            MipState::new(MassaTime::from_utc_ymd_hms(2024, 11, 28, 0, 0, 0).unwrap()),
-        ), // TODO: set when known, (when the MIP becomes defined, e.g. when merged to main branch)
+            MipState::new(MassaTime::from_utc_ymd_hms(2025, 2, 4, 10, 0, 0).unwrap()),
+        ), // TODO: set when known, (when the MIP becomes defined, e.g. when merged to main branch, ex: Tuesday 4th February 2025 10:00:00 UTC)
     ];
 
     // debug!("MIP list: {:?}", mip_list);

--- a/massa-versioning/src/mips.rs
+++ b/massa-versioning/src/mips.rs
@@ -12,7 +12,7 @@ pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
     let mip_list = [
         (
             MipInfo {
-                name: "MIP-0001-Execution-BugFix".to_string(),
+                name: "MIP-0001-DeferredCalls-And-Execution-BugFix".to_string(),
                 version: 1,
                 components: BTreeMap::from([
                     (MipComponent::Execution, 1),
@@ -41,7 +41,7 @@ pub fn get_mip_list() -> [(MipInfo, MipState); 1] {
     println!("Running with test-exports feature");
 
     let mip_info_1 = MipInfo {
-        name: "MIP-0001-Execution-BugFix".to_string(),
+        name: "MIP-0001-DeferredCalls-And-Execution-BugFix".to_string(),
         version: 1,
         components: BTreeMap::from([(MipComponent::Execution, 1), (MipComponent::FinalState, 1)]),
         start: MassaTime::from_millis(2), // TODO: set when known, ex: MassaTime::from_utc_ymd_hms(2024, 7, 10, 15, 0, 0).unwrap();


### PR DESCRIPTION
- [x] Set defined:
  - a few hours before release
  - e.g. `MassaTime::from_utc_ymd_hms(2025, 5, 12, 10, 0, 0).unwrap(), // Monday 12th May 2025 10:00:00 UTC`
- [x] Set started:
  - 1 week after defined
  - e.g. `MassaTime::from_utc_ymd_hms(2025, 5, 19, 10, 0, 0).unwrap(), // Monday 19th May 2025 10:00:00 UTC`
- [x] Set timeout:
  - 1 month after started
  - e.g. `MassaTime::from_utc_ymd_hms(2025, 6, 19, 10, 0, 0).unwrap(), // Thursday 19th June 2025 10:00:00 UTC`
- [x] Set activation_delay:
  - 7 days
  - e.g. `MassaTime::from_millis(7 * 24 * 60 * 60 * 1000) // 7 days`
