### PR TITLE
[F114] bound the per-round endorsement propagation drain with a confi…

### DIFF
--- a/massa-api/src/tests/mock.rs
+++ b/massa-api/src/tests/mock.rs
@@ -213,6 +213,7 @@ pub(crate) fn start_public_api(addr: SocketAddr) -> (API<Public>, APIConfig) {
             genesis_timestamp: MassaTime::now(),
             t0: MassaTime::from_millis(16000),
             max_ops_kept_for_propagation: 10000,
+            max_endorsements_per_propagation_round: 10000,
             max_operations_propagation_time: MassaTime::from_millis(30000),
             max_endorsements_propagation_time: MassaTime::from_millis(60000),
             initial_peers: NamedTempFile::new()

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -347,6 +347,8 @@
     timeout_connection = 1000
     # max number of operations kept for propagation
     max_ops_kept_for_propagation = 320000
+    # max number of endorsements merged into a single propagation round
+    max_endorsements_per_propagation_round = 10000
     # time threshold after which operation are not propagated
     max_operations_propagation_time = 32000
     # time threshold after which endorsement are not propagated

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -348,7 +348,7 @@
     # max number of operations kept for propagation
     max_ops_kept_for_propagation = 320000
     # max number of endorsements merged into a single propagation round
-    max_endorsements_per_propagation_round = 10000
+    max_endorsements_per_propagation_round = 1024
     # time threshold after which operation are not propagated
     max_operations_propagation_time = 32000
     # time threshold after which endorsement are not propagated

--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -741,6 +741,9 @@ async fn launch(
         endorsement_count: ENDORSEMENT_COUNT,
         max_message_size: MAX_MESSAGE_SIZE as usize,
         max_ops_kept_for_propagation: SETTINGS.protocol.max_ops_kept_for_propagation,
+        max_endorsements_per_propagation_round: SETTINGS
+            .protocol
+            .max_endorsements_per_propagation_round,
         max_operations_propagation_time: SETTINGS.protocol.max_operations_propagation_time,
         max_endorsements_propagation_time: SETTINGS.protocol.max_endorsements_propagation_time,
         last_start_period: final_state.read().get_last_start_period(),

--- a/massa-node/src/settings.rs
+++ b/massa-node/src/settings.rs
@@ -268,6 +268,8 @@ pub struct ProtocolSettings {
     pub max_operations_per_message: u64,
     /// MAx number of operations kept for propagation
     pub max_ops_kept_for_propagation: usize,
+    /// Max number of endorsements merged into a single propagation round
+    pub max_endorsements_per_propagation_round: usize,
     /// Time threshold after which operation are not propagated
     pub max_operations_propagation_time: MassaTime,
     /// Time threshold after which operation are not propagated

--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -84,6 +84,8 @@ pub struct ProtocolConfig {
     pub genesis_timestamp: MassaTime,
     /// max number of operations kept in memory for propagation
     pub max_ops_kept_for_propagation: usize,
+    /// max number of endorsements merged into a single propagation round
+    pub max_endorsements_per_propagation_round: usize,
     /// max time we propagate operations
     pub max_operations_propagation_time: MassaTime,
     /// max time we propagate endorsements

--- a/massa-protocol-exports/src/test_exports/config.rs
+++ b/massa-protocol-exports/src/test_exports/config.rs
@@ -42,6 +42,7 @@ impl Default for ProtocolConfig {
             genesis_timestamp: MassaTime::now(),
             t0: MassaTime::from_millis(16000),
             max_ops_kept_for_propagation: 10000,
+            max_endorsements_per_propagation_round: 10000,
             max_operations_propagation_time: MassaTime::from_millis(30000),
             max_endorsements_propagation_time: MassaTime::from_millis(60000),
             initial_peers: NamedTempFile::new()

--- a/massa-protocol-worker/src/handlers/endorsement_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/propagation.rs
@@ -41,22 +41,13 @@ impl PropagationThread {
             match msg {
                 // endorsements to propagate
                 EndorsementHandlerPropagationCommand::PropagateEndorsements(mut endorsements) => {
-                    // also drain any remaining propagation messages that might have accumulated
-                    while let Ok(msg) = self.receiver.try_recv() {
-                        match msg {
-                            // we got more endorsements to propagate: extend the buffer
-                            EndorsementHandlerPropagationCommand::PropagateEndorsements(
-                                new_endorsements,
-                            ) => {
-                                endorsements.extend(new_endorsements);
-                            }
-                            // we grabbed a message that is not a propagation message, mark it for processing
-                            other_msg => {
-                                next_message = Some(other_msg);
-                                break;
-                            }
-                        }
-                    }
+                    // also drain any remaining propagation messages that might have accumulated,
+                    // within the per-round budget
+                    next_message = drain_propagation_commands(
+                        &self.receiver,
+                        &mut endorsements,
+                        self.config.max_endorsements_per_propagation_round,
+                    );
                     // propagate the endorsements
                     self.propagate_endorsements(endorsements);
                 }
@@ -139,6 +130,36 @@ impl PropagationThread {
     }
 }
 
+/// Merge the queued `PropagateEndorsements` commands into `endorsements` until the channel is
+/// empty or `max_endorsements_per_propagation_round` endorsements have been accumulated.
+///
+/// Returns a message that was pulled from the channel but not consumed by this round (a
+/// non-propagation command), which the caller must process next.
+///
+/// Bounding the drain keeps a single propagation round from growing unboundedly: without it a
+/// sustained endorsement source could make the batch (and the per-peer work derived from it)
+/// arbitrarily large. Endorsements left in the channel are not dropped, they are propagated by
+/// the next loop iteration.
+fn drain_propagation_commands(
+    receiver: &MassaReceiver<EndorsementHandlerPropagationCommand>,
+    endorsements: &mut Storage,
+    max_endorsements_per_propagation_round: usize,
+) -> Option<EndorsementHandlerPropagationCommand> {
+    while endorsements.get_endorsement_refs().len() < max_endorsements_per_propagation_round {
+        match receiver.try_recv() {
+            // we got more endorsements to propagate: extend the buffer
+            Ok(EndorsementHandlerPropagationCommand::PropagateEndorsements(new_endorsements)) => {
+                endorsements.extend(new_endorsements);
+            }
+            // we grabbed a message that is not a propagation message, mark it for processing
+            Ok(other_msg) => return Some(other_msg),
+            // nothing left to merge
+            Err(_) => break,
+        }
+    }
+    None
+}
+
 pub fn start_propagation_thread(
     receiver: MassaReceiver<EndorsementHandlerPropagationCommand>,
     cache: SharedEndorsementCache,
@@ -160,4 +181,96 @@ pub fn start_propagation_thread(
             propagation_thread.run();
         })
         .expect("OS failed to start endorsement propagation thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use massa_channel::MassaChannel;
+    use massa_hash::Hash;
+    use massa_models::{
+        block_id::BlockId,
+        endorsement::{Endorsement, EndorsementSerializer, SecureShareEndorsement},
+        secure_share::SecureShareContent,
+        slot::Slot,
+    };
+    use massa_signature::KeyPair;
+
+    /// Build an endorsement, `index` making it unique so that the storage does not deduplicate it
+    fn endorsement(index: u32) -> SecureShareEndorsement {
+        let keypair = KeyPair::generate(0).unwrap();
+        let content = Endorsement {
+            slot: Slot::new(1, 0),
+            index,
+            endorsed_block: BlockId::generate_from_hash(Hash::compute_from(b"block")),
+        };
+        Endorsement::new_verifiable(content, EndorsementSerializer::new(), &keypair, 0).unwrap()
+    }
+
+    /// Build a storage sharing `root`'s objects and holding `count` distinct endorsements
+    fn storage_with(root: &Storage, count: u32) -> Storage {
+        let mut storage = root.clone_without_refs();
+        storage.store_endorsements((0..count).map(endorsement).collect());
+        storage
+    }
+
+    #[test]
+    fn test_drain_propagation_commands_is_bounded() {
+        let root = Storage::create_root();
+        let (sender, receiver) = MassaChannel::new("test_drain_bounded".to_string(), None);
+        for _ in 0..10 {
+            sender
+                .send(EndorsementHandlerPropagationCommand::PropagateEndorsements(
+                    storage_with(&root, 3),
+                ))
+                .unwrap();
+        }
+
+        // budget of 5 endorsements: merging stops as soon as the budget is reached
+        let mut endorsements = storage_with(&root, 3);
+        assert!(drain_propagation_commands(&receiver, &mut endorsements, 5).is_none());
+        assert_eq!(endorsements.get_endorsement_refs().len(), 6);
+        // the commands over budget are left in the channel for the next round
+        assert_eq!(receiver.len(), 9);
+    }
+
+    #[test]
+    fn test_drain_propagation_commands_merges_everything_within_budget() {
+        let root = Storage::create_root();
+        let (sender, receiver) = MassaChannel::new("test_drain_full".to_string(), None);
+        for _ in 0..3 {
+            sender
+                .send(EndorsementHandlerPropagationCommand::PropagateEndorsements(
+                    storage_with(&root, 2),
+                ))
+                .unwrap();
+        }
+
+        let mut endorsements = root.clone_without_refs();
+        assert!(drain_propagation_commands(&receiver, &mut endorsements, 1000).is_none());
+        assert_eq!(endorsements.get_endorsement_refs().len(), 6);
+        assert_eq!(receiver.len(), 0);
+    }
+
+    #[test]
+    fn test_drain_propagation_commands_returns_non_propagation_command() {
+        let root = Storage::create_root();
+        let (sender, receiver) = MassaChannel::new("test_drain_stop".to_string(), None);
+        sender
+            .send(EndorsementHandlerPropagationCommand::PropagateEndorsements(
+                storage_with(&root, 2),
+            ))
+            .unwrap();
+        sender
+            .send(EndorsementHandlerPropagationCommand::Stop)
+            .unwrap();
+
+        let mut endorsements = root.clone_without_refs();
+        let next = drain_propagation_commands(&receiver, &mut endorsements, 1000);
+        assert!(matches!(
+            next,
+            Some(EndorsementHandlerPropagationCommand::Stop)
+        ));
+        assert_eq!(endorsements.get_endorsement_refs().len(), 2);
+    }
 }


### PR DESCRIPTION
…gurable budget

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification