### PR TITLE
fix(bootstrap): keep ACL refresher alive when a list file fails to reload

### DIFF
--- a/massa-bootstrap/src/server.rs
+++ b/massa-bootstrap/src/server.rs
@@ -230,7 +230,16 @@ impl BootstrapServer<'_> {
                         Err(e) => return Err(BootstrapError::GeneralError(format!("update stopper error : {}", e))),
                     }
                 },
-                recv(ticker) -> _ => {list.update()?;},
+                recv(ticker) -> _ => {
+                    // A failed refresh (e.g. malformed JSON in an ACL file)
+                    // must not kill the updater: log it and keep the previously
+                    // loaded lists, retrying on the next tick. Propagating the
+                    // error here would stop all future reloads while the event
+                    // loop kept enforcing a stale ACL snapshot.
+                    if let Err(e) = list.update() {
+                        warn!("failed to refresh bootstrap white/black list, keeping previous lists: {}", e);
+                    }
+                },
             }
         }
     }
@@ -798,5 +807,41 @@ pub(crate) fn manage_bootstrap(
                 }
             },
         };
+    }
+}
+
+#[cfg(test)]
+mod updater_tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    fn updater_survives_a_malformed_acl_reload() {
+        let dir = TempDir::new().unwrap();
+        let white = dir.path().join("whitelist.json");
+        let black = dir.path().join("blacklist.json");
+        // Start from a valid (empty) blacklist so init succeeds.
+        std::fs::write(&black, "[]").unwrap();
+
+        let list = SharedWhiteBlackList::new(white, black.clone()).unwrap();
+        let (stop_tx, stop_rx) = crossbeam::channel::unbounded::<()>();
+        let handle = std::thread::spawn(move || {
+            BootstrapServer::run_updater(list, Duration::from_millis(20), stop_rx)
+        });
+
+        // Corrupt the file so subsequent periodic reloads fail to parse.
+        std::fs::write(&black, "{ not valid json ]").unwrap();
+        // Let several ticks elapse; the updater must keep running.
+        std::thread::sleep(Duration::from_millis(200));
+        assert!(
+            !handle.is_finished(),
+            "updater thread must survive a malformed ACL reload instead of dying"
+        );
+
+        // It must still stop cleanly on request.
+        stop_tx.send(()).unwrap();
+        let res = handle.join().expect("updater thread panicked");
+        assert!(res.is_ok(), "clean stop should return Ok, got {:?}", res);
     }
 }


### PR DESCRIPTION
## Summary
`run_updater` called `list.update()?` on every tick. A single failed refresh — e.g. malformed JSON in a whitelist/blacklist file (`WhiteBlackListInner::load_list` → `BootstrapError::InitListError`) — propagated out and **terminated the updater thread permanently**. The bootstrap event loop then kept enforcing the last cached ACL snapshot, with no further periodic reloads until process restart.

Addresses AI-report **Finding 16** (severity: minor).

## Fix
Catch the refresh error inside the tick arm, log it, and keep the previously loaded lists — retrying on the next tick. The stop path is unchanged.

## Scope / safety
Node-local ACL-refresh robustness only. No consensus, wire-format, JSON-RPC, or gRPC surface is touched. Enforcement already relied on the cached lists between ticks; this simply keeps refreshes going after a transient/bad file.

## Testing
- New regression test `updater_survives_a_malformed_acl_reload`: runs `run_updater` on a thread, corrupts the blacklist file, and asserts the thread is still alive after several ticks and still stops cleanly on request. (Under the old code the thread would have exited on the first bad reload.)
- `cargo test -p massa_bootstrap --lib`: pass. `cargo clippy --all-targets`: clean. `cargo fmt`: clean.

## Checklist
* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging
* [x] if the API has changed, update the API specification (n/a)

Made with [Cursor](https://cursor.com)