### PR TITLE
fix(protocol): don't panic on startup when initial peer set exceeds channel capacity

### DIFF
--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -232,7 +232,16 @@ impl PeerManagementHandler {
                     &mut message,
                 )
                 .unwrap();
-            sender_msg.try_send((*peer_id, message)).unwrap();
+            // The initial peer set is the union of the locally configured peers and the
+            // network-provided bootstrap peers, so it can exceed the channel capacity.
+            // Dropping an excess peer here must not panic (and abort) node startup: the
+            // peer can still be (re)discovered later through normal peer exchange.
+            if let Err(err) = sender_msg.try_send((*peer_id, message)) {
+                warn!(
+                    "could not enqueue initial peer {} for the peer-management thread: {}",
+                    peer_id, err
+                );
+            }
         }
 
         Self {


### PR DESCRIPTION
## Summary

In `PeerManagementHandler::new`, the initial peer set — the union of locally
configured `initial_peers` and network-provided `bootstrap_peers` — is pushed into a
**bounded** channel with `sender_msg.try_send(...).unwrap()`, one message per peer.

There is no check that the merged peer count fits
`max_size_channel_network_to_peer_handler`. If the combined list exceeds the channel
capacity, `try_send` returns `Full`, the `unwrap()` panics, and because this runs on
the node's startup path the node can fail to join the network.

## Change

Replace the `unwrap()` with graceful handling: on a `try_send` error, log a warning
and skip that peer. Dropping an excess peer at startup is safe — peers are
(re)discovered through normal peer exchange — and it must not abort node startup.

## Testing

- `cargo build` / `cargo clippy` clean for `massa_protocol_worker`.
- The change is a localized `unwrap()` → error-logging conversion inside a constructor
  that spawns the peer-management thread; reproducing channel saturation deterministically
  would require a full handler harness, so no dedicated unit test is added.

## Risk

Low — the only behavioural change is that an over-capacity initial peer list now logs
and continues instead of panicking. Under normal configuration the channel is not
saturated and behaviour is unchanged.

Tracking: finding F139.
