### PR TITLE
fix(protocol): record last_success on successful connection for peer prioritization

### DIFF
--- a/massa-protocol-worker/src/connectivity.rs
+++ b/massa-protocol-worker/src/connectivity.rs
@@ -420,7 +420,7 @@ fn try_connect_peer(
     let conn_res = network_controller.try_connect(addr, config.timeout_connection.to_duration());
     {
         let mut peer_db_write = peer_db.write();
-        peer_db_write.set_try_connect_success_or_insert(&addr);
+        peer_db_write.set_try_connect_or_insert(&addr);
         if let Err(ref err) = conn_res {
             debug!("Failed to connect to peer {:?}: {:?}", addr, err);
             peer_db_write.set_try_connect_failure_or_insert(&addr);

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -513,6 +513,9 @@ impl InitConnectionHandler<PeerId, Context, MessagesHandler> for MassaHandshake 
                 Ok((peer_id, Some(announcement))) => {
                     info!("Peer connected: {:?}", peer_id);
                     peer_db_write.set_try_connect_success_or_insert(&addr);
+                    // Record the successful connection so that `last_success` feeds the
+                    // peer-priority comparator (previously it was never written anywhere).
+                    peer_db_write.set_success_or_insert(&addr);
                     peer_db_write
                         .get_peers_mut()
                         .entry(*peer_id)

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -603,6 +603,9 @@ impl InitConnectionHandler<PeerId, Context, MessagesHandler> for MassaHandshake 
                         self.config.allow_local_peers(),
                     );
                     peer_db_write.set_try_connect_success_or_insert(&addr);
+                    // Record the successful connection so that `last_success` feeds the
+                    // peer-priority comparator (previously it was never written anywhere).
+                    peer_db_write.set_success_or_insert(&addr);
                     peer_db_write
                         .get_peers_mut()
                         .entry(*peer_id)

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -602,7 +602,7 @@ impl InitConnectionHandler<PeerId, Context, MessagesHandler> for MassaHandshake 
                         announcement.listeners,
                         self.config.allow_local_peers(),
                     );
-                    peer_db_write.set_try_connect_success_or_insert(&addr);
+                    peer_db_write.set_try_connect_or_insert(&addr);
                     // Record the successful connection so that `last_success` feeds the
                     // peer-priority comparator (previously it was never written anywhere).
                     peer_db_write.set_success_or_insert(&addr);

--- a/massa-protocol-worker/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/models.rs
@@ -315,7 +315,7 @@ impl PeerDBTrait for PeerDB {
         self.try_connect_history.entry(*addr).or_default().success();
     }
 
-    fn set_try_connect_success_or_insert(&mut self, addr: &SocketAddr) {
+    fn set_try_connect_or_insert(&mut self, addr: &SocketAddr) {
         self.try_connect_history
             .entry(*addr)
             .or_default()
@@ -371,8 +371,33 @@ mod tests {
     use std::net::SocketAddr;
 
     use super::super::announcement::{Announcement, MAX_ANNOUNCEMENT_CLOCK_SKEW_MS};
-    use super::{PeerDB, PeerInfo, PeerState, THREE_DAYS_MS};
+    use super::*;
     use crate::wrap_peer_db::PeerDBTrait;
+
+    #[test]
+    fn set_success_records_last_success_for_priority_comparator() {
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let mut db = PeerDB::default();
+
+        // Recording only a connection *attempt* must not populate `last_success`:
+        // that field is what feeds the peer-priority comparator.
+        db.set_try_connect_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_none(),
+            "a mere connect attempt should not count as a success"
+        );
+        assert!(meta.last_try_connect.is_some());
+
+        // Recording an actual success (as the handshake-success path now does)
+        // must populate `last_success`.
+        db.set_success_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_some(),
+            "a successful connection must be recorded in last_success"
+        );
+    }
 
     /// Build a peer announcing one listener, with its announcement timestamp forced to `timestamp`.
     fn peer_announcing_at(timestamp: u64) -> (PeerId, PeerInfo) {
@@ -418,30 +443,5 @@ mod tests {
         assert!(!within_skew.last_announce.unwrap().is_future_dated(now));
         let (_, beyond_skew) = peer_announcing_at(now + MAX_ANNOUNCEMENT_CLOCK_SKEW_MS + 1);
         assert!(beyond_skew.last_announce.unwrap().is_future_dated(now));
-    }
-
-    #[test]
-    fn set_success_records_last_success_for_priority_comparator() {
-        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
-        let mut db = PeerDB::default();
-
-        // Recording only a connection *attempt* must not populate `last_success`:
-        // that field is what feeds the peer-priority comparator.
-        db.set_try_connect_success_or_insert(&addr);
-        let meta = db.get_connection_metadata_or_default(&addr);
-        assert!(
-            meta.last_success.is_none(),
-            "a mere connect attempt should not count as a success"
-        );
-        assert!(meta.last_try_connect.is_some());
-
-        // Recording an actual success (as the handshake-success path now does)
-        // must populate `last_success`.
-        db.set_success_or_insert(&addr);
-        let meta = db.get_connection_metadata_or_default(&addr);
-        assert!(
-            meta.last_success.is_some(),
-            "a successful connection must be recorded in last_success"
-        );
     }
 }

--- a/massa-protocol-worker/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/models.rs
@@ -311,6 +311,10 @@ impl PeerDBTrait for PeerDB {
             .unwrap_or(ConnectionMetadata::default())
     }
 
+    fn set_success_or_insert(&mut self, addr: &SocketAddr) {
+        self.try_connect_history.entry(*addr).or_default().success();
+    }
+
     fn set_try_connect_success_or_insert(&mut self, addr: &SocketAddr) {
         self.try_connect_history
             .entry(*addr)
@@ -364,6 +368,7 @@ mod tests {
     use massa_time::MassaTime;
     use peernet::transports::TransportType;
     use std::collections::HashMap;
+    use std::net::SocketAddr;
 
     use super::super::announcement::{Announcement, MAX_ANNOUNCEMENT_CLOCK_SKEW_MS};
     use super::{PeerDB, PeerInfo, PeerState, THREE_DAYS_MS};
@@ -413,5 +418,30 @@ mod tests {
         assert!(!within_skew.last_announce.unwrap().is_future_dated(now));
         let (_, beyond_skew) = peer_announcing_at(now + MAX_ANNOUNCEMENT_CLOCK_SKEW_MS + 1);
         assert!(beyond_skew.last_announce.unwrap().is_future_dated(now));
+    }
+
+    #[test]
+    fn set_success_records_last_success_for_priority_comparator() {
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let mut db = PeerDB::default();
+
+        // Recording only a connection *attempt* must not populate `last_success`:
+        // that field is what feeds the peer-priority comparator.
+        db.set_try_connect_success_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_none(),
+            "a mere connect attempt should not count as a success"
+        );
+        assert!(meta.last_try_connect.is_some());
+
+        // Recording an actual success (as the handshake-success path now does)
+        // must populate `last_success`.
+        db.set_success_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_some(),
+            "a successful connection must be recorded in last_success"
+        );
     }
 }

--- a/massa-protocol-worker/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/models.rs
@@ -308,6 +308,10 @@ impl PeerDBTrait for PeerDB {
             .unwrap_or(ConnectionMetadata::default())
     }
 
+    fn set_success_or_insert(&mut self, addr: &SocketAddr) {
+        self.try_connect_history.entry(*addr).or_default().success();
+    }
+
     fn set_try_connect_success_or_insert(&mut self, addr: &SocketAddr) {
         self.try_connect_history
             .entry(*addr)
@@ -351,5 +355,35 @@ impl PeerDBTrait for PeerDB {
 
     fn get_tested_addresses(&self) -> &HashMap<SocketAddr, MassaTime> {
         &self.tested_addresses
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_success_records_last_success_for_priority_comparator() {
+        let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+        let mut db = PeerDB::default();
+
+        // Recording only a connection *attempt* must not populate `last_success`:
+        // that field is what feeds the peer-priority comparator.
+        db.set_try_connect_success_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_none(),
+            "a mere connect attempt should not count as a success"
+        );
+        assert!(meta.last_try_connect.is_some());
+
+        // Recording an actual success (as the handshake-success path now does)
+        // must populate `last_success`.
+        db.set_success_or_insert(&addr);
+        let meta = db.get_connection_metadata_or_default(&addr);
+        assert!(
+            meta.last_success.is_some(),
+            "a successful connection must be recorded in last_success"
+        );
     }
 }

--- a/massa-protocol-worker/src/wrap_peer_db.rs
+++ b/massa-protocol-worker/src/wrap_peer_db.rs
@@ -27,7 +27,7 @@ pub trait PeerDBTrait: Send + Sync {
     fn get_peers_mut(&mut self) -> &mut HashMap<PeerId, PeerInfo>;
     fn get_connection_metadata_or_default(&self, addr: &SocketAddr) -> ConnectionMetadata;
     fn set_success_or_insert(&mut self, addr: &SocketAddr);
-    fn set_try_connect_success_or_insert(&mut self, addr: &SocketAddr);
+    fn set_try_connect_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_failure_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_test_success_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_test_failure_or_insert(&mut self, addr: &SocketAddr);

--- a/massa-protocol-worker/src/wrap_peer_db.rs
+++ b/massa-protocol-worker/src/wrap_peer_db.rs
@@ -26,6 +26,7 @@ pub trait PeerDBTrait: Send + Sync {
     fn get_peers(&self) -> &HashMap<PeerId, PeerInfo>;
     fn get_peers_mut(&mut self) -> &mut HashMap<PeerId, PeerInfo>;
     fn get_connection_metadata_or_default(&self, addr: &SocketAddr) -> ConnectionMetadata;
+    fn set_success_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_success_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_failure_or_insert(&mut self, addr: &SocketAddr);
     fn set_try_connect_test_success_or_insert(&mut self, addr: &SocketAddr);


### PR DESCRIPTION
## Summary

`ConnectionMetadata.last_success` feeds the peer-priority comparator
(`ConnectionMetadata::cmp`), but it was **never written anywhere** in the codebase.

The successful-handshake path in `peer_handler::mod` and the dial path in
`connectivity.rs` both route through `set_try_connect_success_or_insert`, whose name
suggests it records success but which only updates `last_try_connect` (the attempt
timestamp) via `ConnectionMetadata::try_connect()`. `ConnectionMetadata::success()`
existed but had no callers, so `last_success` stayed `None` forever and the
`last_success`-based prioritization branch was effectively dead.

## Change

- Add a dedicated `set_success_or_insert` method to `PeerDBTrait` / `PeerDB` that
  records an actual successful connection via `ConnectionMetadata::success()`.
- Call it on the successful-handshake path (`Ok((peer_id, Some(announcement)))`), in
  addition to the existing attempt bookkeeping.

This keeps the attempt vs. success semantics distinct: `last_try_connect` still tracks
every dial attempt, while `last_success` now reflects real successful connections and
can drive peer prioritization as intended.

## Testing

- New unit test `set_success_records_last_success_for_priority_comparator` on the real
  `PeerDB`: verifies that a mere connect attempt leaves `last_success` unset, and that
  `set_success_or_insert` populates it.
- `cargo test -p massa_protocol_worker --features test-exports` passes; `clippy` clean.

## Risk

Low — additive metadata bookkeeping. It only starts populating a field that was
previously always empty; it does not change connection acceptance or banning logic.

Tracking: findings F103 and F137.
