### PR TITLE
[F91] feat: make chain() atomic in case of error

### DIFF
--- a/massa-models/src/ledger.rs
+++ b/massa-models/src/ledger.rs
@@ -461,9 +461,12 @@ impl LedgerChanges {
 
     /// chain with another `LedgerChange`
     pub fn chain(&mut self, other: &LedgerChanges) -> Result<()> {
+        // We avoid mutating self directly to ensure atomicity in error cases.
+        let mut updated = self.clone();
         for (addr, change) in other.0.iter() {
-            self.apply(addr, change)?;
+            updated.apply(addr, change)?;
         }
+        *self = updated;
         Ok(())
     }
 


### PR DESCRIPTION
Note: there is no need to make it a breaking change (and add versioning to it) as this method is not part of the execution path, it's currently unused.