### PR TITLE
fix(protocol): use matching channel-capacity config for block retrieval/propagation channels

### DIFF
--- a/massa-protocol-worker/src/worker.rs
+++ b/massa-protocol-worker/src/worker.rs
@@ -114,11 +114,11 @@ pub fn create_protocol_controller(
         );
     let (sender_blocks_propagation_ext, receiver_blocks_propagation_ext) = MassaChannel::new(
         "blocks_propagation_ext".to_string(),
-        Some(config.max_size_channel_commands_retrieval_blocks),
+        Some(config.max_size_channel_commands_propagation_blocks),
     );
     let (sender_blocks_retrieval_ext, receiver_blocks_retrieval_ext) = MassaChannel::new(
         "blocks_retrieval_ext".to_string(),
-        Some(config.max_size_channel_commands_propagation_blocks),
+        Some(config.max_size_channel_commands_retrieval_blocks),
     );
     let (sender_connectivity_ext, receiver_connectivity_ext) = MassaChannel::new(
         "connectivity_ext".to_string(),


### PR DESCRIPTION
## Summary

`create_protocol_controller` initializes the block retrieval and block propagation
channels with **swapped** capacity fields from `ProtocolConfig`:

- `blocks_propagation_ext` was created with `max_size_channel_commands_retrieval_blocks`
- `blocks_retrieval_ext` was created with `max_size_channel_commands_propagation_blocks`

This wires each channel to the *other* channel's configured bound. It is a latent
correctness bug: if the two limits are ever configured to different values, the
retrieval and propagation channels would be sized incorrectly. In the shipped
codebase both limits currently happen to hold the same value, so there is no
present functional impact — this is a pure correctness fix that makes each channel
use the config field that matches its name and downstream usage.

## Change

Swap the two capacity fields so each channel uses its own limit.

## Testing

- `cargo build` / `cargo clippy` clean for `massa_protocol_worker`.
- No behavioural change with the current (equal) config values; channel capacity is
  not observable through a public API, so no dedicated unit test is added.

## Risk

None — the values are equal in the shipped config, and the change only relabels
which config field feeds which channel.

Tracking: finding F142.
