### PR TITLE
ci: drop macOS from full test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
   #         save-if: ${{ github.ref_name == 'main' }}
   #     - run: cargo xtask check_gas_cost_definitions
 
-  # Full cross-platform tests required to merge on main branch
+  # Full tests required to merge on main branch (Linux; macOS covered by CD binary builds)
   full:
     name: full
     needs: sanity
@@ -143,7 +143,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macOS-latest
+          # - macOS-latest  # disabled: GitHub macOS runners ~10x Linux cost; keep macOS for CD binary builds only
           # - windows-latest
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
## Summary
- Remove `macOS-latest` from the CI `full` job matrix (Linux-only tests on PRs/merges).
- Leave CD binary builds (including macOS sign/notarize) unchanged.

## Why
Org Actions analysis: macOS was ~$640 YTD gross, mostly from running the full Rust test suite on every PR. macOS runners cost ~10× Linux. `p-layer` already made this change in May.

## Test plan
- [ ] CI passes on this PR (Linux `full` only)
- [ ] Confirm `cd.yml` still lists macOS matrix entries for releases

Made with [Cursor](https://cursor.com)