### PR TITLE
fix(wallet): verify decrypted keypair matches declared address on load

### DIFF
--- a/massa-wallet/src/error.rs
+++ b/massa-wallet/src/error.rs
@@ -26,4 +26,6 @@ pub enum WalletError {
     MassaCipherError(#[from] massa_cipher::CipherError),
     /// Version error: {0}
     VersionError(String),
+    /// Inconsistent wallet file: {0}
+    InconsistentWalletFile(String),
 }

--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -108,10 +108,21 @@ impl Wallet {
                             return Err(WalletError::VersionError("Invalid wallet/version matching: your wallet does not follow its version's secret key encoding format.".to_string()))
                         }
                     }
-                    keys.insert(
-                        Address::from_str(&wallet.address)?,
-                        KeyPair::from_bytes(&secret_key)?,
-                    );
+                    let keypair = KeyPair::from_bytes(&secret_key)?;
+                    // Do not trust the plaintext metadata: verify that the
+                    // decrypted keypair actually derives the declared address.
+                    // Otherwise a tampered wallet file could relabel encrypted
+                    // key material under a forged address, misbinding local
+                    // wallet state and address-based lookups.
+                    let declared_address = Address::from_str(&wallet.address)?;
+                    let derived_address = Address::from_public_key(&keypair.get_public_key());
+                    if derived_address != declared_address {
+                        return Err(WalletError::InconsistentWalletFile(format!(
+                            "wallet file declares address {} but the decrypted key derives {}",
+                            declared_address, derived_address
+                        )));
+                    }
+                    keys.insert(derived_address, keypair);
                 }
             }
             Ok(Wallet {
@@ -309,8 +320,9 @@ impl std::fmt::Display for Wallet {
 pub mod test_exports;
 
 #[cfg(all(test, feature = "test-exports"))]
-mod save_cleanup_tests {
+mod tests {
     use super::*;
+    use massa_signature::KeyPair;
     use tempfile::TempDir;
 
     #[test]
@@ -340,5 +352,36 @@ mod save_cleanup_tests {
             !stale.exists(),
             "stale managed wallet_*.yaml file must be removed"
         );
+    }
+
+    #[test]
+    fn honest_wallet_loads_and_tampered_address_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        // Create a wallet with a single keypair and persist it.
+        let mut wallet = Wallet::new(dir_path.clone(), "pw".to_string(), 0).unwrap();
+        let kp = KeyPair::generate(0).unwrap();
+        let addr = Address::from_public_key(&kp.get_public_key());
+        wallet.add_keypairs(vec![kp]).unwrap();
+
+        // An untampered reload succeeds and binds the right address.
+        let reloaded = Wallet::new(dir_path.clone(), "pw".to_string(), 0).unwrap();
+        assert!(reloaded.keys.contains_key(&addr));
+
+        // Tamper: relabel the declared address to an unrelated one while leaving
+        // the encrypted key material unchanged.
+        let file = dir_path.join(format!("wallet_{}.yaml", addr));
+        let content = std::fs::read(&file).unwrap();
+        let mut parsed: WalletFileFormat = serde_yaml::from_slice(&content).unwrap();
+        let other = Address::from_public_key(&KeyPair::generate(0).unwrap().get_public_key());
+        parsed.address = other.to_string();
+        std::fs::write(&file, serde_yaml::to_string(&parsed).unwrap()).unwrap();
+
+        // Loading the tampered file must be rejected rather than silently
+        // binding the key under the forged address.
+        let err = Wallet::new(dir_path, "pw".to_string(), 0)
+            .expect_err("a tampered declared address must be rejected");
+        assert!(matches!(err, WalletError::InconsistentWalletFile(_)));
     }
 }

--- a/massa-wallet/src/lib.rs
+++ b/massa-wallet/src/lib.rs
@@ -108,10 +108,21 @@ impl Wallet {
                             return Err(WalletError::VersionError("Invalid wallet/version matching: your wallet does not follow its version's secret key encoding format.".to_string()))
                         }
                     }
-                    keys.insert(
-                        Address::from_str(&wallet.address)?,
-                        KeyPair::from_bytes(&secret_key)?,
-                    );
+                    let keypair = KeyPair::from_bytes(&secret_key)?;
+                    // Do not trust the plaintext metadata: verify that the
+                    // decrypted keypair actually derives the declared address.
+                    // Otherwise a tampered wallet file could relabel encrypted
+                    // key material under a forged address, misbinding local
+                    // wallet state and address-based lookups.
+                    let declared_address = Address::from_str(&wallet.address)?;
+                    let derived_address = Address::from_public_key(&keypair.get_public_key());
+                    if derived_address != declared_address {
+                        return Err(WalletError::InconsistentWalletFile(format!(
+                            "wallet file declares address {} but the decrypted key derives {}",
+                            declared_address, derived_address
+                        )));
+                    }
+                    keys.insert(derived_address, keypair);
                 }
             }
             Ok(Wallet {
@@ -276,3 +287,41 @@ impl std::fmt::Display for Wallet {
 /// Test utils
 #[cfg(feature = "test-exports")]
 pub mod test_exports;
+
+#[cfg(all(test, feature = "test-exports"))]
+mod load_tests {
+    use super::*;
+    use massa_signature::KeyPair;
+    use tempfile::TempDir;
+
+    #[test]
+    fn honest_wallet_loads_and_tampered_address_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_path_buf();
+
+        // Create a wallet with a single keypair and persist it.
+        let mut wallet = Wallet::new(dir_path.clone(), "pw".to_string(), 0).unwrap();
+        let kp = KeyPair::generate(0).unwrap();
+        let addr = Address::from_public_key(&kp.get_public_key());
+        wallet.add_keypairs(vec![kp]).unwrap();
+
+        // An untampered reload succeeds and binds the right address.
+        let reloaded = Wallet::new(dir_path.clone(), "pw".to_string(), 0).unwrap();
+        assert!(reloaded.keys.contains_key(&addr));
+
+        // Tamper: relabel the declared address to an unrelated one while leaving
+        // the encrypted key material unchanged.
+        let file = dir_path.join(format!("wallet_{}.yaml", addr));
+        let content = std::fs::read(&file).unwrap();
+        let mut parsed: WalletFileFormat = serde_yaml::from_slice(&content).unwrap();
+        let other = Address::from_public_key(&KeyPair::generate(0).unwrap().get_public_key());
+        parsed.address = other.to_string();
+        std::fs::write(&file, serde_yaml::to_string(&parsed).unwrap()).unwrap();
+
+        // Loading the tampered file must be rejected rather than silently
+        // binding the key under the forged address.
+        let err = Wallet::new(dir_path, "pw".to_string(), 0)
+            .expect_err("a tampered declared address must be rejected");
+        assert!(matches!(err, WalletError::InconsistentWalletFile(_)));
+    }
+}


### PR DESCRIPTION
## Summary
`Wallet::new` decrypted each entry's key material and inserted it into `keys` under the **plaintext** YAML `address`, without verifying that the decrypted `KeyPair` actually derives that address. A tampered wallet file could relabel encrypted key material under a forged address, misbinding local wallet state and address-based lookups (local file-integrity / confusion issue).

Addresses AI-report **Finding 147** (severity: minor).

## Fix
Derive the address from the decrypted keypair's public key and:
- reject the file with a new `WalletError::InconsistentWalletFile` if it disagrees with the declared `address`;
- insert the entry under the derived (authenticated) address.

Since an address is the hash of the public key, this binds the map key to the real key material and also validates it against the file's label.

## Scope / safety
- Honest wallet files are unaffected: `save` always writes the derived address, so `declared == derived`.
- Purely local wallet loading. No consensus, wire-format, JSON-RPC, or gRPC surface is touched.

## Testing
- New unit test `honest_wallet_loads_and_tampered_address_is_rejected`: a freshly saved wallet reloads and binds the correct address; after rewriting the file's `Address` field to an unrelated address, `Wallet::new` returns `InconsistentWalletFile`.
- `cargo test -p massa_wallet --features test-exports`: pass. `cargo clippy --all-targets`: clean. `cargo fmt`: clean.

## Checklist
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging (n/a)
* [x] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)