### PR TITLE
[F5] [F6] bound the bootstrap resume cursor with max_consensus_block_ids i…

### DIFF
--- a/massa-bootstrap/src/bindings/server.rs
+++ b/massa-bootstrap/src/bindings/server.rs
@@ -42,6 +42,7 @@ struct ClientMessageLeader {
 
 /// Bootstrap server binder
 pub struct BootstrapServerBinder {
+    /// max number of block ids accepted in the client's cumulative bootstrap cursor
     max_consensus_block_ids: u64,
     thread_count: u8,
     max_datastore_key_length: u8,
@@ -73,7 +74,8 @@ impl BootstrapServerBinder {
             thread_count,
             max_datastore_key_length,
             randomness_size_bytes,
-            consensus_bootstrap_part_size,
+            consensus_bootstrap_part_size: _part_size,
+            max_consensus_block_ids,
             write_error_timeout,
         } = cfg;
 
@@ -82,7 +84,7 @@ impl BootstrapServerBinder {
         });
         let duplex = Limiter::new(duplex, limit_opts.clone(), limit_opts);
         BootstrapServerBinder {
-            max_consensus_block_ids: consensus_bootstrap_part_size,
+            max_consensus_block_ids,
             local_keypair,
             duplex,
             prev_message: None,

--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -65,7 +65,7 @@ impl BSConnector for DefaultConnector {
 /// This function will send the starting point to receive a stream of the ledger and will receive and process each part until receive a `BootstrapServerMessage::FinalStateFinished` message from the server.
 /// `next_bootstrap_message` passed as parameter must be `BootstrapClientMessage::AskFinalStatePart` enum variant.
 /// `next_bootstrap_message` will be updated after receiving each part so that in case of connection lost we can restart from the last message we processed.
-fn stream_final_state_and_consensus(
+pub(crate) fn stream_final_state_and_consensus(
     cfg: &BootstrapConfig,
     client: &mut BootstrapClientBinder,
     next_bootstrap_message: &mut BootstrapClientMessage,
@@ -150,8 +150,6 @@ fn stream_final_state_and_consensus(
                 }
                 BootstrapServerMessage::BootstrapFinished => {
                     info!("State bootstrap complete");
-                    // Set next bootstrap message
-                    *next_bootstrap_message = BootstrapClientMessage::AskBootstrapPeers;
 
                     // Update MIP store by reading from the disk
                     let mut guard = global_bootstrap_state.final_state.write();
@@ -162,6 +160,11 @@ fn stream_final_state_and_consensus(
                         .map_err(|e| BootstrapError::from(FinalStateError::from(e)))?;
 
                     warn_user_about_versioning_updates(updated, added);
+
+                    // Only advance to the next phase once the streamed state has been fully
+                    // post-processed: on failure the retry must replay the state streaming
+                    // instead of resuming from the peers phase with a half-updated store.
+                    *next_bootstrap_message = BootstrapClientMessage::AskBootstrapPeers;
 
                     return Ok(());
                 }
@@ -176,6 +179,12 @@ fn stream_final_state_and_consensus(
                     };
                     let mut write_final_state = global_bootstrap_state.final_state.write();
                     write_final_state.reset();
+                    drop(write_final_state);
+                    // The cursor above restarts the consensus stream from `Started`, for which the
+                    // server reports no outdated ids: blocks kept from the aborted attempt would
+                    // never be pruned and would be merged into the next attempt's graph.
+                    global_bootstrap_state.graph = None;
+                    global_bootstrap_state.peers = None;
                     return Err(BootstrapError::GeneralError(String::from("Slot too old")));
                 }
                 // At this point, we have successfully received the next message from the server, and it's an error-message String

--- a/massa-bootstrap/src/settings.rs
+++ b/massa-bootstrap/src/settings.rs
@@ -139,6 +139,7 @@ pub struct BootstrapSrvBindCfg {
     pub max_datastore_key_length: u8,
     pub randomness_size_bytes: usize,
     pub consensus_bootstrap_part_size: u64,
+    pub max_consensus_block_ids: u64,
     pub write_error_timeout: MassaTime,
 }
 

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -1,3 +1,4 @@
+use crate::client::stream_final_state_and_consensus;
 use crate::messages::{BootstrapClientMessage, BootstrapServerMessage};
 use crate::server::manage_bootstrap;
 use crate::settings::{BootstrapClientConfig, BootstrapSrvBindCfg};
@@ -6,11 +7,12 @@ use crate::{
     bindings::{BootstrapClientBinder, BootstrapServerBinder},
     tests::tools::get_bootstrap_config,
 };
-use crate::{BootstrapConfig, BootstrapError};
+use crate::{BootstrapConfig, BootstrapError, GlobalBootstrapState};
+use massa_consensus_exports::bootstrapable_graph::BootstrapableGraph;
 use massa_consensus_exports::MockConsensusController;
 use massa_db_exports::{MassaDBConfig, MassaDBController};
 use massa_db_worker::MassaDB;
-use massa_final_state::FinalStateConfig;
+use massa_final_state::{FinalStateConfig, MockFinalStateController};
 use massa_hash::Hash;
 use massa_models::block_id::BlockId;
 use massa_models::config::{
@@ -50,7 +52,7 @@ use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use super::tools::{get_random_final_state_bootstrap, parametric_test};
+use super::tools::{gen_export_active_blocks, get_random_final_state_bootstrap, parametric_test};
 
 /// Fixed-width length slot written by [`BootstrapClientBinder::send_timeout`].
 fn padded_client_bootstrap_length_field(
@@ -1009,4 +1011,84 @@ fn test_server_rejects_oversized_consensus_cursor() {
         server.next_timeout(Some(timeout)).is_err(),
         "Server accepted a consensus cursor above MAX_CONSENSUS_BLOCKS_IDS"
     );
+}
+
+/// After `SlotTooOld` the client restarts the consensus stream from `Started`, a step for which the
+/// server reports no outdated ids. Blocks retained from the aborted attempt would therefore never
+/// be pruned and would end up merged into the next attempt's graph, so the whole session state has
+/// to be dropped, not just the final state.
+#[test]
+#[serial]
+fn test_slot_too_old_clears_session_state() {
+    let timeout = Duration::from_secs(30);
+    let (bootstrap_config, _): &(BootstrapConfig, KeyPair) = &BOOTSTRAP_CONFIG_KEYPAIR;
+    let (mut server, mut client) = init_server_client_pair();
+
+    let mut final_state = MockFinalStateController::new();
+    final_state.expect_reset().times(1).return_const(());
+
+    let mut rng = rand::thread_rng();
+    let mut global_bootstrap_state = GlobalBootstrapState {
+        final_state: Arc::new(RwLock::new(final_state)),
+        graph: Some(BootstrapableGraph {
+            final_blocks: vec![gen_export_active_blocks(&mut rng)],
+        }),
+        peers: Some(BootstrapPeers(vec![])),
+    };
+    // a cursor as it would stand after a first session streamed some parts
+    let mut next_bootstrap_message = BootstrapClientMessage::AskBootstrapPart {
+        last_slot: Some(Slot::new(1, 0)),
+        last_state_step: StreamingStep::Ongoing(vec![0]),
+        last_versioning_step: StreamingStep::Ongoing(vec![0]),
+        last_consensus_step: StreamingStep::Ongoing(PreHashSet::default()),
+        send_last_start_period: false,
+    };
+
+    let server_thread = std::thread::Builder::new()
+        .name("test_slot_too_old::server_thread".to_string())
+        .spawn(move || {
+            // consume the resume request, then tell the client its cursor is too old
+            server.next_timeout(Some(timeout)).unwrap();
+            server
+                .send_timeout(BootstrapServerMessage::SlotTooOld, Some(timeout))
+                .unwrap();
+        })
+        .unwrap();
+
+    let res = stream_final_state_and_consensus(
+        bootstrap_config,
+        &mut client,
+        &mut next_bootstrap_message,
+        &mut global_bootstrap_state,
+    );
+    server_thread.join().unwrap();
+
+    match res {
+        Err(BootstrapError::GeneralError(err)) => assert_eq!(err, "Slot too old"),
+        other => panic!("Expected a 'Slot too old' error, got {other:?}"),
+    }
+    assert!(
+        global_bootstrap_state.graph.is_none(),
+        "consensus blocks of the aborted attempt were kept across the reset"
+    );
+    assert!(
+        global_bootstrap_state.peers.is_none(),
+        "peers of the aborted attempt were kept across the reset"
+    );
+    match next_bootstrap_message {
+        BootstrapClientMessage::AskBootstrapPart {
+            last_slot,
+            last_consensus_step,
+            send_last_start_period,
+            ..
+        } => {
+            assert!(last_slot.is_none());
+            assert_eq!(last_consensus_step, StreamingStep::Started);
+            assert!(
+                send_last_start_period,
+                "restart metadata must be requested again from the next server"
+            );
+        }
+        other => panic!("Expected an AskBootstrapPart cursor, got {other:?}"),
+    }
 }

--- a/massa-bootstrap/src/tests/binders.rs
+++ b/massa-bootstrap/src/tests/binders.rs
@@ -12,20 +12,24 @@ use massa_db_exports::{MassaDBConfig, MassaDBController};
 use massa_db_worker::MassaDB;
 use massa_final_state::FinalStateConfig;
 use massa_hash::Hash;
+use massa_models::block_id::BlockId;
 use massa_models::config::{
     BOOTSTRAP_RANDOMNESS_SIZE_BYTES, CHAINID, CONSENSUS_BOOTSTRAP_PART_SIZE, ENDORSEMENT_COUNT,
     MAX_ADVERTISE_LENGTH, MAX_BOOTSTRAP_BLOCKS, MAX_BOOTSTRAP_ERROR_LENGTH,
     MAX_BOOTSTRAP_FINAL_STATE_PARTS_SIZE, MAX_BOOTSTRAP_MESSAGE_FROM_CLIENT_SIZE,
     MAX_BOOTSTRAP_MESSAGE_FROM_CLIENT_SIZE_BYTES, MAX_BOOTSTRAP_VERSIONING_ELEMENTS_SIZE,
-    MAX_DATASTORE_ENTRY_COUNT, MAX_DATASTORE_KEY_LENGTH, MAX_DATASTORE_VALUE_LENGTH,
-    MAX_DEFERRED_CREDITS_LENGTH, MAX_DENUNCIATIONS_PER_BLOCK_HEADER,
+    MAX_CONSENSUS_BLOCKS_IDS, MAX_DATASTORE_ENTRY_COUNT, MAX_DATASTORE_KEY_LENGTH,
+    MAX_DATASTORE_VALUE_LENGTH, MAX_DEFERRED_CREDITS_LENGTH, MAX_DENUNCIATIONS_PER_BLOCK_HEADER,
     MAX_DENUNCIATION_CHANGES_LENGTH, MAX_EXECUTED_OPS_CHANGES_LENGTH, MAX_EXECUTED_OPS_LENGTH,
     MAX_LEDGER_CHANGES_COUNT, MAX_LISTENERS_PER_PEER, MAX_OPERATIONS_PER_BLOCK,
     MAX_PRODUCTION_STATS_LENGTH, MAX_ROLLS_COUNT_LENGTH, MIP_STORE_STATS_BLOCK_CONSIDERED,
     THREAD_COUNT,
 };
 use massa_models::node::NodeId;
+use massa_models::prehash::{CapacityAllocator, PreHashSet};
 use massa_models::serialization::SerializeMinBEInt;
+use massa_models::slot::Slot;
+use massa_models::streaming_step::StreamingStep;
 use massa_models::version::Version;
 
 use massa_pos_exports::{MockSelectorControllerWrapper, PoSFinalState};
@@ -151,6 +155,7 @@ fn init_server_client_pair() -> (BootstrapServerBinder, BootstrapClientBinder) {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         Some(u64::MAX),
@@ -381,6 +386,7 @@ fn test_partial_msg() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         None,
@@ -458,6 +464,7 @@ fn test_staying_connected_without_message_trigger_read_timeout() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         None,
@@ -553,6 +560,7 @@ fn test_staying_connected_pass_handshake_but_deadline_after() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         None,
@@ -652,6 +660,7 @@ fn test_staying_connected_pass_handshake_but_deadline_during_data_exchange() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         None,
@@ -752,6 +761,7 @@ fn test_client_drip_feed() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         None,
@@ -845,6 +855,7 @@ fn test_bandwidth() {
             max_datastore_key_length: MAX_DATASTORE_KEY_LENGTH,
             randomness_size_bytes: BOOTSTRAP_RANDOMNESS_SIZE_BYTES,
             consensus_bootstrap_part_size: CONSENSUS_BOOTSTRAP_PART_SIZE,
+            max_consensus_block_ids: MAX_CONSENSUS_BLOCKS_IDS,
             write_error_timeout: MassaTime::from_millis(1000),
         },
         Some(100),
@@ -950,4 +961,52 @@ fn test_bandwidth() {
 
     server_thread.join().unwrap();
     client_thread.join().unwrap();
+}
+
+// Build an `AskBootstrapPart` resume cursor holding `nb_block_ids` consensus block ids.
+fn ask_bootstrap_part_with_cursor(nb_block_ids: usize) -> BootstrapClientMessage {
+    let mut rng = rand::thread_rng();
+    let mut block_ids = PreHashSet::with_capacity(nb_block_ids);
+    while block_ids.len() < nb_block_ids {
+        block_ids.insert(BlockId::generate_from_hash(Hash::compute_from(
+            &rng.gen::<[u8; 32]>(),
+        )));
+    }
+    BootstrapClientMessage::AskBootstrapPart {
+        last_slot: Some(Slot::new(1, 0)),
+        last_state_step: StreamingStep::Started,
+        last_versioning_step: StreamingStep::Started,
+        last_consensus_step: StreamingStep::Ongoing(block_ids),
+        send_last_start_period: false,
+    }
+}
+
+/// `last_consensus_step` is a cumulative resume cursor: it grows with every consensus part already
+/// streamed, so the server must accept more than `consensus_bootstrap_part_size` block ids in it.
+#[test]
+#[serial]
+fn test_server_accepts_cumulative_consensus_cursor() {
+    let timeout = Duration::from_secs(30);
+    let (mut server, mut client) = init_server_client_pair();
+
+    // several parts worth of block ids, still within the cumulative cursor bound
+    let msg = ask_bootstrap_part_with_cursor((CONSENSUS_BOOTSTRAP_PART_SIZE as usize) * 3);
+    client.send_timeout(&msg, Some(timeout)).unwrap();
+    assert_server_got_msg(timeout, &mut server, msg);
+}
+
+/// The cumulative cursor is still bounded: a client cannot make the server allocate an unbounded
+/// number of block ids.
+#[test]
+#[serial]
+fn test_server_rejects_oversized_consensus_cursor() {
+    let timeout = Duration::from_secs(30);
+    let (mut server, mut client) = init_server_client_pair();
+
+    let msg = ask_bootstrap_part_with_cursor((MAX_CONSENSUS_BLOCKS_IDS as usize) + 1);
+    client.send_timeout(&msg, Some(timeout)).unwrap();
+    assert!(
+        server.next_timeout(Some(timeout)).is_err(),
+        "Server accepted a consensus cursor above MAX_CONSENSUS_BLOCKS_IDS"
+    );
 }

--- a/massa-bootstrap/src/tests/tools.rs
+++ b/massa-bootstrap/src/tests/tools.rs
@@ -395,7 +395,7 @@ pub fn get_bootstrap_config(bootstrap_public_key: NodeId) -> BootstrapConfig {
     }
 }
 
-fn gen_export_active_blocks<R: Rng>(rng: &mut R) -> ExportActiveBlock {
+pub(crate) fn gen_export_active_blocks<R: Rng>(rng: &mut R) -> ExportActiveBlock {
     let keypair = KeyPair::generate(0).unwrap();
     let block = gen_random_block(&keypair, rng)
         .new_verifiable(BlockSerializer::new(), &keypair, *CHAINID)


### PR DESCRIPTION
…nstead of the per-part size

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification