### PR TITLE
[F75] gRPC operation stream subscribes before handshake

### DIFF
--- a/massa-grpc/src/stream/new_operations.rs
+++ b/massa-grpc/src/stream/new_operations.rs
@@ -39,8 +39,8 @@ pub(crate) async fn new_operations(
     let (tx, rx) = tokio::sync::mpsc::channel(grpc.grpc_config.max_channel_size);
     // Get the inner stream from the request
     let mut in_stream = request.into_inner();
-    // Subscribe to the new operations channel
-    let mut subscriber = grpc.pool_broadcasts.operation_sender.subscribe();
+    // Clone the new operations channel sender to subscribe from the spawned task
+    let operation_sender = grpc.pool_broadcasts.operation_sender.clone();
     // Clone grpc to be able to use it in the spawned task
     // let grpc = grpc.clone();
 
@@ -61,6 +61,11 @@ pub(crate) async fn new_operations(
                         return;
                     }
                 };
+
+            // Subscribe to the new operations channel only once the initial
+            // filters are known, so that operations broadcast before the
+            // handshake are not buffered and replayed
+            let mut subscriber = operation_sender.subscribe();
 
             loop {
                 select! {

--- a/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
+++ b/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
@@ -42,21 +42,32 @@ pub(crate) async fn new_slot_abi_call_stacks(
     // Extract the incoming stream of abi call stacks messages
     let mut in_stream = request.into_inner();
 
-    // Subscribe to the new slot execution events channel
+    // Clone the slot execution traces channel sender to subscribe from the spawned task
     #[cfg(feature = "execution-trace")]
-    let mut subscriber = grpc
-        .execution_channels
-        .slot_execution_traces_sender
-        .subscribe();
-    #[cfg(not(feature = "execution-trace"))]
-    let (mut subscriber, _receiver) = {
-        let (subscriber_, receiver) =
-            tokio::sync::broadcast::channel::<(SlotAbiCallStack, bool)>(0);
-        (subscriber_.subscribe(), receiver)
-    };
+    let traces_sender = grpc.execution_channels.slot_execution_traces_sender.clone();
 
     tokio::spawn(async move {
-        let mut finality = FinalityLevel::Unspecified;
+        // Wait for the first request to establish the finality level before
+        // subscribing, so that no traces are forwarded before the client's
+        // selection is known
+        let mut finality: FinalityLevel = match in_stream.next().await {
+            Some(Ok(message)) => message.finality_level(),
+            _ => {
+                error!("empty request");
+                return;
+            }
+        };
+
+        // Subscribe to the new slot execution events channel
+        #[cfg(feature = "execution-trace")]
+        let mut subscriber = traces_sender.subscribe();
+        #[cfg(not(feature = "execution-trace"))]
+        let (mut subscriber, _receiver) = {
+            let (subscriber_, receiver) =
+                tokio::sync::broadcast::channel::<(SlotAbiCallStack, bool)>(0);
+            (subscriber_.subscribe(), receiver)
+        };
+
         loop {
             select! {
                 // Receive a new slot execution traces from the subscriber


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification