### PR TITLE
fix(serialization): reject zero-denominator ratio on deserialization

### DIFF
--- a/massa-serialization/src/lib.rs
+++ b/massa-serialization/src/lib.rs
@@ -465,7 +465,7 @@ where
         &self,
         buffer: &'a [u8],
     ) -> IResult<&'a [u8], Ratio<T>, E> {
-        let mut parser = context(
+        context(
             "Ratio<_> deserializer failed",
             map_opt(
                 tuple((
@@ -487,8 +487,8 @@ where
                     }
                 },
             ),
-        );
-        parser.parse(buffer)
+        )
+        .parse(buffer)
     }
 }
 

--- a/massa-serialization/src/lib.rs
+++ b/massa-serialization/src/lib.rs
@@ -7,7 +7,7 @@ use displaydoc::Display;
 use nom::{
     branch::alt,
     bytes::complete::tag,
-    combinator::value,
+    combinator::{map_opt, value},
     error::{ContextError, ParseError},
     sequence::preceded,
     sequence::tuple,
@@ -465,19 +465,30 @@ where
         &self,
         buffer: &'a [u8],
     ) -> IResult<&'a [u8], Ratio<T>, E> {
-        context(
+        let mut parser = context(
             "Ratio<_> deserializer failed",
-            tuple((
-                context("numer deser failed", |input| {
-                    self.data_deserializer.deserialize(input)
-                }),
-                context("denom deser failed", |input| {
-                    self.data_deserializer.deserialize(input)
-                }),
-            )),
-        )
-        .map(|(numer, denom)| Ratio::new(numer, denom))
-        .parse(buffer)
+            map_opt(
+                tuple((
+                    context("numer deser failed", |input| {
+                        self.data_deserializer.deserialize(input)
+                    }),
+                    context("denom deser failed", |input| {
+                        self.data_deserializer.deserialize(input)
+                    }),
+                )),
+                |(numer, denom)| {
+                    // A zero denominator is not a representable ratio: reject it as a
+                    // parse error instead of letting `Ratio::new` panic (which could
+                    // abort DB/bootstrap validation paths).
+                    if num::Zero::is_zero(&denom) {
+                        None
+                    } else {
+                        Some(Ratio::new(numer, denom))
+                    }
+                },
+            ),
+        );
+        parser.parse(buffer)
     }
 }
 
@@ -731,5 +742,22 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(format!("{}", err), "Parsing Error: Ratio<_> deserializer failed / denom deser failed / Failed u64 deserialization / Fail / Input: [4]\n");
+    }
+
+    #[test]
+    fn test_ratio_deserializer_rejects_zero_denominator() {
+        // numer = 1, denom = 0, each encoded as a single-byte u64 varint.
+        // A zero denominator must be rejected as a parse error instead of
+        // panicking inside `Ratio::new`.
+        let buffer = vec![1u8, 0u8];
+        let ratio_deserializer = super::RatioDeserializer::new(super::U64VarIntDeserializer::new(
+            std::ops::Bound::Included(0),
+            std::ops::Bound::Included(u64::MAX),
+        ));
+        let result = ratio_deserializer.deserialize::<DeserializeError>(&buffer);
+        assert!(
+            result.is_err(),
+            "a zero denominator must produce a deserialization error, not a panic"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`RatioDeserializer::deserialize` unconditionally called `Ratio::new(numer, denom)`, which **panics when `denom == 0`**. The `u64` denominator deserializer used by `ComponentStateDeserializer::new` and `AdvanceLWDeserializer::new` is configured with `U64VarIntDeserializer::new(Included(0), Included(u64::MAX))`, so `0` is accepted as a denominator.

As a result, a malformed versioning value encoding a ratio with denominator `0` could **panic during `MipStore::is_key_value_valid`** — a path that is supposed to return `false` for invalid data. This is reachable during final-state checks and bootstrap-fed DB validation, turning a validation failure into a process abort (DoS).

Addresses AI-report **Finding 145** (severity: medium).

## Fix

Validate the denominator inside the deserializer using `map_opt`: a zero denominator now produces a normal parse error instead of reaching `Ratio::new`.

```rust
|(numer, denom)| {
    if num::Zero::is_zero(&denom) {
        None // -> parse error
    } else {
        Some(Ratio::new(numer, denom))
    }
}
```

## Why this is non-breaking (no consensus / wire / deployment impact)

- `Ratio::new` can **never** construct a zero-denominator value (it panics), so no valid in-memory ratio — and therefore no valid *serialized* ratio — has a zero denominator.
- The only inputs whose behavior changes are malformed byte sequences that previously **panicked**; they now return a clean deserialization error.
- Valid ratios round-trip identically (same `Ratio::new` normalization for non-zero denominators).
- Pure local robustness fix in `massa-serialization`; no change to serialization output, consensus rules, or network messages.

## Testing

- Added unit test `test_ratio_deserializer_rejects_zero_denominator` (asserts a `[1, 0]` buffer yields `Err`, not a panic).
- `cargo test -p massa_serialization`: 23 passed, 0 failed (+ 2 doc-tests).
- `cargo clippy -p massa_serialization --all-targets`: clean.
- `cargo fmt`: clean.

## Checklist
* [x] document all added functions (n/a — no new public API; behavior documented inline)
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging (n/a — returns a descriptive parse error)
* [ ] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)