### PR TITLE
[PDF8] fix endorsement pool index desync and bound conflicting endors…

### DIFF
--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -3,7 +3,7 @@
 use massa_models::{
     block_id::BlockId,
     endorsement::EndorsementId,
-    prehash::{CapacityAllocator, PreHashSet},
+    prehash::{CapacityAllocator, PreHashMap, PreHashSet},
     slot::Slot,
 };
 use massa_pool_exports::{PoolChannels, PoolConfig};
@@ -11,22 +11,28 @@ use massa_storage::Storage;
 use massa_wallet::Wallet;
 use parking_lot::RwLock;
 use std::{
-    collections::{hash_map::Entry, BTreeMap, HashMap},
+    collections::{hash_map::Entry, BTreeMap},
     sync::Arc,
 };
 use tracing::{trace, warn};
+
+/// Maximum number of endorsements kept for a given `(slot, index)` pair, whatever the endorsed
+/// block is. Only one endorsement per `(slot, index)` can ever end up in a block, and an honest
+/// endorser signs exactly one. The endorsed block is not constrained at ingress, so without this
+/// bound an equivocating drawn endorser could mint arbitrarily many valid endorsements differing
+/// only by their endorsed block and grow the pool without limit.
+const MAX_ENDORSEMENTS_PER_SLOT_INDEX: usize = 1;
 
 #[derive(Clone)]
 pub struct EndorsementPool {
     /// configuration
     config: PoolConfig,
 
-    /// endorsements indexed by slot, index and block ID
-    endorsements_indexed: HashMap<(Slot, u32, BlockId), EndorsementId>,
-
-    /// endorsements sorted by increasing inclusion slot for pruning
-    /// indexed by thread, then `BTreeMap<(inclusion_slot, index, target_block), endorsement_id>`
-    endorsements_sorted: Vec<BTreeMap<(Slot, u32, BlockId), EndorsementId>>,
+    /// endorsements sorted by increasing inclusion slot for pruning,
+    /// indexed by thread, then `BTreeMap<(inclusion_slot, index), map of endorsement_id by target block>`.
+    /// This is the single source of truth of the pool contents: keeping a second index keyed on the
+    /// target block would risk desynchronizing on pruning and leak entries.
+    endorsements_sorted: Vec<BTreeMap<(Slot, u32), PreHashMap<BlockId, EndorsementId>>>,
 
     /// storage
     storage: Storage,
@@ -50,7 +56,6 @@ impl EndorsementPool {
     ) -> Self {
         EndorsementPool {
             last_cs_final_periods: vec![0u64; config.thread_count as usize],
-            endorsements_indexed: Default::default(),
             endorsements_sorted: vec![Default::default(); config.thread_count as usize],
             config,
             storage: storage.clone_without_refs(),
@@ -63,7 +68,6 @@ impl EndorsementPool {
     /// This is used for double buffering.
     pub(crate) fn replace_with(&mut self, other: &EndorsementPool) {
         self.last_cs_final_periods = other.last_cs_final_periods.clone();
-        self.endorsements_indexed = other.endorsements_indexed.clone();
         self.endorsements_sorted = other.endorsements_sorted.clone();
         self.storage.replace_with(&other.storage);
     }
@@ -86,18 +90,17 @@ impl EndorsementPool {
         // remove all endorsements whose periods <= last_cs_final_periods[endorsement.thread]
         let mut removed: PreHashSet<EndorsementId> = Default::default();
         for thread in 0..self.config.thread_count {
-            while let Some((&(inclusion_slot, index, block_id), &endo_id)) =
+            while let Some((&(inclusion_slot, _index), _)) =
                 self.endorsements_sorted[thread as usize].first_key_value()
             {
-                if inclusion_slot.period <= self.last_cs_final_periods[thread as usize] {
-                    self.endorsements_sorted[thread as usize].pop_first();
-                    self.endorsements_indexed
-                        .remove(&(inclusion_slot, index, block_id))
-                        .expect("endorsement should be in endorsements_indexed at this point");
-                    removed.insert(endo_id);
-                } else {
+                if inclusion_slot.period > self.last_cs_final_periods[thread as usize] {
                     break;
                 }
+                // won't panic because first_key_value returned an entry above
+                let (_key, endos) = self.endorsements_sorted[thread as usize]
+                    .pop_first()
+                    .unwrap();
+                removed.extend(endos.into_values());
             }
         }
         self.storage.drop_endorsement_refs(&removed);
@@ -175,20 +178,25 @@ impl EndorsementPool {
                 }
 
                 // insert
-                let key = (
-                    endo.content.slot,
-                    endo.content.index,
-                    endo.content.endorsed_block,
-                );
+                let by_target_block = self.endorsements_sorted[endo.content.slot.thread as usize]
+                    .entry((endo.content.slot, endo.content.index))
+                    .or_default();
+                let is_full = by_target_block.len() >= MAX_ENDORSEMENTS_PER_SLOT_INDEX;
                 // note that we don't want equivalent endorsements (slot, index, block etc...) to overwrite each other
-                if let Entry::Vacant(e) = self.endorsements_indexed.entry(key) {
-                    e.insert(endo.id);
-                    if self.endorsements_sorted[endo.content.slot.thread as usize]
-                        .insert(key, endo.id)
-                        .is_some()
-                    {
-                        panic!("endorsement is expected to be absent from endorsements_sorted at this point");
+                if let Entry::Vacant(e) = by_target_block.entry(endo.content.endorsed_block) {
+                    // refuse conflicting endorsements beyond the per-(slot, index) bound: the
+                    // endorsed block is not constrained at ingress, so without it an equivocating
+                    // drawn endorser could flood the pool
+                    if is_full {
+                        warn!(
+                            "ignoring endorsement {} at slot {} index {}: too many conflicting endorsements for that draw",
+                            endo.id.clone(),
+                            endo.content.slot,
+                            endo.content.index
+                        );
+                        continue;
                     }
+                    e.insert(endo.id);
                     added.insert(endo.id);
                 }
             }
@@ -200,11 +208,13 @@ impl EndorsementPool {
                 > self.config.max_endorsements_pool_size_per_thread
             {
                 // won't panic because len was checked above
-                let (_key, endo_id) = self.endorsements_sorted[thread as usize]
+                let (_key, endos) = self.endorsements_sorted[thread as usize]
                     .pop_last()
                     .unwrap();
-                if !added.remove(&endo_id) {
-                    removed.insert(endo_id);
+                for endo_id in endos.into_values() {
+                    if !added.remove(&endo_id) {
+                        removed.insert(endo_id);
+                    }
                 }
             }
         }
@@ -230,12 +240,14 @@ impl EndorsementPool {
         let mut endo_ids = Vec::with_capacity(self.config.max_block_endorsement_count as usize);
 
         // gather endorsements
+        let thread_endorsements = self.endorsements_sorted.get(slot.thread as usize);
         for index in 0..self.config.max_block_endorsement_count {
-            endo_ids.push(
-                self.endorsements_indexed
-                    .get(&(*slot, index, *target_block))
-                    .copied(),
-            );
+            endo_ids.push(thread_endorsements.and_then(|endos| {
+                endos
+                    .get(&(*slot, index))
+                    .and_then(|by_target_block| by_target_block.get(target_block))
+                    .copied()
+            }));
         }
 
         // setup endorsement storage
@@ -244,7 +256,18 @@ impl EndorsementPool {
             endo_ids.iter().filter_map(|&opt| opt).collect();
         let claimed_endos = endo_storage.claim_endorsement_refs(&claim_endos);
         if claimed_endos.len() != claim_endos.len() {
-            panic!("could not claim all endorsements from storage");
+            // The pool holds a storage reference for every endorsement it indexes, so this should
+            // not happen. Drop the unclaimable ones instead of killing the pool worker: producing a
+            // block with fewer endorsements is always better than not producing one at all.
+            warn!(
+                "could not claim all endorsements from storage for a block at slot {}",
+                slot
+            );
+            for endo_id in endo_ids.iter_mut() {
+                if endo_id.map_or(false, |id| !claimed_endos.contains(&id)) {
+                    *endo_id = None;
+                }
+            }
         }
 
         (endo_ids, endo_storage)

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -17,11 +17,19 @@ use std::{
 use tracing::{trace, warn};
 
 /// Maximum number of endorsements kept for a given `(slot, index)` pair, whatever the endorsed
-/// block is. Only one endorsement per `(slot, index)` can ever end up in a block, and an honest
-/// endorser signs exactly one. The endorsed block is not constrained at ingress, so without this
-/// bound an equivocating drawn endorser could mint arbitrarily many valid endorsements differing
-/// only by their endorsed block and grow the pool without limit.
-const MAX_ENDORSEMENTS_PER_SLOT_INDEX: usize = 1;
+/// block is. An honest endorser signs exactly one endorsement per `(slot, index)`: the factory
+/// walks slots strictly monotonically and never re-endorses after a reorg. So several entries
+/// under the same key mean the drawn endorser equivocated, and the endorsed block is not
+/// constrained at ingress: without a bound such an endorser could mint arbitrarily many valid
+/// endorsements differing only by their endorsed block and grow the pool without limit.
+///
+/// The bound is kept above 1 because [`EndorsementPool::get_block_endorsements`] only returns the
+/// endorsement matching the parent the block factory settled on. Keeping a single variant makes
+/// insertion first-write-wins, letting an equivocating endorser deliberately send the variant that
+/// does not match our parent and permanently deny us that endorsement slot, which costs block
+/// fitness and rewards. A few variants cover the competing blockclique tips of a real fork while
+/// keeping the worst-case pool size within a small multiple of `max_endorsements_pool_size_per_thread`.
+pub(crate) const MAX_ENDORSEMENTS_PER_SLOT_INDEX: usize = 4;
 
 #[derive(Clone)]
 pub struct EndorsementPool {

--- a/massa-pool-worker/src/tests/endorsement_pool_tests.rs
+++ b/massa-pool-worker/src/tests/endorsement_pool_tests.rs
@@ -1,11 +1,13 @@
 use std::{collections::BTreeMap, time::Duration};
 
-use massa_models::{address::Address, config::THREAD_COUNT, slot::Slot};
+use massa_models::{address::Address, config::THREAD_COUNT, prehash::PreHashSet, slot::Slot};
 use massa_pool_exports::PoolConfig;
 use massa_pos_exports::{MockSelectorController, Selection};
 use massa_signature::KeyPair;
 
-use super::tools::{create_endorsement, default_mock_execution_controller, pool_test};
+use super::tools::{
+    create_endorsement, create_endorsement_on_block, default_mock_execution_controller, pool_test,
+};
 
 fn create_selector_mock_with_address(address: Address) -> MockSelectorController {
     let mut res = MockSelectorController::new();
@@ -268,6 +270,128 @@ fn test_get_block_endorsements_works() {
             assert!(endorsement_ids[0].is_some());
             assert!(endorsement_ids[1].is_some());
             assert_eq!(endorsements_storage.get_endorsement_refs().len(), 2);
+        },
+    );
+}
+
+/// A drawn endorser can sign arbitrarily many valid endorsements for the same `(slot, index)`
+/// that only differ by their endorsed block. The pool must only keep a bounded number of them.
+#[test]
+fn test_bound_conflicting_endorsements_per_slot_index() {
+    let sender_keypair = KeyPair::generate(0).unwrap();
+    let address = Address::from_public_key(&sender_keypair.get_public_key());
+    let execution_controller = default_mock_execution_controller();
+    let selector_controller = default_mock_selector(address);
+    pool_test(
+        PoolConfig::default(),
+        execution_controller,
+        selector_controller,
+        Some((address, sender_keypair.clone())),
+        |mut pool, mut storage| {
+            let endorsements: Vec<_> = (0..10)
+                .map(|i| {
+                    create_endorsement_on_block(
+                        &sender_keypair,
+                        0,
+                        Slot::new(1, 2),
+                        &format!("conflicting_block_{}", i),
+                    )
+                })
+                .collect();
+            storage.store_endorsements(endorsements);
+            pool.add_endorsements(storage.clone());
+            // Allow some time for the pool to add the endorsements
+            std::thread::sleep(Duration::from_secs(2));
+            assert_eq!(
+                pool.get_endorsement_count(None)
+                    .expect("Failed to get endorsement count"),
+                1
+            );
+        },
+    );
+}
+
+/// Pruning used to drop an endorsement from the sort index only, leaving the lookup index pointing
+/// at an endorsement whose storage reference had been released. Looking that endorsement up for
+/// block creation then panicked, halting the pool worker.
+#[test]
+fn test_pruned_endorsements_are_not_returned_for_block_creation() {
+    let sender_keypair = KeyPair::generate(0).unwrap();
+    let address = Address::from_public_key(&sender_keypair.get_public_key());
+    let execution_controller = default_mock_execution_controller();
+    let selector_controller = default_mock_selector(address);
+    let cfg = PoolConfig {
+        max_endorsements_pool_size_per_thread: 1,
+        ..Default::default()
+    };
+    pool_test(
+        cfg,
+        execution_controller,
+        selector_controller,
+        Some((address, sender_keypair.clone())),
+        |mut pool, mut storage| {
+            // both endorsements land in thread 2, so the second one is pruned away by the size cap
+            let kept = create_endorsement(&sender_keypair, 0, Slot::new(1, 2));
+            let pruned = create_endorsement(&sender_keypair, 0, Slot::new(2, 2));
+            storage.store_endorsements(vec![kept.clone(), pruned.clone()]);
+            pool.add_endorsements(storage.clone());
+            // Allow some time for the pool to add the endorsements
+            std::thread::sleep(Duration::from_secs(2));
+            assert_eq!(
+                pool.contains_endorsements(&[kept.id, pruned.id], None)
+                    .expect("Failed to check contains endorsements"),
+                vec![true, false]
+            );
+
+            // release the caller-side reference so that nothing keeps the pruned endorsement alive
+            // in storage anymore
+            storage.drop_endorsement_refs(&PreHashSet::from_iter([pruned.id]));
+
+            // the pruned endorsement must not be handed out for block creation (used to panic)
+            let (endorsement_ids, endorsements_storage) = pool
+                .get_block_endorsements(&pruned.content.endorsed_block, &Slot::new(2, 2), None)
+                .expect("Failed to get block endorsements");
+            assert!(endorsement_ids.iter().all(|id| id.is_none()));
+            assert!(endorsements_storage.get_endorsement_refs().is_empty());
+
+            // the endorsement that was kept is still available
+            let (endorsement_ids, _) = pool
+                .get_block_endorsements(&kept.content.endorsed_block, &Slot::new(1, 2), None)
+                .expect("Failed to get block endorsements");
+            assert_eq!(endorsement_ids[0], Some(kept.id));
+        },
+    );
+}
+
+/// After finalization pruning, nothing must be left behind in the pool for the finalized slots.
+#[test]
+fn test_finalization_leaves_no_orphan_entry() {
+    let sender_keypair = KeyPair::generate(0).unwrap();
+    let address = Address::from_public_key(&sender_keypair.get_public_key());
+    let execution_controller = default_mock_execution_controller();
+    let selector_controller = default_mock_selector(address);
+    pool_test(
+        PoolConfig::default(),
+        execution_controller,
+        selector_controller,
+        Some((address, sender_keypair.clone())),
+        |mut pool, mut storage| {
+            let endorsement = create_endorsement(&sender_keypair, 0, Slot::new(1, 2));
+            storage.store_endorsements(vec![endorsement.clone()]);
+            pool.add_endorsements(storage.clone());
+            std::thread::sleep(Duration::from_secs(2));
+            pool.notify_final_cs_periods(&vec![1; THREAD_COUNT as usize]);
+            std::thread::sleep(Duration::from_secs(2));
+
+            assert_eq!(
+                pool.get_endorsement_count(None)
+                    .expect("Failed to get endorsement count"),
+                0
+            );
+            let (endorsement_ids, _) = pool
+                .get_block_endorsements(&endorsement.content.endorsed_block, &Slot::new(1, 2), None)
+                .expect("Failed to get block endorsements");
+            assert!(endorsement_ids.iter().all(|id| id.is_none()));
         },
     );
 }

--- a/massa-pool-worker/src/tests/endorsement_pool_tests.rs
+++ b/massa-pool-worker/src/tests/endorsement_pool_tests.rs
@@ -8,6 +8,7 @@ use massa_signature::KeyPair;
 use super::tools::{
     create_endorsement, create_endorsement_on_block, default_mock_execution_controller, pool_test,
 };
+use crate::endorsement_pool::MAX_ENDORSEMENTS_PER_SLOT_INDEX;
 
 fn create_selector_mock_with_address(address: Address) -> MockSelectorController {
     let mut res = MockSelectorController::new();
@@ -305,8 +306,53 @@ fn test_bound_conflicting_endorsements_per_slot_index() {
             assert_eq!(
                 pool.get_endorsement_count(None)
                     .expect("Failed to get endorsement count"),
-                1
+                MAX_ENDORSEMENTS_PER_SLOT_INDEX
             );
+        },
+    );
+}
+
+/// The bound must leave room for more than one endorsed block per `(slot, index)`: an equivocating
+/// endorser sending a variant that does not match the parent our block factory settles on must not
+/// be able to deny us the endorsement variant that does match it.
+#[test]
+fn test_conflicting_endorsement_does_not_deny_the_matching_one() {
+    let sender_keypair = KeyPair::generate(0).unwrap();
+    let address = Address::from_public_key(&sender_keypair.get_public_key());
+    let execution_controller = default_mock_execution_controller();
+    let selector_controller = default_mock_selector(address);
+    pool_test(
+        PoolConfig::default(),
+        execution_controller,
+        selector_controller,
+        Some((address, sender_keypair.clone())),
+        |mut pool, mut storage| {
+            // fill the draw with conflicting variants, one of which endorses the parent our block
+            // factory will settle on. Insertion order is not controlled, so stay at the bound to
+            // assert order-independently that the matching variant is never the one evicted.
+            let matching =
+                create_endorsement_on_block(&sender_keypair, 0, Slot::new(1, 2), "our_parent");
+            let mut endorsements: Vec<_> = (0..MAX_ENDORSEMENTS_PER_SLOT_INDEX - 1)
+                .map(|i| {
+                    create_endorsement_on_block(
+                        &sender_keypair,
+                        0,
+                        Slot::new(1, 2),
+                        &format!("other_tip_{}", i),
+                    )
+                })
+                .collect();
+            endorsements.push(matching.clone());
+            let target_block = matching.content.endorsed_block;
+            storage.store_endorsements(endorsements);
+            pool.add_endorsements(storage.clone());
+            // Allow some time for the pool to add the endorsements
+            std::thread::sleep(Duration::from_secs(2));
+
+            let (endorsement_ids, _) = pool
+                .get_block_endorsements(&target_block, &Slot::new(1, 2), None)
+                .expect("Failed to get block endorsements");
+            assert_eq!(endorsement_ids[0], Some(matching.id));
         },
     );
 }

--- a/massa-pool-worker/src/tests/tools.rs
+++ b/massa-pool-worker/src/tests/tools.rs
@@ -178,10 +178,20 @@ pub fn create_endorsement(
     index: u32,
     slot: Slot,
 ) -> SecureShareEndorsement {
+    create_endorsement_on_block(sender_keypair, index, slot, "blabla")
+}
+
+/// Creates an endorsement endorsing a block derived from `block_seed`, for use in pool tests.
+pub fn create_endorsement_on_block(
+    sender_keypair: &KeyPair,
+    index: u32,
+    slot: Slot,
+    block_seed: &str,
+) -> SecureShareEndorsement {
     let content = Endorsement {
         slot,
         index,
-        endorsed_block: BlockId::generate_from_hash(Hash::compute_from("blabla".as_bytes())),
+        endorsed_block: BlockId::generate_from_hash(Hash::compute_from(block_seed.as_bytes())),
     };
     Endorsement::new_verifiable(
         content,


### PR DESCRIPTION
…ements per draw

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification