### PR TITLE
fix(channel): only unregister channel metrics when the last receiver clone drops

### DIFF
--- a/massa-channel/src/receiver.rs
+++ b/massa-channel/src/receiver.rs
@@ -25,11 +25,8 @@ pub struct MassaReceiver<T> {
 
 impl<T> Drop for MassaReceiver<T> {
     fn drop(&mut self) {
-        let ref_count = Arc::strong_count(&self.ref_counter);
-        if ref_count == 1 {
-            // this is the last ref so we can unregister metrics
-            self.unregister_metrics();
-        }
+        // this only unregisters if this is the last live clone
+        self.unregister_metrics_if_last();
     }
 }
 
@@ -43,6 +40,18 @@ impl<T> MassaReceiver<T> {
         self.actual_len.set(self.receiver.len() as f64);
 
         self.received.inc();
+    }
+
+    /// Unregister metrics only if this is the last live receiver clone.
+    ///
+    /// Channel disconnection is observed by *every* clone, so unregistering
+    /// unconditionally from a `recv*`/`try_recv` disconnect branch would remove
+    /// the metrics from the registry while sibling clones are still alive and
+    /// updating them. Only the last remaining clone should unregister.
+    fn unregister_metrics_if_last(&self) {
+        if Arc::strong_count(&self.ref_counter) == 1 {
+            self.unregister_metrics();
+        }
     }
 
     /// unregister metrics
@@ -73,7 +82,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(crossbeam::channel::TryRecvError::Empty) => Err(TryRecvError::Empty),
             Err(crossbeam::channel::TryRecvError::Disconnected) => {
-                self.unregister_metrics();
+                self.unregister_metrics_if_last();
                 Err(TryRecvError::Disconnected)
             }
         }
@@ -87,7 +96,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
             Err(RecvTimeoutError::Disconnected) => {
-                self.unregister_metrics();
+                self.unregister_metrics_if_last();
                 Err(RecvTimeoutError::Disconnected)
             }
         }
@@ -101,7 +110,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
             Err(RecvTimeoutError::Disconnected) => {
-                self.unregister_metrics();
+                self.unregister_metrics_if_last();
                 Err(RecvTimeoutError::Disconnected)
             }
         }
@@ -114,7 +123,7 @@ impl<T> MassaReceiver<T> {
                 Ok(msg)
             }
             Err(e) => {
-                self.unregister_metrics();
+                self.unregister_metrics_if_last();
                 Err(e)
             }
         }
@@ -132,5 +141,60 @@ impl<T> Deref for MassaReceiver<T> {
 impl<T> DerefMut for MassaReceiver<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.receiver
+    }
+}
+
+// Metrics are only registered in the default prometheus registry when the
+// `test-exports` feature is disabled (see `MassaChannel::new`), so these
+// registry-observing tests are gated to that build configuration.
+#[cfg(all(test, not(feature = "test-exports")))]
+mod tests {
+    use crate::MassaChannel;
+
+    /// Returns true if a metric family with the given name is currently
+    /// registered in the default prometheus registry.
+    fn metric_registered(name: &str) -> bool {
+        prometheus::gather().iter().any(|mf| mf.get_name() == name)
+    }
+
+    #[test]
+    fn disconnect_does_not_unregister_metrics_while_a_clone_is_alive() {
+        let chan_name = "massa_channel_test_disconnect_keeps_metrics".to_string();
+        let size_metric = format!("{}_channel_actual_size", chan_name);
+        let recv_metric = format!("{}_channel_total_receive", chan_name);
+
+        let (sender, receiver) = MassaChannel::new::<u8>(chan_name, None);
+        // Second live clone of the receiver.
+        let receiver2 = receiver.clone();
+
+        assert!(metric_registered(&size_metric));
+        assert!(metric_registered(&recv_metric));
+
+        // Disconnect the channel; every receiver clone now observes disconnection.
+        drop(sender);
+
+        // Hitting the disconnect branch on one clone must NOT tear down the
+        // metrics, because `receiver2` is still alive and using them.
+        assert!(receiver.recv().is_err());
+        assert!(
+            metric_registered(&size_metric),
+            "actual_size metric must stay registered while a clone is alive"
+        );
+        assert!(
+            metric_registered(&recv_metric),
+            "total_receive metric must stay registered while a clone is alive"
+        );
+
+        // Once the last clone is dropped, the metrics are unregistered.
+        drop(receiver);
+        drop(receiver2);
+        assert!(
+            !metric_registered(&size_metric),
+            "actual_size metric must be unregistered after the last clone drops"
+        );
+        assert!(
+            !metric_registered(&recv_metric),
+            "total_receive metric must be unregistered after the last clone drops"
+        );
     }
 }

--- a/massa-channel/src/receiver.rs
+++ b/massa-channel/src/receiver.rs
@@ -45,7 +45,16 @@ impl<T> MassaReceiver<T> {
         self.received.inc();
     }
 
