### PR TITLE
5018 f79 grpc send operations underestimates smart contract operation gas accepting operations exceeding the block gas limit

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -46,7 +46,7 @@ use massa_models::{
     error::ModelsError,
     execution::EventFilter,
     node::NodeId,
-    operation::{OperationDeserializer, OperationId, OperationType, SecureShareOperation},
+    operation::{OperationDeserializer, OperationId, SecureShareOperation},
     output_event::SCOutputEvent,
     prehash::{PreHashMap, PreHashSet},
     secure_share::SecureShareDeserializer,
@@ -1586,27 +1586,13 @@ fn check_input_operation(
     let (rest, op): (&[u8], SecureShareOperation) = operation_deserializer
         .deserialize::<DeserializeError>(&op_serialized)
         .map_err(|err| ApiError::ModelsError(ModelsError::DeserializeError(err.to_string())))?;
-    match op.content.op {
-        OperationType::CallSC { .. } => {
-            let gas_usage =
-                op.get_gas_usage(api_cfg.base_operation_gas_cost, api_cfg.sp_compilation_cost);
-            if gas_usage > api_cfg.max_gas_per_block {
-                let err_msg = format!("Upper gas limit for CallSC operation is {}. Your operation will never be included in a block.",
-                    api_cfg.max_gas_per_block.saturating_sub(api_cfg.base_operation_gas_cost));
-                return Err(ApiError::InconsistencyError(err_msg).into());
-            }
-        }
-        OperationType::ExecuteSC { .. } => {
-            let gas_usage =
-                op.get_gas_usage(api_cfg.base_operation_gas_cost, api_cfg.sp_compilation_cost);
-            if gas_usage > api_cfg.max_gas_per_block {
-                let err_msg = format!("Upper gas limit for ExecuteSC operation is {}. Your operation will never be included in a block.",
-                    api_cfg.max_gas_per_block.saturating_sub(api_cfg.base_operation_gas_cost).saturating_sub(api_cfg.sp_compilation_cost));
-                return Err(ApiError::InconsistencyError(err_msg).into());
-            }
-        }
-        _ => {}
-    };
+    if let Err(err_msg) = op.check_gas_usage(
+        api_cfg.max_gas_per_block,
+        api_cfg.base_operation_gas_cost,
+        api_cfg.sp_compilation_cost,
+    ) {
+        return Err(ApiError::InconsistencyError(err_msg).into());
+    }
     if let Some(slot) = last_slot {
         if op.content.expire_period < slot.period {
             return Err(

--- a/massa-grpc/src/config.rs
+++ b/massa-grpc/src/config.rs
@@ -90,6 +90,10 @@ pub struct GrpcConfig {
     pub max_operations_per_message: u32,
     /// max gas per block
     pub max_gas_per_block: u64,
+    /// gas cost of a basic operation
+    pub base_operation_gas_cost: u64,
+    /// gas cost of the smart contract compilation
+    pub sp_compilation_cost: u64,
     /// `genesis_timestamp`
     pub genesis_timestamp: MassaTime,
     /// t0

--- a/massa-grpc/src/stream/send_operations.rs
+++ b/massa-grpc/src/stream/send_operations.rs
@@ -3,7 +3,7 @@
 use crate::error::{match_for_io_error, GrpcError};
 use crate::server::MassaPublicGrpc;
 use futures_util::StreamExt;
-use massa_models::operation::{OperationDeserializer, OperationType, SecureShareOperation};
+use massa_models::operation::{OperationDeserializer, SecureShareOperation};
 use massa_models::secure_share::SecureShareDeserializer;
 use massa_models::timeslots::get_latest_block_slot_at_timestamp;
 use massa_proto_rs::massa::api::v1 as grpc_api;
@@ -98,17 +98,13 @@ pub(crate) async fn send_operations(
                                     let verified_op_res = match operation_deserializer.deserialize::<DeserializeError>(&proto_operation) {
                                         Ok(tuple) => {
                                             let (rest, res_operation): (&[u8], SecureShareOperation) = tuple;
-                                            match res_operation.content.op {
-                                                // the gas actually consumed by the operation includes mandatory
-                                                // overheads, so check the full usage as the block filling logic does
-                                                OperationType::CallSC { .. } | OperationType::ExecuteSC { .. } => {
-                                                    let gas_usage = res_operation.get_gas_usage(config.base_operation_gas_cost, config.sp_compilation_cost);
-                                                    if gas_usage > config.max_gas_per_block {
-                                                        return Err(GrpcError::InvalidArgument("Total gas usage of the operation is higher than the block gas limit. Your operation will never be included in a block.".into()));
-                                                    }
-                                                },
-                                                _ => {}
-                                            };
+                                            if let Err(err_msg) = res_operation.check_gas_usage(
+                                                config.max_gas_per_block,
+                                                config.base_operation_gas_cost,
+                                                config.sp_compilation_cost,
+                                            ) {
+                                                return Err(GrpcError::InvalidArgument(err_msg));
+                                            }
                                             if let Some(slot) = last_slot {
                                                 if res_operation.content.expire_period < slot.period {
                                                     return Err(GrpcError::InvalidArgument("Operation expire_period is lower than the current period of this node. Your operation will never be included in a block.".into()));

--- a/massa-grpc/src/stream/send_operations.rs
+++ b/massa-grpc/src/stream/send_operations.rs
@@ -99,9 +99,12 @@ pub(crate) async fn send_operations(
                                         Ok(tuple) => {
                                             let (rest, res_operation): (&[u8], SecureShareOperation) = tuple;
                                             match res_operation.content.op {
-                                                OperationType::CallSC { max_gas, .. } | OperationType::ExecuteSC { max_gas, .. } => {
-                                                    if max_gas > config.max_gas_per_block {
-                                                        return Err(GrpcError::InvalidArgument("Gas limit of the operation is higher than the block gas limit. Your operation will never be included in a block.".into()));
+                                                // the gas actually consumed by the operation includes mandatory
+                                                // overheads, so check the full usage as the block filling logic does
+                                                OperationType::CallSC { .. } | OperationType::ExecuteSC { .. } => {
+                                                    let gas_usage = res_operation.get_gas_usage(config.base_operation_gas_cost, config.sp_compilation_cost);
+                                                    if gas_usage > config.max_gas_per_block {
+                                                        return Err(GrpcError::InvalidArgument("Total gas usage of the operation is higher than the block gas limit. Your operation will never be included in a block.".into()));
                                                     }
                                                 },
                                                 _ => {}

--- a/massa-grpc/src/tests/mock.rs
+++ b/massa-grpc/src/tests/mock.rs
@@ -64,6 +64,8 @@ pub(crate) fn grpc_public_service(addr: &SocketAddr) -> MassaPublicGrpc {
         max_decoding_message_size: 4194304,
         max_encoding_message_size: 4194304,
         max_gas_per_block: u32::MAX as u64,
+        base_operation_gas_cost: 0,
+        sp_compilation_cost: 0,
         concurrency_limit_per_connection: 5,
         timeout: Default::default(),
         initial_stream_window_size: None,

--- a/massa-grpc/src/tests/stream.rs
+++ b/massa-grpc/src/tests/stream.rs
@@ -1523,9 +1523,15 @@ async fn send_operations_gas_over_block_limit() {
         .into_inner();
 
     let keypair = KeyPair::generate(0).unwrap();
-    for op in [
-        create_execute_sc_op_with_too_much_gas(&keypair, 11950000),
-        create_call_sc_op_with_too_much_gas(&keypair, 11950000),
+    for (op, expected_limit) in [
+        (
+            create_execute_sc_op_with_too_much_gas(&keypair, 11950000),
+            "Upper gas limit for ExecuteSC operation is 4294967275",
+        ),
+        (
+            create_call_sc_op_with_too_much_gas(&keypair, 11950000),
+            "Upper gas limit for CallSC operation is 4294967285",
+        ),
     ] {
         let mut buffer: Vec<u8> = Vec::new();
         SecureShareSerializer::new()
@@ -1551,7 +1557,7 @@ async fn send_operations_gas_over_block_limit() {
                 panic!("should be error");
             }
             massa_proto_rs::massa::api::v1::send_operations_response::Result::Error(e) => {
-                assert_eq!(e.message, "invalid operation(s): Invalid argument error: Total gas usage of the operation is higher than the block gas limit. Your operation will never be included in a block.");
+                assert_eq!(e.message, format!("invalid operation(s): Invalid argument error: {}. Your operation will never be included in a block.", expected_limit));
             }
         }
     }

--- a/massa-grpc/src/tests/stream.rs
+++ b/massa-grpc/src/tests/stream.rs
@@ -25,7 +25,8 @@ use massa_proto_rs::massa::{
 };
 use massa_protocol_exports::{
     test_exports::tools::{
-        create_block, create_block_with_operations, create_endorsement,
+        create_block, create_block_with_operations, create_call_sc_op_with_too_much_gas,
+        create_endorsement, create_execute_sc_op_with_too_much_gas,
         create_operation_with_expire_period,
     },
     MockProtocolController,
@@ -1465,6 +1466,93 @@ async fn send_operations_low_fee() {
         }
         massa_proto_rs::massa::api::v1::send_operations_response::Result::Error(e) => {
             assert_eq!(e.message, "invalid operation(s): Invalid argument error: Operation fee is lower than the minimal fee. Your operation will never be included in a block.");
+        }
+    }
+
+    stop_handle.stop();
+}
+
+#[tokio::test]
+async fn send_operations_gas_over_block_limit() {
+    let addr: SocketAddr = "[::]:4001".parse().unwrap();
+    let mut public_server = grpc_public_service(&addr);
+    // the raw max_gas of the operations below fits under the block gas limit,
+    // only the mandatory overheads push their total gas usage above it
+    public_server.grpc_config.max_gas_per_block = u32::MAX as u64;
+    public_server.grpc_config.base_operation_gas_cost = 10;
+    public_server.grpc_config.sp_compilation_cost = 10;
+
+    let mut pool_ctrl = Box::new(MockPoolController::new());
+    pool_ctrl.expect_clone_box().returning(|| {
+        let mut pool_ctrl = Box::new(MockPoolController::new());
+
+        pool_ctrl.expect_add_operations().returning(|_| Ok(()));
+
+        pool_ctrl
+    });
+
+    let mut protocol_ctrl = Box::new(MockProtocolController::new());
+    protocol_ctrl.expect_clone_box().returning(|| {
+        let mut ctrl = Box::new(MockProtocolController::new());
+
+        ctrl.expect_propagate_operations().returning(|_| Ok(()));
+
+        ctrl
+    });
+
+    public_server.pool_controller = pool_ctrl;
+    public_server.protocol_controller = protocol_ctrl;
+
+    let config = public_server.grpc_config.clone();
+    let stop_handle = public_server.serve(&config).await.unwrap();
+
+    let (tx, rx) = tokio::sync::mpsc::channel(10);
+    let request_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
+
+    let mut public_client = PublicServiceClient::connect(format!(
+        "grpc://localhost:{}",
+        addr.to_string().split(':').last().unwrap()
+    ))
+    .await
+    .unwrap();
+
+    let mut resp_stream = public_client
+        .send_operations(request_stream)
+        .await
+        .unwrap()
+        .into_inner();
+
+    let keypair = KeyPair::generate(0).unwrap();
+    for op in [
+        create_execute_sc_op_with_too_much_gas(&keypair, 11950000),
+        create_call_sc_op_with_too_much_gas(&keypair, 11950000),
+    ] {
+        let mut buffer: Vec<u8> = Vec::new();
+        SecureShareSerializer::new()
+            .serialize(&op, &mut buffer)
+            .unwrap();
+
+        tx.send(SendOperationsRequest {
+            operations: vec![buffer],
+        })
+        .await
+        .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_secs(5), resp_stream.next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .result
+            .unwrap();
+
+        match result {
+            massa_proto_rs::massa::api::v1::send_operations_response::Result::OperationIds(_) => {
+                panic!("should be error");
+            }
+            massa_proto_rs::massa::api::v1::send_operations_response::Result::Error(e) => {
+                assert_eq!(e.message, "invalid operation(s): Invalid argument error: Total gas usage of the operation is higher than the block gas limit. Your operation will never be included in a block.");
+            }
         }
     }
 

--- a/massa-models/src/operation.rs
+++ b/massa-models/src/operation.rs
@@ -1001,6 +1001,41 @@ impl SecureShareOperation {
         .saturating_add(base_operation_gas_cost)
     }
 
+    /// Check that the operation can ever fit in a block, gas-wise.
+    ///
+    /// Compares the full gas usage (see `get_gas_usage`, mandatory overheads included)
+    /// against the block gas limit, so that every submission interface applies the same
+    /// includability criterion as the block filling logic.
+    ///
+    /// On failure returns the client-facing error message, stating the highest `max_gas`
+    /// the operation could have declared.
+    pub fn check_gas_usage(
+        &self,
+        max_gas_per_block: u64,
+        base_operation_gas_cost: u64,
+        sp_compilation_cost: u64,
+    ) -> Result<(), String> {
+        // gas that the operation is charged on top of its declared max_gas
+        let (op_name, gas_overhead) = match &self.content.op {
+            OperationType::CallSC { .. } => ("CallSC", base_operation_gas_cost),
+            OperationType::ExecuteSC { .. } => (
+                "ExecuteSC",
+                base_operation_gas_cost.saturating_add(sp_compilation_cost),
+            ),
+            OperationType::RollBuy { .. }
+            | OperationType::RollSell { .. }
+            | OperationType::Transaction { .. } => return Ok(()),
+        };
+        if self.get_gas_usage(base_operation_gas_cost, sp_compilation_cost) > max_gas_per_block {
+            return Err(format!(
+                "Upper gas limit for {} operation is {}. Your operation will never be included in a block.",
+                op_name,
+                max_gas_per_block.saturating_sub(gas_overhead)
+            ));
+        }
+        Ok(())
+    }
+
     /// get the addresses that are involved in this operation from a ledger point of view
     pub fn get_ledger_involved_addresses(&self) -> PreHashSet<Address> {
         let mut res = PreHashSet::<Address>::default();

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -1014,6 +1014,7 @@ async fn launch(
             keypair.clone(),
             &final_state,
             SETTINGS.pool.minimal_fees,
+            gas_costs.sp_compilation_cost,
         );
 
         let grpc_public_api = MassaPublicGrpc {
@@ -1055,6 +1056,7 @@ async fn launch(
             keypair.clone(),
             &final_state,
             SETTINGS.pool.minimal_fees,
+            gas_costs.sp_compilation_cost,
         );
 
         let bs_white_black_list = bootstrap_manager
@@ -1213,6 +1215,7 @@ fn configure_grpc(
     keypair: KeyPair,
     final_state: &Arc<RwLock<dyn FinalStateController>>,
     minimal_fees: Amount,
+    sp_compilation_cost: u64,
 ) -> GrpcConfig {
     GrpcConfig {
         name,
@@ -1255,6 +1258,8 @@ fn configure_grpc(
         max_parameter_size: MAX_PARAMETERS_SIZE,
         max_operations_per_message: MAX_OPERATIONS_PER_MESSAGE,
         max_gas_per_block: MAX_GAS_PER_BLOCK,
+        base_operation_gas_cost: BASE_OPERATION_GAS_COST,
+        sp_compilation_cost,
         genesis_timestamp: *GENESIS_TIMESTAMP,
         t0: T0,
         periods_per_cycle: PERIODS_PER_CYCLE,


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification