### PR TITLE
fix(event-cache): don't lose stop signal when a final batch is queued

### DIFF
--- a/massa-event-cache/src/worker.rs
+++ b/massa-event-cache/src/worker.rs
@@ -41,20 +41,22 @@ impl EventCacheWriterThread {
             // lock input data
             let mut input_data_lock = self.input_data.1.lock();
 
+            // Only consume the shared input once there is something to do
+            // (events to flush and/or a stop request). Taking the whole input
+            // unconditionally used to consume the `stop` flag together with a
+            // pending batch of events and then drop it when returning early,
+            // which could make the writer wait forever after `stop()`.
+            if input_data_lock.events.is_empty() && !input_data_lock.stop {
+                self.input_data.0.wait(&mut input_data_lock);
+                continue;
+            }
+
             // take current input data, resetting it
-            let input_data: EventCacheWriterInputData = std::mem::take(&mut input_data_lock);
-
-            // Check if there is some input data
-            if !input_data.events.is_empty() {
-                return (input_data, false);
-            }
-
-            // if we need to stop, return None
-            if input_data.stop {
-                return (input_data, true);
-            }
-
-            self.input_data.0.wait(&mut input_data_lock);
+            let input_data: EventCacheWriterInputData = std::mem::take(&mut *input_data_lock);
+            // Propagate the (durable) stop flag alongside the taken events so a
+            // final queued batch is still flushed before the loop terminates.
+            let stop = input_data.stop;
+            return (input_data, stop);
         }
     }
 
@@ -67,16 +69,18 @@ impl EventCacheWriterThread {
                 input_data
             );
 
-            if stop {
-                // we need to stop
-                break;
-            }
-
-            {
+            // Always flush any queued events, even if this iteration also
+            // observed a stop request, so no final batch is silently lost.
+            if !input_data.events.is_empty() {
                 let mut lock = self.cache.write();
                 lock.insert_multi_it(input_data.events.into_iter());
                 // drop the lock as early as possible
                 drop(lock);
+            }
+
+            if stop {
+                // we need to stop
+                break;
             }
         }
     }
@@ -159,4 +163,75 @@ pub fn start_event_cache_writer_worker(
 
     // return the manager and controller pair
     (Box::new(manager), Box::new(controller))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::controller::EventCacheWriterInputData;
+    use crate::event_cache::EventCache;
+    use massa_models::config::{
+        MAX_EVENT_DATA_SIZE, MAX_EVENT_PER_OPERATION, MAX_OPERATIONS_PER_BLOCK,
+        MAX_RECURSIVE_CALLS_DEPTH, THREAD_COUNT,
+    };
+    use massa_models::output_event::{EventExecutionContext, SCOutputEvent};
+    use massa_models::slot::Slot;
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    fn sample_event() -> SCOutputEvent {
+        SCOutputEvent {
+            context: EventExecutionContext {
+                slot: Slot::new(1, 0),
+                block: None,
+                read_only: false,
+                index_in_slot: 0,
+                call_stack: Default::default(),
+                origin_operation_id: None,
+                is_final: true,
+                is_error: false,
+                deferred_call_id: None,
+                async_msg_id: None,
+            },
+            data: "shutdown-race event".to_string(),
+        }
+    }
+
+    /// Reproduces the lost-stop-signal race: a final batch of events is queued
+    /// *together with* a stop request. The writer must flush the batch and then
+    /// terminate, instead of consuming the stop flag with the batch and waiting
+    /// on the condvar forever.
+    #[test]
+    fn stop_is_not_lost_when_a_final_batch_is_queued() {
+        let tmp = TempDir::new().unwrap();
+        let cache = Arc::new(RwLock::new(EventCache::new(
+            tmp.path(),
+            1000,
+            300,
+            THREAD_COUNT,
+            MAX_RECURSIVE_CALLS_DEPTH,
+            MAX_EVENT_DATA_SIZE as u64,
+            MAX_EVENT_PER_OPERATION as u64,
+            MAX_OPERATIONS_PER_BLOCK as u64,
+            5000,
+        )));
+
+        let mut input = EventCacheWriterInputData::new();
+        input.events.push_back(sample_event());
+        input.stop = true;
+        let input_data = Arc::new((Condvar::new(), Mutex::new(input)));
+
+        let mut worker = EventCacheWriterThread::new(input_data, cache);
+        let handle = thread::spawn(move || worker.main_loop());
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !handle.is_finished() {
+            assert!(
+                Instant::now() < deadline,
+                "event cache writer thread did not stop after a stop request"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        handle.join().expect("event cache writer thread panicked");
+    }
 }


### PR DESCRIPTION
## Summary
`EventCacheWriterThread::wait_loop_event` consumed the whole shared input with `mem::take` (both `events` and the `stop` flag) and returned early whenever `events` was non-empty — **before** checking `stop`. If a final batch was already queued when `EventCacheWriterManagerImpl::stop()` set the flag, the writer flushed that batch, silently discarded the consumed `stop` flag, and then blocked on the condvar forever. `stop()` could then hang in `join()`, preventing clean node shutdown.

Addresses AI-report **Finding 37** (severity: minor).

## Fix
- `wait_loop_event` now waits on the condvar until there is actually something to do (`events` non-empty **or** `stop`), takes the input, and returns the taken `stop` flag alongside the events.
- `main_loop` always flushes any queued events first, then breaks if `stop` was observed — so a final batch is never lost and the thread always terminates after `stop()`.

## Scope / safety
Node-local shutdown/lifecycle behavior only. No consensus, wire-format, JSON-RPC, or gRPC surface is touched.

## Testing
- New regression test `stop_is_not_lost_when_a_final_batch_is_queued`: queues a batch together with `stop = true`, runs `main_loop` on a thread, and asserts it terminates within a timeout (would hang under the old logic).
- `cargo test -p massa_event_cache`: pass. `cargo clippy --all-targets`: clean. `cargo fmt`: clean.

## Checklist
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging (n/a)
* [x] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)