### PR TITLE
[F76] fix(grpc): source new_slot_transfers from the broadcast snapsho…

### DIFF
--- a/massa-execution-exports/src/channels.rs
+++ b/massa-execution-exports/src/channels.rs
@@ -3,7 +3,7 @@
 use crate::types::SlotExecutionOutput;
 
 #[cfg(feature = "execution-trace")]
-use crate::types_trace_info::SlotAbiCallStack;
+use crate::types_trace_info::{SlotAbiCallStack, Transfer};
 
 #[cfg(feature = "execution-info")]
 use crate::execution_info::ExecutionInfoForSlot;
@@ -13,9 +13,14 @@ use crate::execution_info::ExecutionInfoForSlot;
 pub struct ExecutionChannels {
     /// Broadcast channel for new slot execution outputs
     pub slot_execution_output_sender: tokio::sync::broadcast::Sender<SlotExecutionOutput>,
-    /// Broadcast channel for execution traces (abi call stacks, boolean true if the slot is finalized, false otherwise)
+    /// Broadcast channel for execution traces (abi call stacks, the slot's direct coin
+    /// transfers, and a boolean true if the slot is finalized, false otherwise). Both the
+    /// call stacks and the transfers are carried in the event so that subscribers build their
+    /// response from a single execution snapshot rather than re-reading the (evictable)
+    /// trace history.
     #[cfg(feature = "execution-trace")]
-    pub slot_execution_traces_sender: tokio::sync::broadcast::Sender<(SlotAbiCallStack, bool)>,
+    pub slot_execution_traces_sender:
+        tokio::sync::broadcast::Sender<(SlotAbiCallStack, Vec<Transfer>, bool)>,
     /// Broadcast channel for execution info
     #[cfg(feature = "execution-info")]
     pub slot_execution_info_sender: tokio::sync::broadcast::Sender<ExecutionInfoForSlot>,

--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -356,11 +356,11 @@ impl ExecutionState {
         #[cfg(feature = "execution-trace")]
         {
             if self.config.broadcast_traces_enabled {
-                if let Some((slot_trace, _)) = exec_out.slot_trace.clone() {
+                if let Some((slot_trace, transfers)) = exec_out.slot_trace.clone() {
                     if let Err(err) = self
                         .channels
                         .slot_execution_traces_sender
-                        .send((slot_trace, true))
+                        .send((slot_trace, transfers, true))
                     {
                         trace!(
                             "error, failed to broadcast abi trace for slot {} due to: {}",
@@ -2040,11 +2040,11 @@ impl ExecutionState {
         #[cfg(feature = "execution-trace")]
         {
             if self.config.broadcast_traces_enabled {
-                if let Some((slot_trace, _)) = exec_out.slot_trace.clone() {
+                if let Some((slot_trace, transfers)) = exec_out.slot_trace.clone() {
                     if let Err(err) = self
                         .channels
                         .slot_execution_traces_sender
-                        .send((slot_trace, false))
+                        .send((slot_trace, transfers, false))
                     {
                         trace!(
                             "error, failed to broadcast abi trace for slot {} due to: {}",

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -4590,16 +4590,20 @@ fn execution_trace() {
     let mut receiver = universe.broadcast_traces_channel_receiver.take().unwrap();
     let join_handle = thread::spawn(move || loop {
         if let Ok(exec_traces) = receiver.blocking_recv() {
-            if exec_traces.1 == true {
+            if exec_traces.2 == true {
                 return Ok::<
-                    (massa_execution_exports::SlotAbiCallStack, bool),
+                    (
+                        massa_execution_exports::SlotAbiCallStack,
+                        Vec<massa_execution_exports::Transfer>,
+                        bool,
+                    ),
                     tokio::sync::broadcast::error::RecvError,
                 >(exec_traces);
             }
         }
     });
     let broadcast_result_ = join_handle.join().expect("Nothing received from thread");
-    let (broadcast_result, _) = broadcast_result_.unwrap();
+    let (broadcast_result, _, _) = broadcast_result_.unwrap();
 
     let abi_name_1 = "assembly_script_generate_event";
     let traces_1: Vec<(OperationId, Vec<AbiTrace>)> = broadcast_result
@@ -4716,9 +4720,13 @@ fn execution_trace_nested() {
         // Execution Output
         loop {
             if let Ok(exec_traces) = receiver.blocking_recv() {
-                if exec_traces.1 == true {
+                if exec_traces.2 == true {
                     return Ok::<
-                        (massa_execution_exports::SlotAbiCallStack, bool),
+                        (
+                            massa_execution_exports::SlotAbiCallStack,
+                            Vec<massa_execution_exports::Transfer>,
+                            bool,
+                        ),
                         tokio::sync::broadcast::error::RecvError,
                     >(exec_traces);
                 }
@@ -4728,7 +4736,7 @@ fn execution_trace_nested() {
     let broadcast_result_ = join_handle.join().expect("Nothing received from thread");
 
     // println!("b r: {:?}", broadcast_result_);
-    let (broadcast_result, _) = broadcast_result_.unwrap();
+    let (broadcast_result, _, _) = broadcast_result_.unwrap();
 
     let abi_name_1 = "assembly_script_call";
     let traces_1: Vec<(OperationId, Vec<AbiTrace>)> = broadcast_result

--- a/massa-execution-worker/src/tests/universe.rs
+++ b/massa-execution-worker/src/tests/universe.rs
@@ -16,7 +16,7 @@ use massa_event_cache::MockEventCacheControllerWrapper;
 #[cfg(feature = "execution-info")]
 use massa_execution_exports::execution_info::ExecutionInfoForSlot;
 #[cfg(feature = "execution-trace")]
-use massa_execution_exports::types_trace_info::SlotAbiCallStack;
+use massa_execution_exports::types_trace_info::{SlotAbiCallStack, Transfer};
 use massa_execution_exports::{
     ExecutionBlockMetadata, ExecutionChannels, ExecutionConfig, ExecutionController,
     ExecutionError, ExecutionManager, SlotExecutionOutput,
@@ -169,7 +169,7 @@ pub struct ExecutionTestUniverse {
     pub broadcast_channel_receiver: Option<tokio::sync::broadcast::Receiver<SlotExecutionOutput>>,
     #[cfg(feature = "execution-trace")]
     pub broadcast_traces_channel_receiver:
-        Option<tokio::sync::broadcast::Receiver<(SlotAbiCallStack, bool)>>,
+        Option<tokio::sync::broadcast::Receiver<(SlotAbiCallStack, Vec<Transfer>, bool)>>,
     #[cfg(feature = "execution-info")]
     pub broadcast_execution_info_channel_receiver:
         Option<tokio::sync::broadcast::Receiver<ExecutionInfoForSlot>>,

--- a/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
+++ b/massa-grpc/src/stream/new_slot_abi_call_stacks.rs
@@ -64,7 +64,7 @@ pub(crate) async fn new_slot_abi_call_stacks(
         #[cfg(not(feature = "execution-trace"))]
         let (mut subscriber, _receiver) = {
             let (subscriber_, receiver) =
-                tokio::sync::broadcast::channel::<(SlotAbiCallStack, bool)>(0);
+                tokio::sync::broadcast::channel::<(SlotAbiCallStack, Vec<()>, bool)>(0);
             (subscriber_.subscribe(), receiver)
         };
 
@@ -73,7 +73,7 @@ pub(crate) async fn new_slot_abi_call_stacks(
                 // Receive a new slot execution traces from the subscriber
                 event = subscriber.recv() => {
                     match event {
-                        Ok((massa_slot_execution_trace, received_finality)) => {
+                        Ok((massa_slot_execution_trace, _transfers, received_finality)) => {
                             if (finality == FinalityLevel::Final && !received_finality) ||
                                 (finality == FinalityLevel::Candidate && received_finality) {
                                 continue;

--- a/massa-grpc/src/stream/new_slot_transfers.rs
+++ b/massa-grpc/src/stream/new_slot_transfers.rs
@@ -41,7 +41,6 @@ pub(crate) async fn new_slot_transfers(
         .subscribe();
 
     tokio::spawn({
-        let execution_controller = grpc.execution_controller.clone();
         async move {
             let mut finality = FinalityLevel::Unspecified;
             loop {
@@ -49,7 +48,7 @@ pub(crate) async fn new_slot_transfers(
                     // Receive a new slot execution traces from the subscriber
                     event = subscriber.recv() => {
                         match event {
-                            Ok((massa_slot_execution_trace, is_final)) => {
+                            Ok((massa_slot_execution_trace, slot_transfers, is_final)) => {
                                 if (finality == FinalityLevel::Final && !is_final) ||
                                     (finality == FinalityLevel::Candidate && is_final) ||
                                     (finality == FinalityLevel::Unspecified && !is_final) {
@@ -116,22 +115,22 @@ pub(crate) async fn new_slot_transfers(
                                         }
                                     }
                                 }
-                                let transfers =
-                                    execution_controller
-                                    .get_transfers_for_slot(massa_slot_execution_trace.slot);
-                                if let Some(transfers) = transfers {
-                                    for transfer in transfers {
-                                        ret_transfers.push(TransferInfo {
-                                            from: transfer.from.to_string(),
-                                            to: transfer.to.to_string(),
-                                            amount: transfer.amount.to_raw(),
-                                            operation_id_or_asc_index: Some(
-                                                grpc_api::transfer_info::OperationIdOrAscIndex::OperationId(
-                                                    transfer.op_id.to_string(),
-                                                ),
+                                // Direct coin transfers come from the broadcast event itself,
+                                // i.e. the same execution snapshot as the ABI call stacks above.
+                                // Reading them from the (LRU-evictable) trace history instead
+                                // could return a different execution's data, or nothing at all
+                                // once the slot has been evicted.
+                                for transfer in slot_transfers {
+                                    ret_transfers.push(TransferInfo {
+                                        from: transfer.from.to_string(),
+                                        to: transfer.to.to_string(),
+                                        amount: transfer.amount.to_raw(),
+                                        operation_id_or_asc_index: Some(
+                                            grpc_api::transfer_info::OperationIdOrAscIndex::OperationId(
+                                                transfer.op_id.to_string(),
                                             ),
-                                        });
-                                    }
+                                        ),
+                                    });
                                 }
                                 let ret = grpc_api::NewSlotTransfersResponse {
                                     slot: Some(massa_slot_execution_trace.slot.into()),


### PR DESCRIPTION
…t instead of the evictable trace history

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification