### PR TITLE
fix: MessagesSerializer error label for ID serialization

### DIFF
--- a/massa-protocol-worker/src/messages.rs
+++ b/massa-protocol-worker/src/messages.rs
@@ -140,7 +140,7 @@ impl PeerNetMessagesSerializer<Message> for MessagesSerializer {
             .serialize(&MessageTypeId::from(message).into(), buffer)
             .map_err(|err| {
                 PeerNetError::HandlerError.error(
-                    "MessagesHandler",
+                    "MessagesSerializer",
                     Some(format!("Failed to serialize id {}", err)),
                 )
             })?;


### PR DESCRIPTION
The error context in MessagesSerializer::serialize() used "MessagesHandler" when mapping the error for message type ID serialization. This was inconsistent with the rest of the method, where "MessagesSerializer" is correctly used, and with
the convention in MessagesHandler::handle().

Using the correct component label improves log consistency, diagnostics, and filtering. No functional behavior changes; this is a logging/diagnostic fix.
