### PR TITLE
fix(protocol): consume default outbound slot on dial success, not failure

### DIFF
--- a/massa-protocol-worker/src/connectivity.rs
+++ b/massa-protocol-worker/src/connectivity.rs
@@ -368,7 +368,9 @@ pub(crate) fn start_connectivity_thread(
                                 // Default category
                                 None if connection_slots["default"] > 0 => {
                                     // In case the connection succeeds, we take a place in a slot
-                                    if try_connect_peer(*addr, &mut network_controller, &peer_db, &config).is_err() {
+                                    // (mirrors the special-category branch above: the slot is
+                                    // consumed and the address recorded on success, not failure).
+                                    if try_connect_peer(*addr, &mut network_controller, &peer_db, &config).is_ok() {
                                         if let Some(v) = connection_slots.get_mut("default") {
                                             *v = v.saturating_sub(1);
                                         }


### PR DESCRIPTION
## Summary

In `start_connectivity_thread`'s outbound dialing loop, the **default-category**
branch consumed a connection slot and recorded the address as connected on
`try_connect_peer(...).is_err()` — i.e. on **failure** — which is inverted.

Compare the special-category branch just above, which (correctly) consumes the slot
and records the address on `.is_ok()`.

Because of the inversion, for uncategorized peers:
- a **failed** dial wrongly consumed a slot and marked the peer connected, so the
  node could stop dialing while still under-connected;
- a **successful** dial did not consume a slot, so the node could exceed the intended
  outbound target for the default category.

## Change

Consume the default-category slot and record the address on **success** (`.is_ok()`),
mirroring the special-category branch.

## Testing

- `cargo build` / `cargo clippy` clean for `massa_protocol_worker`.
- The fix is a one-token control-flow correction inside the connectivity thread's
  `select!` loop; exercising it in isolation would require a full network-controller
  mock and connectivity-thread harness, so no dedicated unit test is added. The change
  is verified by direct comparison with the adjacent, correct special-category branch.

## Risk

Low — it aligns the default-category accounting with the already-correct
special-category accounting.

Tracking: finding F140.
