### PR TITLE
feat(execution): add slot execution timing warning

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1983,7 +1983,8 @@ impl ExecutionState {
             .config
             .t0
             .checked_div_u64(self.config.thread_count as u64)
-            .expect("could not deduce slot duration").to_duration();
+            .expect("could not deduce slot duration")
+            .to_duration();
         let total_slot_duration = slot_start_time.elapsed();
         if total_slot_duration > max_slot_duration {
             warn!(

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1983,7 +1983,7 @@ impl ExecutionState {
             .config
             .t0
             .checked_div_u64(self.config.thread_count as u64)
-            .expect("could not deduce slot duration");
+            .expect("could not deduce slot duration").to_duration();
         let total_slot_duration = slot_start_time.elapsed();
         if total_slot_duration > max_slot_duration {
             warn!(

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1523,6 +1523,7 @@ impl ExecutionState {
         exec_target: Option<&(BlockId, ExecutionBlockMetadata)>,
         selector: Box<dyn SelectorController>,
     ) -> ExecutionOutput {
+        // Start slot execution timer
         let slot_start_time = Instant::now();
         #[cfg(feature = "execution-trace")]
         let mut slot_trace = SlotAbiCallStack {
@@ -1977,6 +1978,7 @@ impl ExecutionState {
 
         exec_out.state_changes.deferred_call_changes.exec_stats = deferred_calls_stats;
 
+        // Warn if the slot execution took more than the maximum slot duration
         let max_slote_duration = self
             .config
             .t0

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1979,16 +1979,16 @@ impl ExecutionState {
         exec_out.state_changes.deferred_call_changes.exec_stats = deferred_calls_stats;
 
         // Warn if the slot execution took more than the maximum slot duration
-        let max_slote_duration = self
+        let max_slot_duration = self
             .config
             .t0
             .checked_div_u64(self.config.thread_count as u64)
             .expect("could not deduce slot duration");
         let total_slot_duration = slot_start_time.elapsed();
-        if total_slot_duration > max_slote_duration {
+        if total_slot_duration > max_slot_duration {
             warn!(
                 "slot {} execution took {:?} (above the {:?} maximum slot duration)",
-                slot, total_slot_duration, max_slote_duration
+                slot, total_slot_duration, max_slot_duration
             );
         }
 


### PR DESCRIPTION
This adds a timing warning in case slot execution takes longer than the expected slot time.