-    /// unregister metrics
+    /// Unregister the channel metrics.
+    ///
+    /// Called from every `recv*`/`try_recv` disconnect branch on purpose, even
+    /// though `MassaReceiver` is `Clone`: a crossbeam disconnect means all senders
+    /// are dropped and the buffer is empty, so the channel is dead for every clone
+    /// at once and the metrics are frozen. Unregistering right away also frees the
+    /// metric names for the relaunch (`NeedSync`) that re-creates the channels
+    /// with the same names; `MassaChannel::new` only logs registration failures
+    /// at debug level. Later calls (from other clones or from `Drop`) fail with
+    /// "not registered" and are swallowed at trace level.
     fn unregister_metrics(&self) {
         if let Err(e) = prometheus::unregister(Box::new(self.actual_len.clone())) {
             trace!(

--- a/massa-channel/src/receiver.rs
+++ b/massa-channel/src/receiver.rs
@@ -25,8 +25,11 @@ pub struct MassaReceiver<T> {
 
 impl<T> Drop for MassaReceiver<T> {
     fn drop(&mut self) {
-        // this only unregisters if this is the last live clone
-        self.unregister_metrics_if_last();
+        let ref_count = Arc::strong_count(&self.ref_counter);
+        if ref_count == 1 {
+            // this is the last ref so we can unregister metrics
+            self.unregister_metrics();
+        }
     }
 }
 
@@ -40,18 +43,6 @@ impl<T> MassaReceiver<T> {
         self.actual_len.set(self.receiver.len() as f64);
 
         self.received.inc();
-    }
-
-    /// Unregister metrics only if this is the last live receiver clone.
-    ///
-    /// Channel disconnection is observed by *every* clone, so unregistering
-    /// unconditionally from a `recv*`/`try_recv` disconnect branch would remove
-    /// the metrics from the registry while sibling clones are still alive and
-    /// updating them. Only the last remaining clone should unregister.
-    fn unregister_metrics_if_last(&self) {
-        if Arc::strong_count(&self.ref_counter) == 1 {
-            self.unregister_metrics();
-        }
     }
 
     /// unregister metrics
@@ -82,7 +73,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(crossbeam::channel::TryRecvError::Empty) => Err(TryRecvError::Empty),
             Err(crossbeam::channel::TryRecvError::Disconnected) => {
-                self.unregister_metrics_if_last();
+                self.unregister_metrics();
                 Err(TryRecvError::Disconnected)
             }
         }
@@ -96,7 +87,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
             Err(RecvTimeoutError::Disconnected) => {
-                self.unregister_metrics_if_last();
+                self.unregister_metrics();
                 Err(RecvTimeoutError::Disconnected)
             }
         }
@@ -110,7 +101,7 @@ impl<T> MassaReceiver<T> {
             }
             Err(RecvTimeoutError::Timeout) => Err(RecvTimeoutError::Timeout),
             Err(RecvTimeoutError::Disconnected) => {
-                self.unregister_metrics_if_last();
+                self.unregister_metrics();
                 Err(RecvTimeoutError::Disconnected)
             }
         }
@@ -123,7 +114,7 @@ impl<T> MassaReceiver<T> {
                 Ok(msg)
             }
             Err(e) => {
-                self.unregister_metrics_if_last();
+                self.unregister_metrics();
                 Err(e)
             }
         }
@@ -141,60 +132,5 @@ impl<T> Deref for MassaReceiver<T> {
 impl<T> DerefMut for MassaReceiver<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.receiver
-    }
-}
-
-// Metrics are only registered in the default prometheus registry when the
-// `test-exports` feature is disabled (see `MassaChannel::new`), so these
-// registry-observing tests are gated to that build configuration.
-#[cfg(all(test, not(feature = "test-exports")))]
-mod tests {
-    use crate::MassaChannel;
-
-    /// Returns true if a metric family with the given name is currently
-    /// registered in the default prometheus registry.
-    fn metric_registered(name: &str) -> bool {
-        prometheus::gather().iter().any(|mf| mf.get_name() == name)
-    }
-
-    #[test]
-    fn disconnect_does_not_unregister_metrics_while_a_clone_is_alive() {
-        let chan_name = "massa_channel_test_disconnect_keeps_metrics".to_string();
-        let size_metric = format!("{}_channel_actual_size", chan_name);
-        let recv_metric = format!("{}_channel_total_receive", chan_name);
-
-        let (sender, receiver) = MassaChannel::new::<u8>(chan_name, None);
-        // Second live clone of the receiver.
-        let receiver2 = receiver.clone();
-
-        assert!(metric_registered(&size_metric));
-        assert!(metric_registered(&recv_metric));
-
-        // Disconnect the channel; every receiver clone now observes disconnection.
-        drop(sender);
-
-        // Hitting the disconnect branch on one clone must NOT tear down the
-        // metrics, because `receiver2` is still alive and using them.
-        assert!(receiver.recv().is_err());
-        assert!(
-            metric_registered(&size_metric),
-            "actual_size metric must stay registered while a clone is alive"
-        );
-        assert!(
-            metric_registered(&recv_metric),
-            "total_receive metric must stay registered while a clone is alive"
-        );
-
-        // Once the last clone is dropped, the metrics are unregistered.
-        drop(receiver);
-        drop(receiver2);
-        assert!(
-            !metric_registered(&size_metric),
-            "actual_size metric must be unregistered after the last clone drops"
-        );
-        assert!(
-            !metric_registered(&recv_metric),
-            "total_receive metric must be unregistered after the last clone drops"
-        );
     }
 }


### PR DESCRIPTION
## Summary
`MassaReceiver<T>` is `Clone`. When the channel disconnects, **every** clone observes the disconnection, but the `recv` / `recv_deadline` / `recv_timeout` / `try_recv` disconnect branches called `unregister_metrics()` unconditionally. The first clone to hit the disconnect therefore removed the `*_channel_actual_size` gauge and `*_channel_total_receive` counter from the prometheus registry while sibling clones were still alive and calling `update_metrics()` on them.

Addresses AI-report **Finding 18** (severity: minor).

## Fix
As shows the discussion below, the finding does not need any fix. We explained why in a doc comment, and that is all that PR updates.