### PR TITLE
[F69] gRPC datastore entry queries silently drop malformed filters

### DIFF
--- a/massa-grpc/src/private.rs
+++ b/massa-grpc/src/private.rs
@@ -16,7 +16,6 @@ use massa_proto_rs::massa::model::v1 as grpc_model;
 use massa_protocol_exports::{PeerConnectionType, PeerId};
 use massa_signature::KeyPair;
 use massa_time::MassaTime;
-use tracing::warn;
 // use massa_proto_rs::massa::model::v1 "add_to_bootstrap_blacklist"as grpc_model;
 
 /// Add IP addresses to node bootstrap blacklist
@@ -29,19 +28,16 @@ pub(crate) fn add_to_bootstrap_blacklist(
     let ips = inner_req
         .ips
         .into_iter()
-        .filter_map(|ip| match IpAddr::from_str(&ip) {
-            Ok(ip_addr) => Some(ip_addr),
-            Err(e) => {
-                warn!("error when parsing address : {}", e);
-                None
-            }
+        .map(|ip| {
+            IpAddr::from_str(&ip)
+                .map_err(|_| GrpcError::InvalidArgument(format!("invalid ip address: {}", ip)))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     if let Some(bs_list) = &grpc.bs_white_black_list {
-        if let Err(e) = bs_list.add_ips_to_blacklist(ips) {
-            warn!("error when adding ips to bootstrap blacklist : {}", e)
-        }
+        bs_list
+            .add_ips_to_blacklist(ips)
+            .map_err(|e| GrpcError::InternalServerError(e.to_string()))?;
     }
 
     Ok(grpc_api::AddToBootstrapBlacklistResponse {})
@@ -56,19 +52,16 @@ pub(crate) fn add_to_bootstrap_whitelist(
     let ips = inner_req
         .ips
         .into_iter()
-        .filter_map(|ip| match IpAddr::from_str(&ip) {
-            Ok(ip_addr) => Some(ip_addr),
-            Err(e) => {
-                warn!("error when parsing address : {}", e);
-                None
-            }
+        .map(|ip| {
+            IpAddr::from_str(&ip)
+                .map_err(|_| GrpcError::InvalidArgument(format!("invalid ip address: {}", ip)))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     if let Some(bs_list) = &grpc.bs_white_black_list {
-        if let Err(e) = bs_list.add_ips_to_whitelist(ips) {
-            warn!("error when adding ips to bootstrap whitelist : {}", e)
-        }
+        bs_list
+            .add_ips_to_whitelist(ips)
+            .map_err(|e| GrpcError::InternalServerError(e.to_string()))?;
     }
 
     Ok(grpc_api::AddToBootstrapWhitelistResponse {})
@@ -338,19 +331,16 @@ pub(crate) fn remove_from_bootstrap_blacklist(
     let ips = inner_req
         .ips
         .into_iter()
-        .filter_map(|ip| match IpAddr::from_str(&ip) {
-            Ok(ip_addr) => Some(ip_addr),
-            Err(e) => {
-                warn!("error when parsing address : {}", e);
-                None
-            }
+        .map(|ip| {
+            IpAddr::from_str(&ip)
+                .map_err(|_| GrpcError::InvalidArgument(format!("invalid ip address: {}", ip)))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     if let Some(bs_list) = &grpc.bs_white_black_list {
-        if let Err(e) = bs_list.remove_ips_from_blacklist(ips) {
-            warn!("error when removing ips to bootstrap blacklist : {}", e)
-        }
+        bs_list
+            .remove_ips_from_blacklist(ips)
+            .map_err(|e| GrpcError::InternalServerError(e.to_string()))?;
     }
 
     Ok(grpc_api::RemoveFromBootstrapBlacklistResponse {})
@@ -364,19 +354,16 @@ pub(crate) fn remove_from_bootstrap_whitelist(
     let ips = inner_req
         .ips
         .into_iter()
-        .filter_map(|ip| match IpAddr::from_str(&ip) {
-            Ok(ip_addr) => Some(ip_addr),
-            Err(e) => {
-                warn!("error when parsing address : {}", e);
-                None
-            }
+        .map(|ip| {
+            IpAddr::from_str(&ip)
+                .map_err(|_| GrpcError::InvalidArgument(format!("invalid ip address: {}", ip)))
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     if let Some(bs_list) = &grpc.bs_white_black_list {
-        if let Err(e) = bs_list.remove_ips_from_whitelist(ips) {
-            warn!("error when removing ips to bootstrap whitelist : {}", e)
-        }
+        bs_list
+            .remove_ips_from_whitelist(ips)
+            .map_err(|e| GrpcError::InternalServerError(e.to_string()))?;
     }
 
     Ok(grpc_api::RemoveFromBootstrapWhitelistResponse {})

--- a/massa-grpc/src/public.rs
+++ b/massa-grpc/src/public.rs
@@ -254,18 +254,20 @@ pub(crate) fn get_datastore_entries(
     let filters: Vec<(Address, Vec<u8>)> = inner_req
         .filters
         .into_iter()
-        .filter_map(|filter| {
-            filter.filter.and_then(|filter| match filter {
+        .map(|filter| {
+            let filter = filter
+                .filter
+                .ok_or_else(|| GrpcError::InvalidArgument("no filter provided".to_string()))?;
+            match filter {
                 grpc_api::get_datastore_entry_filter::Filter::AddressKey(addrs) => {
-                    if let Ok(add) = &Address::from_str(&addrs.address) {
-                        Some((*add, addrs.key))
-                    } else {
-                        None
-                    }
+                    let add = Address::from_str(&addrs.address).map_err(|_| {
+                        GrpcError::InvalidArgument(format!("invalid address: {}", addrs.address))
+                    })?;
+                    Ok((add, addrs.key))
                 }
-            })
+            }
         })
-        .collect();
+        .collect::<Result<Vec<(Address, Vec<u8>)>, GrpcError>>()?;
 
     let entries = grpc
         .execution_controller


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

[gRPC datastore entry queries silently drop malformed filters
](https://github.com/massalabs/massa/issues/5084)