### PR TITLE
fix(wallet): scope Wallet::save cleanup to managed wallet files only

### DIFF
--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -17,7 +17,7 @@ use massa_signature::{KeyPair, PublicKey};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -198,6 +198,32 @@ impl Wallet {
         self.keys.keys().copied().collect()
     }
 
+    /// Returns `true` if `path` is a wallet file managed by this module, i.e. a
+    /// `wallet_*.yaml` / `wallet_*.yml` file written by [`Wallet::save`].
+    ///
+    /// The stale-file cleanup in `save` must only ever remove such files so that
+    /// unrelated files living in the same directory (backups, exports, recovery
+    /// notes, other custody material, subdirectories, ...) are never deleted.
+    fn is_managed_wallet_file(path: &Path) -> bool {
+        if !path.is_file() {
+            return false;
+        }
+        let ext_ok = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| {
+                let e = e.to_ascii_lowercase();
+                e == "yaml" || e == "yml"
+            })
+            .unwrap_or(false);
+        let name_ok = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("wallet_"))
+            .unwrap_or(false);
+        ext_ok && name_ok
+    }
+
     /// Save the wallets in a directory, each wallet in a yaml file.
     pub fn save(&self) -> Result<(), WalletError> {
         let mut existing_keys: HashSet<PathBuf> = HashSet::new();
@@ -206,7 +232,12 @@ impl Wallet {
         } else {
             let read_dir = std::fs::read_dir(&self.wallet_path)?;
             for path in read_dir {
-                existing_keys.insert(path?.path());
+                let path = path?.path();
+                // Only track files we manage, so cleanup can never delete
+                // unrelated files that happen to sit in the wallet directory.
+                if Self::is_managed_wallet_file(&path) {
+                    existing_keys.insert(path);
+                }
             }
         }
         let mut persisted_keys: HashSet<PathBuf> = HashSet::new();
@@ -276,3 +307,38 @@ impl std::fmt::Display for Wallet {
 /// Test utils
 #[cfg(feature = "test-exports")]
 pub mod test_exports;
+
+#[cfg(all(test, feature = "test-exports"))]
+mod save_cleanup_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn save_only_removes_managed_wallet_files() {
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        // Unrelated files that must survive a save().
+        let notes = dir_path.join("notes.txt");
+        let backup = dir_path.join("backup.yaml"); // yaml, but not a wallet_ file
+        let stale = dir_path.join("wallet_stale.yaml"); // managed -> should be removed
+        std::fs::write(&notes, b"important recovery notes").unwrap();
+        std::fs::write(&backup, b"not: a-wallet").unwrap();
+        std::fs::write(&stale, b"stale: wallet").unwrap();
+
+        let wallet = Wallet {
+            keys: PreHashMap::default(),
+            wallet_path: dir_path.clone(),
+            password: "pw".to_string(),
+            chain_id: 0,
+        };
+        wallet.save().unwrap();
+
+        assert!(notes.exists(), "unrelated non-yaml file must be preserved");
+        assert!(backup.exists(), "non-wallet .yaml file must be preserved");
+        assert!(
+            !stale.exists(),
+            "stale managed wallet_*.yaml file must be removed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
`Wallet::save` deleted every file in the wallet directory that was not rewritten during the current save, without restricting deletion to wallet-owned files. Unrelated files stored alongside the wallet (backups, exports, recovery notes, other custody material) could be **silently deleted** during `save()` or an implicit save triggered by `add_keypairs`, risking permanent key/recovery-material loss.

Addresses AI-report **Finding 146** (severity: medium).

## Fix
Introduce `is_managed_wallet_file(path)` (a `wallet_*.yaml` / `wallet_*.yml` file, matching what `save` writes) and restrict both the scanned `existing_keys` set and the resulting deletion set to those files. Unrelated files and subdirectories are never considered for removal.

## Scope / safety
- Purely local wallet-file management. No consensus, wire-format, JSON-RPC, or gRPC surface is touched.
- Stale wallet files written by this module (`wallet_<addr>.yaml`) are still cleaned up exactly as before.

## Testing
- New unit test `save_only_removes_managed_wallet_files`: after `save()`, an unrelated `notes.txt` and a non-wallet `backup.yaml` are preserved while a stale `wallet_stale.yaml` is removed.
- `cargo test -p massa_wallet --features test-exports`: pass. `cargo clippy --all-targets`: clean. `cargo fmt`: clean.

## Checklist
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging (n/a)
* [x] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)