### PR TITLE
[F78] bind slot transfers to the trace broadcast event to avoid hybri…

### DIFF
--- a/massa-execution-exports/src/channels.rs
+++ b/massa-execution-exports/src/channels.rs
@@ -3,7 +3,7 @@
 use crate::types::SlotExecutionOutput;
 
 #[cfg(feature = "execution-trace")]
-use crate::types_trace_info::SlotAbiCallStack;
+use crate::types_trace_info::{SlotAbiCallStack, Transfer};
 
 #[cfg(feature = "execution-info")]
 use crate::execution_info::ExecutionInfoForSlot;
@@ -13,9 +13,11 @@ use crate::execution_info::ExecutionInfoForSlot;
 pub struct ExecutionChannels {
     /// Broadcast channel for new slot execution outputs
     pub slot_execution_output_sender: tokio::sync::broadcast::Sender<SlotExecutionOutput>,
-    /// Broadcast channel for execution traces (abi call stacks, boolean true if the slot is finalized, false otherwise)
+    /// Broadcast channel for execution traces (abi call stacks, the slot's transfers, boolean true if the slot is finalized, false otherwise).
+    /// The transfers are bound to the same execution instance as the abi call stacks so subscribers never need a separate slot-keyed lookup (which could be overwritten by a re-execution of the same slot).
     #[cfg(feature = "execution-trace")]
-    pub slot_execution_traces_sender: tokio::sync::broadcast::Sender<(SlotAbiCallStack, bool)>,
+    pub slot_execution_traces_sender:
+        tokio::sync::broadcast::Sender<(SlotAbiCallStack, Vec<Transfer>, bool)>,
     /// Broadcast channel for execution info
     #[cfg(feature = "execution-info")]
     pub slot_execution_info_sender: tokio::sync::broadcast::Sender<ExecutionInfoForSlot>,

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -356,11 +356,11 @@ impl ExecutionState {
         #[cfg(feature = "execution-trace")]
         {
             if self.config.broadcast_traces_enabled {
-                if let Some((slot_trace, _)) = exec_out.slot_trace.clone() {
+                if let Some((slot_trace, transfers)) = exec_out.slot_trace.clone() {
                     if let Err(err) = self
                         .channels
                         .slot_execution_traces_sender
-                        .send((slot_trace, true))
+                        .send((slot_trace, transfers, true))
                     {
                         trace!(
                             "error, failed to broadcast abi trace for slot {} due to: {}",
@@ -2040,11 +2040,11 @@ impl ExecutionState {
         #[cfg(feature = "execution-trace")]
         {
             if self.config.broadcast_traces_enabled {
-                if let Some((slot_trace, _)) = exec_out.slot_trace.clone() {
+                if let Some((slot_trace, transfers)) = exec_out.slot_trace.clone() {
                     if let Err(err) = self
                         .channels
                         .slot_execution_traces_sender
-                        .send((slot_trace, false))
+                        .send((slot_trace, transfers, false))
                     {
                         trace!(
                             "error, failed to broadcast abi trace for slot {} due to: {}",

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -4550,6 +4550,103 @@ fn send_and_receive_async_message_with_reset() {
 
 #[cfg(feature = "execution-trace")]
 #[test]
+fn execution_trace_transfers_are_bound_to_event() {
+    // A Transaction operation produces a transfer. This test checks that the
+    // transfer travels *inside* the broadcast trace event, bound to the same
+    // execution instance as the abi call stacks, rather than being fetched
+    // separately from a mutable slot-keyed cache that a re-execution of the same
+    // slot could overwrite (which used to allow a hybrid response mixing an old
+    // trace with newer transfers).
+    let mut exec_cfg = ExecutionConfig::default();
+    // Make sure broadcast is enabled as we need it for this test
+    exec_cfg.broadcast_enabled = true;
+
+    let finalized_waitpoint = WaitPoint::new();
+    let finalized_waitpoint_trigger_handle = finalized_waitpoint.get_trigger_handle();
+    let mut foreign_controllers = ExecutionForeignControllers::new_with_mocks();
+    selector_boilerplate(&mut foreign_controllers.selector_controller);
+    final_state_boilerplate(
+        &mut foreign_controllers.final_state,
+        foreign_controllers.db.clone(),
+        &foreign_controllers.selector_controller,
+        &mut foreign_controllers.ledger_controller,
+        None,
+        None,
+        None,
+        None,
+    );
+    foreign_controllers
+        .final_state
+        .write()
+        .expect_finalize()
+        .times(1)
+        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
+        .returning(move |_, _| {
+            finalized_waitpoint_trigger_handle.trigger();
+        });
+
+    let mut universe = ExecutionTestUniverse::new(foreign_controllers, exec_cfg);
+
+    // build a transaction that transfers coins (this is what populates the
+    // per-slot transfers)
+    let sender_keypair = KeyPair::from_str(TEST_SK_1).unwrap();
+    let sender_address = Address::from_public_key(&sender_keypair.get_public_key());
+    let recipient_address =
+        Address::from_public_key(&KeyPair::generate(0).unwrap().get_public_key());
+    let amount = Amount::from_str("10").unwrap();
+    let operation = Operation::new_verifiable(
+        Operation {
+            fee: Amount::from_str("5").unwrap(),
+            expire_period: 10,
+            op: OperationType::Transaction {
+                recipient_address,
+                amount,
+            },
+        },
+        OperationSerializer::new(),
+        &sender_keypair,
+        *CHAINID,
+    )
+    .unwrap();
+    let op_id = operation.id;
+
+    universe.storage.store_operations(vec![operation.clone()]);
+    let block = ExecutionTestUniverse::create_block(
+        &sender_keypair,
+        Slot::new(1, 0),
+        vec![operation],
+        vec![],
+        vec![],
+    );
+    universe.send_and_finalize(&sender_keypair, block, None);
+    finalized_waitpoint.wait();
+
+    // read the finalized broadcast trace event for our slot and assert the
+    // transfer is carried by the event itself
+    let mut receiver = universe.broadcast_traces_channel_receiver.take().unwrap();
+    let join_handle = thread::spawn(move || loop {
+        if let Ok((slot_trace, transfers, is_final)) = receiver.blocking_recv() {
+            if is_final && slot_trace.slot == Slot::new(1, 0) {
+                return (slot_trace, transfers);
+            }
+        }
+    });
+    let (_slot_trace, transfers) = join_handle.join().expect("Nothing received from thread");
+
+    assert_eq!(
+        transfers.len(),
+        1,
+        "the transaction transfer must travel inside the trace event"
+    );
+    let transfer = &transfers[0];
+    assert_eq!(transfer.op_id, op_id);
+    assert_eq!(transfer.from, sender_address);
+    assert_eq!(transfer.to, recipient_address);
+    assert_eq!(transfer.amount, amount);
+}
+
+#[cfg(feature = "execution-trace")]
+#[test]
 fn execution_trace() {
     // setup the period duration
     let mut exec_cfg = ExecutionConfig::default();
@@ -4590,16 +4687,20 @@ fn execution_trace() {
     let mut receiver = universe.broadcast_traces_channel_receiver.take().unwrap();
     let join_handle = thread::spawn(move || loop {
         if let Ok(exec_traces) = receiver.blocking_recv() {
-            if exec_traces.1 == true {
+            if exec_traces.2 == true {
                 return Ok::<
-                    (massa_execution_exports::SlotAbiCallStack, bool),
+                    (
+                        massa_execution_exports::SlotAbiCallStack,
+                        Vec<massa_execution_exports::types_trace_info::Transfer>,
+                        bool,
+                    ),
                     tokio::sync::broadcast::error::RecvError,
                 >(exec_traces);
             }
         }
     });
     let broadcast_result_ = join_handle.join().expect("Nothing received from thread");
-    let (broadcast_result, _) = broadcast_result_.unwrap();
+    let (broadcast_result, _, _) = broadcast_result_.unwrap();
 
     let abi_name_1 = "assembly_script_generate_event";
     let traces_1: Vec<(OperationId, Vec<AbiTrace>)> = broadcast_result
@@ -4716,9 +4817,13 @@ fn execution_trace_nested() {
         // Execution Output
         loop {
             if let Ok(exec_traces) = receiver.blocking_recv() {
-                if exec_traces.1 == true {
+                if exec_traces.2 == true {
                     return Ok::<
-                        (massa_execution_exports::SlotAbiCallStack, bool),
+                        (
+                            massa_execution_exports::SlotAbiCallStack,
+                            Vec<massa_execution_exports::types_trace_info::Transfer>,
+                            bool,
+                        ),
                         tokio::sync::broadcast::error::RecvError,
                     >(exec_traces);
                 }
@@ -4728,7 +4833,7 @@ fn execution_trace_nested() {
     let broadcast_result_ = join_handle.join().expect("Nothing received from thread");
 
     // println!("b r: {:?}", broadcast_result_);
-    let (broadcast_result, _) = broadcast_result_.unwrap();
+    let (broadcast_result, _, _) = broadcast_result_.unwrap();
 
     let abi_name_1 = "assembly_script_call";
     let traces_1: Vec<(OperationId, Vec<AbiTrace>)> = broadcast_result

--- a/massa-execution-worker/src/tests/universe.rs
+++ b/massa-execution-worker/src/tests/universe.rs
@@ -16,7 +16,7 @@ use massa_event_cache::MockEventCacheControllerWrapper;
 #[cfg(feature = "execution-info")]
 use massa_execution_exports::execution_info::ExecutionInfoForSlot;
 #[cfg(feature = "execution-trace")]
-use massa_execution_exports::types_trace_info::SlotAbiCallStack;
+use massa_execution_exports::types_trace_info::{SlotAbiCallStack, Transfer};
 use massa_execution_exports::{
     ExecutionBlockMetadata, ExecutionChannels, ExecutionConfig, ExecutionController,
     ExecutionError, ExecutionManager, SlotExecutionOutput,
@@ -169,7 +169,7 @@ pub struct ExecutionTestUniverse {
     pub broadcast_channel_receiver: Option<tokio::sync::broadcast::Receiver<SlotExecutionOutput>>,
     #[cfg(feature = "execution-trace")]
     pub broadcast_traces_channel_receiver:
-        Option<tokio::sync::broadcast::Receiver<(SlotAbiCallStack, bool)>>,
+        Option<tokio::sync::broadcast::Receiver<(SlotAbiCallStack, Vec<Transfer>, bool)>>,
     #[cfg(feature = "execution-info")]
     pub broadcast_execution_info_channel_receiver:
         Option<tokio::sync::broadcast::Receiver<ExecutionInfoForSlot>>,

--- a/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
+++ b/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
@@ -64,7 +64,7 @@ pub(crate) async fn new_slot_abi_call_stacks(
         #[cfg(not(feature = "execution-trace"))]
         let (mut subscriber, _receiver) = {
             let (subscriber_, receiver) =
-                tokio::sync::broadcast::channel::<(SlotAbiCallStack, bool)>(0);
+                tokio::sync::broadcast::channel::<(SlotAbiCallStack, (), bool)>(0);
             (subscriber_.subscribe(), receiver)
         };
 
@@ -73,7 +73,7 @@ pub(crate) async fn new_slot_abi_call_stacks(
                 // Receive a new slot execution traces from the subscriber
                 event = subscriber.recv() => {
                     match event {
-                        Ok((massa_slot_execution_trace, received_finality)) => {
+                        Ok((massa_slot_execution_trace, _slot_transfers, received_finality)) => {
                             if (finality == FinalityLevel::Final && !received_finality) ||
                                 (finality == FinalityLevel::Candidate && received_finality) {
                                 continue;

--- a/massa-grpc/src/stream/new_slot_transfers.rs
+++ b/massa-grpc/src/stream/new_slot_transfers.rs
@@ -41,7 +41,6 @@ pub(crate) async fn new_slot_transfers(
         .subscribe();
 
     tokio::spawn({
-        let execution_controller = grpc.execution_controller.clone();
         async move {
             let mut finality = FinalityLevel::Unspecified;
             loop {
@@ -49,7 +48,7 @@ pub(crate) async fn new_slot_transfers(
                     // Receive a new slot execution traces from the subscriber
                     event = subscriber.recv() => {
                         match event {
-                            Ok((massa_slot_execution_trace, is_final)) => {
+                            Ok((massa_slot_execution_trace, slot_transfers, is_final)) => {
                                 if (finality == FinalityLevel::Final && !is_final) ||
                                     (finality == FinalityLevel::Candidate && is_final) ||
                                     (finality == FinalityLevel::Unspecified && !is_final) {
@@ -116,22 +115,21 @@ pub(crate) async fn new_slot_transfers(
                                         }
                                     }
                                 }
-                                let transfers =
-                                    execution_controller
-                                    .get_transfers_for_slot(massa_slot_execution_trace.slot);
-                                if let Some(transfers) = transfers {
-                                    for transfer in transfers {
-                                        ret_transfers.push(TransferInfo {
-                                            from: transfer.from.to_string(),
-                                            to: transfer.to.to_string(),
-                                            amount: transfer.amount.to_raw(),
-                                            operation_id_or_asc_index: Some(
-                                                grpc_api::transfer_info::OperationIdOrAscIndex::OperationId(
-                                                    transfer.op_id.to_string(),
-                                                ),
+                                // Transfers are carried in the event itself, bound to the same
+                                // execution instance as the abi call stacks above. This avoids a
+                                // separate slot-keyed lookup, which could return transfers from a
+                                // re-execution of the same slot and yield a hybrid response.
+                                for transfer in slot_transfers {
+                                    ret_transfers.push(TransferInfo {
+                                        from: transfer.from.to_string(),
+                                        to: transfer.to.to_string(),
+                                        amount: transfer.amount.to_raw(),
+                                        operation_id_or_asc_index: Some(
+                                            grpc_api::transfer_info::OperationIdOrAscIndex::OperationId(
+                                                transfer.op_id.to_string(),
                                             ),
-                                        });
-                                    }
+                                        ),
+                                    });
                                 }
                                 let ret = grpc_api::NewSlotTransfersResponse {
                                     slot: Some(massa_slot_execution_trace.slot.into()),


### PR DESCRIPTION
…d NewSlotTransfers responses

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification