### PR TITLE
docs(execution): record that async gas intentionally absorbs unused b…

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -1599,7 +1599,7 @@ impl ExecutionState {
         // Block execution
 
         let mut block_info: Option<ExecutedBlockInfo> = None;
-        // Set block gas (max_gas_per_block - gas used by deferred calls)
+        // Set block gas (deferred calls have their own budget, see async gas below)
         let mut remaining_block_gas = self.config.max_gas_per_block;
 
         // Check if there is a block at this slot
@@ -1887,6 +1887,9 @@ impl ExecutionState {
 
         // Get asynchronous messages to execute
         // The gas available for async messages is the remaining block gas + async remaining gas (max_async - gas used by deferred calls)
+        // Reusing the gas the block left unused is intentional (activated by MIP-0001, MipComponent::Execution v1):
+        // it keeps the whole-slot budget bounded by max_gas_per_block + max_async_gas while letting
+        // underfilled slots do more async work. Changing this formula is a consensus change.
         let async_msg_gas_available = self
             .config
             .max_async_gas

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -315,7 +315,11 @@ pub const PROTOCOL_EVENT_CHANNEL_SIZE: usize = 1024;
 
 /// Maximum of GAS allowed for a block
 pub const MAX_GAS_PER_BLOCK: u64 = u32::MAX as u64;
-/// Maximum of GAS allowed for asynchronous messages execution on one slot
+/// Base GAS budget for asynchronous messages execution on one slot.
+/// This is not a strict per-slot cap: since MIP-0001, `execute_slot` tops this budget
+/// up with the gas left unused by the block at that slot (and subtracts the gas booked
+/// by deferred calls), so async execution can exceed this value on underfilled slots.
+/// The bound that always holds is `MAX_GAS_PER_BLOCK + MAX_ASYNC_GAS` for the whole slot.
 pub const MAX_ASYNC_GAS: u64 = 1_000_000_000;
 /// Constant cost applied to asynchronous messages (to take into account some costs related to snapshot)
 pub const ASYNC_MSG_CST_GAS_COST: u64 = 1_000_000;


### PR DESCRIPTION
…lock gas since MIP-0001

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification