### PR TITLE
feat: move pool channel size from constants to config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3572,6 +3572,7 @@ name = "massa_pool_worker"
 version = "4.0.0"
 dependencies = [
  "crossbeam-channel",
+ "massa_channel",
  "massa_execution_exports",
  "massa_hash",
  "massa_models",

--- a/massa-channel/src/receiver.rs
+++ b/massa-channel/src/receiver.rs
@@ -69,13 +69,11 @@ impl<T> MassaReceiver<T> {
         match self.receiver.try_recv() {
             Ok(msg) => {
                 self.update_metrics();
-
                 Ok(msg)
             }
             Err(crossbeam::channel::TryRecvError::Empty) => Err(TryRecvError::Empty),
             Err(crossbeam::channel::TryRecvError::Disconnected) => {
                 self.unregister_metrics();
-
                 Err(TryRecvError::Disconnected)
             }
         }
@@ -87,9 +85,10 @@ impl<T> MassaReceiver<T> {
                 self.update_metrics();
                 Ok(msg)
             }
-            Err(e) => {
+            Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
+            Err(RecvTimeoutError::Disconnected) => {
                 self.unregister_metrics();
-                Err(e)
+                Err(RecvTimeoutError::Disconnected)
             }
         }
     }
@@ -100,9 +99,10 @@ impl<T> MassaReceiver<T> {
                 self.update_metrics();
                 Ok(msg)
             }
-            Err(e) => {
+            Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
+            Err(RecvTimeoutError::Disconnected) => {
                 self.unregister_metrics();
-                Err(e)
+                Err(RecvTimeoutError::Disconnected)
             }
         }
     }

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -302,12 +302,6 @@ pub const MAX_BOOTSTRAP_ERROR_LENGTH: u64 = 10000;
 pub const PROTOCOL_CONTROLLER_CHANNEL_SIZE: usize = 1024;
 /// Protocol event channel size
 pub const PROTOCOL_EVENT_CHANNEL_SIZE: usize = 1024;
-/// Pool controller operations channel size
-pub const POOL_CONTROLLER_OPERATIONS_CHANNEL_SIZE: usize = 1024;
-/// Pool controller endorsements channel size
-pub const POOL_CONTROLLER_ENDORSEMENTS_CHANNEL_SIZE: usize = 1024;
-/// Pool controller denunciations channel size
-pub const POOL_CONTROLLER_DENUNCIATIONS_CHANNEL_SIZE: usize = 1024;
 
 // ***********************
 // Constants used for execution module (injected from ConsensusConfig)

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -447,7 +447,7 @@
     # max number of items returned per query
     max_item_return_count = 100
     # endorsements channel capacity
-    endorsements_channel_capacity = 1024
+    endorsements_channel_capacity = 2048
     # operations channel capacity
     operations_channel_capacity = 1024
     # denunciation channel capacity

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -447,9 +447,9 @@
     # max number of items returned per query
     max_item_return_count = 100
     # endorsements channel capacity
-    endorsements_channel_capacity = 2048
+    endorsements_channel_capacity = 1024
     # operations channel capacity
-    operations_channel_capacity = 2048
+    operations_channel_capacity = 1024
     # denunciation channel capacity
     denunciations_channel_capacity = 2048
     # broadcast endorsements channel capacity

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -447,12 +447,17 @@
     # max number of items returned per query
     max_item_return_count = 100
     # endorsements channel capacity
-    broadcast_endorsements_channel_capacity = 2000
+    endorsements_channel_capacity = 2048
     # operations channel capacity
+    operations_channel_capacity = 2048
+    # denunciation channel capacity
+    denunciations_channel_capacity = 2048
+    # broadcast endorsements channel capacity
+    broadcast_endorsements_channel_capacity = 2000
+    # broadcast operations channel capacity
     broadcast_operations_channel_capacity = 5000
     # minimal fee to include operation in the pool 0.01MAS
     minimal_fees = 0.01
-
 
 [selector]
     # path to the initial roll distribution

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -451,7 +451,7 @@
     # operations channel capacity
     operations_channel_capacity = 1024
     # denunciation channel capacity
-    denunciations_channel_capacity = 2048
+    denunciations_channel_capacity = 4096
     # broadcast endorsements channel capacity
     broadcast_endorsements_channel_capacity = 2000
     # broadcast operations channel capacity

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -104,8 +104,7 @@ use massa_models::config::{
     MAX_RUNTIME_MODULE_GLOBAL_INITIALIZER, MAX_RUNTIME_MODULE_IMPORTS, MAX_RUNTIME_MODULE_MEMORIES,
     MAX_RUNTIME_MODULE_NAME_LEN, MAX_RUNTIME_MODULE_PASSIVE_DATA,
     MAX_RUNTIME_MODULE_PASSIVE_ELEMENT, MAX_RUNTIME_MODULE_SIGNATURE_LEN, MAX_RUNTIME_MODULE_TABLE,
-    MAX_RUNTIME_MODULE_TABLE_INITIALIZER, POOL_CONTROLLER_DENUNCIATIONS_CHANNEL_SIZE,
-    POOL_CONTROLLER_ENDORSEMENTS_CHANNEL_SIZE, POOL_CONTROLLER_OPERATIONS_CHANNEL_SIZE,
+    MAX_RUNTIME_MODULE_TABLE_INITIALIZER,
 };
 use massa_models::slot::Slot;
 use massa_models::timeslots::get_block_slot_timestamp;
@@ -671,9 +670,9 @@ async fn launch(
         denunciation_pool_swap_interval: SETTINGS.pool.denunciation_pool_swap_interval,
         operation_max_future_start_delay: SETTINGS.pool.operation_max_future_start_delay,
         max_endorsements_pool_size_per_thread: SETTINGS.pool.max_endorsements_pool_size_per_thread,
-        operations_channel_size: POOL_CONTROLLER_OPERATIONS_CHANNEL_SIZE,
-        endorsements_channel_size: POOL_CONTROLLER_ENDORSEMENTS_CHANNEL_SIZE,
-        denunciations_channel_size: POOL_CONTROLLER_DENUNCIATIONS_CHANNEL_SIZE,
+        operations_channel_size: SETTINGS.pool.operations_channel_capacity,
+        endorsements_channel_size: SETTINGS.pool.endorsements_channel_capacity,
+        denunciations_channel_size: SETTINGS.pool.denunciations_channel_capacity,
         broadcast_enabled: SETTINGS.api.enable_broadcast,
         broadcast_endorsements_channel_capacity: SETTINGS
             .pool

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -119,8 +119,14 @@ pub struct PoolSettings {
     pub max_endorsements_pool_size_per_thread: usize,
     pub max_item_return_count: usize,
     /// endorsements channel capacity
-    pub broadcast_endorsements_channel_capacity: usize,
+    pub endorsements_channel_capacity: usize,
     /// operations channel capacity
+    pub operations_channel_capacity: usize,
+    /// denunciations channel capacity
+    pub denunciations_channel_capacity: usize,
+    /// broadcast endorsements channel capacity
+    pub broadcast_endorsements_channel_capacity: usize,
+    /// broadcast operations channel capacity
     pub broadcast_operations_channel_capacity: usize,
     /// operations minimum fees for block creator
     pub minimal_fees: Amount,

--- a/massa-pool-worker/Cargo.toml
+++ b/massa-pool-worker/Cargo.toml
@@ -10,11 +10,13 @@ test-exports = ["massa_execution_exports/test-exports", "massa_pos_exports/test-
 [dependencies]
 tracing = {workspace = true}
 parking_lot = {workspace = true, "features" = ["deadlock_detection"]}
+massa_channel = {workspace = true}
 massa_models = {workspace = true}
 massa_storage = {workspace = true}
 massa_pool_exports = {workspace = true}
 massa_time = {workspace = true}
 massa_wallet = {workspace = true}
+crossbeam-channel = {workspace = true}
 
 [dev-dependencies]
 tokio = {workspace = true, "features" = ["sync"]}
@@ -24,4 +26,3 @@ massa_hash = {workspace = true}
 massa_pool_exports = {workspace = true, "features" = ["test-exports"]}
 massa_pos_exports = {workspace = true, "features" = ["test-exports"]}
 massa_execution_exports = {workspace = true, "features" = ["test-exports"]}
-crossbeam-channel = {workspace = true}


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Tested with channels of size 2048 instead of 1024, and it seems to resolve the issues seen in https://github.com/massalabs/massa/issues/4944

Math for max channel size:
worst case = 1024 endorsements per message (from GRPC stream) * 2048 channel size * 71 bytes / endorsement = 147 MB