### PR TITLE
fix(bootstrap): don't spin the listener on persistent accept errors

### DIFF
--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -19,6 +19,26 @@ pub struct BootstrapTcpListener {
 
 pub struct BootstrapListenerStopHandle(pub(crate) Waker);
 
+/// Drain all currently-ready connections from `accept` into `out`.
+///
+/// The drain ends on the first error, whether it is `WouldBlock` (no more
+/// pending connections) or any other error such as a persistent `EMFILE` /
+/// `ENFILE`. Ending the drain on a non-`WouldBlock` error (instead of
+/// `continue`-ing) is what prevents a sticky listener-level failure from
+/// spinning `poll()` forever and starving the `STOP_LISTENER` token.
+fn drain_accept<S>(mut accept: impl FnMut() -> std::io::Result<S>, out: &mut Vec<S>) {
+    loop {
+        match accept() {
+            Ok(item) => out.push(item),
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
+            Err(e) => {
+                warn!("Error accepting connection in bootstrap: {:?}", e);
+                break;
+            }
+        }
+    }
+}
+
 pub enum PollEvent {
     NewConnections(Vec<(TcpStream, SocketAddr)>),
     Stop,
@@ -83,23 +103,21 @@ impl BootstrapTcpListener {
         // Process each event.
         for event in self.events.iter() {
             match event.token() {
-                NEW_CONNECTION => loop {
-                    match self.server.accept() {
-                        Ok((mut stream, remote_addr)) => {
-                            let _ = self.poll.registry().deregister(&mut stream);
-                            let stream: std::net::TcpStream = mio_stream_to_std(stream);
-                            stream.set_nonblocking(false)?;
-                            results.push((stream, remote_addr));
-                        }
-                        Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                            break;
-                        }
-                        Err(e) => {
-                            warn!("Error accepting connection in bootstrap: {:?}", e);
-                            continue;
-                        }
+                NEW_CONNECTION => {
+                    // Drain the currently-ready connections, borrowing only
+                    // `self.server`, then post-process them (which borrows
+                    // `self.poll`). The drain never spins on a persistent
+                    // accept error, so control always returns to the poller and
+                    // the STOP token can be serviced.
+                    let mut accepted = Vec::new();
+                    drain_accept(|| self.server.accept(), &mut accepted);
+                    for (mut stream, remote_addr) in accepted {
+                        let _ = self.poll.registry().deregister(&mut stream);
+                        let stream: std::net::TcpStream = mio_stream_to_std(stream);
+                        stream.set_nonblocking(false)?;
+                        results.push((stream, remote_addr));
                     }
-                },
+                }
                 STOP_LISTENER => {
                     return Ok(PollEvent::Stop);
                 }
@@ -115,5 +133,45 @@ impl BootstrapListenerStopHandle {
     /// Stop the bootstrap listener.
     pub fn stop(&self) -> Result<(), BootstrapError> {
         self.0.wake().map_err(BootstrapError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::drain_accept;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn drain_stops_on_persistent_error_instead_of_spinning() {
+        let mut calls = 0u32;
+        let mut out: Vec<u8> = Vec::new();
+        drain_accept(
+            || {
+                calls += 1;
+                // A persistent non-WouldBlock error (e.g. EMFILE/ENFILE).
+                Err::<u8, _>(Error::from(ErrorKind::Other))
+            },
+            &mut out,
+        );
+        assert_eq!(
+            calls, 1,
+            "a persistent accept error must break the drain, not loop forever"
+        );
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn drain_collects_ready_connections_until_would_block() {
+        let mut seq = vec![
+            Ok(1u8),
+            Ok(2u8),
+            Err(Error::from(ErrorKind::WouldBlock)),
+            Ok(3u8),
+        ]
+        .into_iter();
+        let mut out = Vec::new();
+        drain_accept(|| seq.next().unwrap(), &mut out);
+        // Stops at the WouldBlock, leaving the trailing item untouched.
+        assert_eq!(out, vec![1, 2]);
     }
 }


### PR DESCRIPTION
## Summary
`BootstrapTcpListener::poll` drained `self.server.accept()` in a loop that only broke on `WouldBlock`; every other error just logged a warning and `continue`d. A persistent listener-level failure (e.g. `EMFILE` / `ENFILE`) could spin this loop indefinitely, consuming CPU and — because control never returned to `mio::Poll` — preventing the `STOP_LISTENER` token from being serviced.

Addresses AI-report **Finding 7** (severity: minor).

## Fix
Extract the accept drain into a small `drain_accept` helper that ends on the first error, whether `WouldBlock` (no more pending connections) or any other error (sticky failure). Connection post-processing (deregister, convert to std, collect) now happens after the drain, which also keeps the `self.server` / `self.poll` borrows disjoint.

## Scope / safety
Node-local listener liveness only. No consensus, wire-format, JSON-RPC, or gRPC surface is touched. Normal accept behavior (drain until `WouldBlock`) is unchanged.

## Testing
- `drain_stops_on_persistent_error_instead_of_spinning`: a closure that always returns a non-`WouldBlock` error is called exactly once (no infinite loop).
- `drain_collects_ready_connections_until_would_block`: items are collected up to the first `WouldBlock`.
- `cargo test -p massa_bootstrap --lib`: pass (the unrelated `test_binders_multiple_send` is a pre-existing timing-sensitive test that passes in isolation). `cargo clippy --all-targets`: clean. `cargo fmt`: clean.

## Checklist
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging
* [x] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)