### PR TITLE
[F74] gRPC new_blocks silently skips lagged blocks

### DIFF
--- a/massa-grpc/src/stream/new_blocks.rs
+++ b/massa-grpc/src/stream/new_blocks.rs
@@ -78,7 +78,15 @@ pub(crate) async fn new_blocks(
                                 }
 
                             },
-                            Err(e) => error!("error on receive new block : {}", e)
+                            Err(e) => {
+                                // fail closed like the websocket path: notify the client
+                                // that blocks were missed so it can reconnect and resync
+                                error!("error on receive new block : {}", e);
+                                if let Err(e) = tx.send(Err(tonic::Status::data_loss(format!("error on receive new block: {}", e)))).await {
+                                    error!("failed to send back NewBlocks error response: {}", e);
+                                }
+                                break;
+                            }
                         }
                     },
                     res = in_stream.next() => {
@@ -191,7 +199,15 @@ pub(crate) async fn new_blocks_server(
                                }
                            }
                        },
-                       Err(e) => error!("error on receive new block : {}", e),
+                       Err(e) => {
+                           // fail closed like the websocket path: notify the client
+                           // that blocks were missed so it can reconnect and resync
+                           error!("error on receive new block : {}", e);
+                           if let Err(e) = tx.send(Err(tonic::Status::data_loss(format!("error on receive new block: {}", e)))).await {
+                               error!("failed to send back NewBlocks error response: {}", e);
+                           }
+                           break;
+                       }
                     }
                 },
                 // Execute the code block whenever the timer ticks


### PR DESCRIPTION
subscriptions fail closed

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification