### PR TITLE
[f123] fix O(n) prune scan in operation propagation by tracking a run…

### DIFF
--- a/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/propagation.rs
@@ -33,6 +33,9 @@ struct PropagationThread {
     active_connections: Box<dyn ActiveConnectionsTrait>,
     // times at which previous ops were announced
     stored_for_propagation: VecDeque<(std::time::Instant, PreHashSet<OperationId>)>,
+    // running total number of operations held in `stored_for_propagation`, maintained
+    // incrementally so pruning does not need to scan the whole queue on every call
+    stored_ops_count: usize,
     op_storage: Storage,
     next_batch: PreHashSet<OperationId>,
     config: ProtocolConfig,
@@ -61,6 +64,8 @@ impl PropagationThread {
 
                             // add to propagation storage
                             let new_ops = operations.get_op_refs().clone();
+                            self.stored_ops_count =
+                                self.stored_ops_count.saturating_add(new_ops.len());
                             self.stored_for_propagation
                                 .push_back((std::time::Instant::now(), new_ops.clone()));
                             self.op_storage.extend(operations);
@@ -103,16 +108,42 @@ impl PropagationThread {
 
     /// Prune the list of operations kept for propagation.
     fn prune_propagation_storage(&mut self) {
+        let removed = Self::prune_stored_for_propagation(
+            &mut self.stored_for_propagation,
+            &mut self.stored_ops_count,
+            self.config.max_operations_propagation_time.to_duration(),
+            self.config.max_ops_kept_for_propagation,
+        );
+
+        // remove from storage
+        self.op_storage.drop_operation_refs(&removed);
+    }
+
+    /// Remove expired and excess operation batches from the propagation queue,
+    /// keeping `stored_ops_count` in sync with the total number of queued operations.
+    ///
+    /// `stored_ops_count` is maintained incrementally (updated here on removal and by
+    /// the caller on insertion) so that pruning costs O(number of removed batches)
+    /// instead of scanning the whole queue on every call. This prevents an attacker
+    /// from making each propagation command increasingly expensive by flooding the
+    /// queue with many tiny batches.
+    ///
+    /// Returns the set of operation ids that were removed from the queue.
+    fn prune_stored_for_propagation(
+        stored_for_propagation: &mut VecDeque<(std::time::Instant, PreHashSet<OperationId>)>,
+        stored_ops_count: &mut usize,
+        max_operations_propagation_time: std::time::Duration,
+        max_ops_kept_for_propagation: usize,
+    ) -> PreHashSet<OperationId> {
         let mut removed = PreHashSet::default();
 
         // remove expired
-        let max_op_prop_time = self.config.max_operations_propagation_time.to_duration();
-        while let Some((t, _)) = self.stored_for_propagation.front() {
-            if t.elapsed() > max_op_prop_time {
-                let (_, op_ids) = self
-                    .stored_for_propagation
+        while let Some((t, _)) = stored_for_propagation.front() {
+            if t.elapsed() > max_operations_propagation_time {
+                let (_, op_ids) = stored_for_propagation
                     .pop_front()
                     .expect("there should be at least one element, checked above");
+                *stored_ops_count = stored_ops_count.saturating_sub(op_ids.len());
                 removed.extend(op_ids);
             } else {
                 break;
@@ -122,23 +153,16 @@ impl PropagationThread {
         // Cap cache size
         // Note that we directly remove batches of operations, not individual operations
         // to favor simplicity and performance over precision.
-        let mut excess_count = self
-            .stored_for_propagation
-            .iter()
-            .map(|(_, ops)| ops.len())
-            .sum::<usize>()
-            .saturating_sub(self.config.max_ops_kept_for_propagation);
-        while excess_count > 0 {
-            if let Some((_t, op_ids)) = self.stored_for_propagation.pop_front() {
-                excess_count = excess_count.saturating_sub(op_ids.len());
+        while *stored_ops_count > max_ops_kept_for_propagation {
+            if let Some((_t, op_ids)) = stored_for_propagation.pop_front() {
+                *stored_ops_count = stored_ops_count.saturating_sub(op_ids.len());
                 removed.extend(op_ids);
             } else {
                 break;
             }
         }
 
-        // remove from storage
-        self.op_storage.drop_operation_refs(&removed);
+        removed
     }
 
     fn announce_ops(&mut self) {
@@ -218,6 +242,7 @@ pub fn start_propagation_thread(
                 stored_for_propagation: VecDeque::with_capacity(
                     config.max_ops_kept_for_propagation,
                 ),
+                stored_ops_count: 0,
                 op_storage,
                 next_batch: PreHashSet::with_capacity(
                     config
@@ -233,4 +258,95 @@ pub fn start_propagation_thread(
             propagation_thread.run();
         })
         .expect("OS failed to start operation propagation thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use massa_hash::Hash;
+    use massa_models::secure_share::Id;
+    use std::time::{Duration, Instant};
+
+    fn op_id(i: u64) -> OperationId {
+        OperationId::new(Hash::compute_from(&i.to_be_bytes()))
+    }
+
+    /// Push a batch of operations, mirroring the accounting done by the propagation
+    /// thread on `PropagateOperations` (increment the running count, then push).
+    fn push_batch(
+        queue: &mut VecDeque<(Instant, PreHashSet<OperationId>)>,
+        count: &mut usize,
+        ops: impl IntoIterator<Item = OperationId>,
+    ) {
+        let ops: PreHashSet<OperationId> = ops.into_iter().collect();
+        *count = count.saturating_add(ops.len());
+        queue.push_back((Instant::now(), ops));
+    }
+
+    /// The ground-truth op count, computed by scanning the whole queue (the O(n)
+    /// operation the running count is meant to replace).
+    fn real_count(queue: &VecDeque<(Instant, PreHashSet<OperationId>)>) -> usize {
+        queue.iter().map(|(_, ops)| ops.len()).sum()
+    }
+
+    /// A flood of tiny (single-op) batches must stay bounded by the op cap, and the
+    /// running count must stay exact so pruning never falls back to scanning.
+    #[test]
+    fn running_count_stays_exact_and_caps_total_ops() {
+        let mut queue = VecDeque::new();
+        let mut count = 0usize;
+        let max_ops = 100;
+        let never_expires = Duration::from_secs(3600);
+
+        for i in 0..1000u64 {
+            push_batch(&mut queue, &mut count, [op_id(i)]);
+            let removed = PropagationThread::prune_stored_for_propagation(
+                &mut queue,
+                &mut count,
+                never_expires,
+                max_ops,
+            );
+
+            // running count must always match the ground truth
+            assert_eq!(count, real_count(&queue));
+            // once the cap is reached, each new 1-op batch evicts exactly one old batch
+            if i >= max_ops as u64 {
+                assert_eq!(removed.len(), 1);
+            }
+        }
+
+        // total ops (== queue length for 1-op batches) stays bounded by the cap
+        assert_eq!(count, max_ops);
+        assert_eq!(queue.len(), max_ops);
+        assert_eq!(count, real_count(&queue));
+    }
+
+    /// Expired batches are dropped and the running count is decremented accordingly.
+    #[test]
+    fn prune_removes_expired_batches_and_updates_count() {
+        let mut queue = VecDeque::new();
+        let mut count = 0usize;
+
+        // a batch inserted "in the past", already older than the propagation time
+        let expired: PreHashSet<OperationId> = [op_id(1), op_id(2)].into_iter().collect();
+        count = count.saturating_add(expired.len());
+        queue.push_back((Instant::now() - Duration::from_secs(60), expired));
+
+        // a fresh batch that must be kept
+        push_batch(&mut queue, &mut count, [op_id(3)]);
+
+        let removed = PropagationThread::prune_stored_for_propagation(
+            &mut queue,
+            &mut count,
+            Duration::from_secs(30),
+            1_000,
+        );
+
+        assert_eq!(removed.len(), 2);
+        assert!(removed.contains(&op_id(1)));
+        assert!(removed.contains(&op_id(2)));
+        assert_eq!(queue.len(), 1);
+        assert_eq!(count, 1);
+        assert_eq!(count, real_count(&queue));
+    }
 }


### PR DESCRIPTION
…ning op count

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification