### PR TITLE
fix(execution): cancel worker-local readonly queue on shutdown

### DIFF
--- a/massa-execution-worker/src/worker.rs
+++ b/massa-execution-worker/src/worker.rs
@@ -231,6 +231,12 @@ impl ExecutionThread {
         let cancel_err = ExecutionError::ChannelError(
             "readonly execution cancelled because the execution worker is closing".into(),
         );
+        // Requests already handed off from the shared input into the worker-local queue
+        // (e.g. during the final loop iteration before `stop`) must be cancelled too:
+        // `RequestQueue` does not cancel on drop, so otherwise their `resp_tx` is dropped
+        // silently and callers see a generic channel-readout error instead of this clean
+        // worker-closing cancellation.
+        self.readonly_requests.cancel(cancel_err.clone());
         self.input_data
             .1
             .lock()


### PR DESCRIPTION
## Summary

`ExecutionThread::main_loop()` moves newly received read-only requests from the shared
`input_data` into the worker-local `self.readonly_requests` queue (via
`update_readonly_requests`) **before** it checks the `stop` flag. When shutdown is
triggered in that same iteration, the thread breaks out of the loop and the cleanup
code only cancels the shared queue:

```rust
self.input_data.1.lock().take().readonly_requests.cancel(cancel_err);
```

Any requests already transferred into `self.readonly_requests` are never explicitly
cancelled. Because `RequestQueue` does not cancel on drop, their `resp_tx` is dropped
silently, so `ExecutionControllerImpl::execute_readonly_request()` surfaces the generic
`readonly execution response channel readout failed` error instead of the intended
worker-closing cancellation error.

## Change

During shutdown cleanup, also cancel the worker-local `self.readonly_requests` queue
with the same worker-closing error, before cancelling the shared input queue.

## Testing

- `cargo build` / `cargo clippy` clean for `massa_execution_worker`.
- The change lives in the worker's shutdown path (which requires a fully wired
  `ExecutionThread` with config/state/selector to exercise), so no bespoke unit test is
  added; the fix simply reuses the existing cancellation error for the second queue.

## Risk

Low — purely additive cleanup on shutdown; it only converts a silent channel drop into
an explicit cancellation with a clear error. Severity: info.

Tracking: finding F51.
