### PR TITLE
[F144] document that massa-sdk's certificate_store setting is ignored…

### DIFF
--- a/massa-client/base_config/config.toml
+++ b/massa-client/base_config/config.toml
@@ -23,6 +23,8 @@ chain_id = 77658377
     # maximum number of outcoming connections allowed
     max_concurrent_requests = 100
     # certificate_store, `Native` or `WebPki`
+    # deprecated: this setting is currently ignored, the client connects to the node over
+    # plaintext http/ws/grpc. It is kept to avoid breaking existing configuration files.
     certificate_store = "Native"
     # JSON-RPC request object id data type, `String` or `Number`
     id_kind = "Number"

--- a/massa-sdk/src/config.rs
+++ b/massa-sdk/src/config.rs
@@ -13,6 +13,11 @@ pub struct ClientConfig {
     /// maximum concurrent requests.
     pub max_concurrent_requests: usize,
     /// certificate_store, `Native` or `WebPki`
+    ///
+    /// Deprecated: this setting is currently ignored. The underlying `jsonrpsee` client no
+    /// longer exposes a trust-store selection, and TLS is instead enabled by using an
+    /// `https`/`wss` url, validated against the platform trust store. It is kept to avoid
+    /// breaking existing configuration files.
     pub certificate_store: String,
     /// JSON-RPC request object id data type, `Number` or `String`
     pub id_kind: String,

--- a/massa-sdk/src/lib.rs
+++ b/massa-sdk/src/lib.rs
@@ -82,6 +82,11 @@ pub struct Client {
 
 impl Client {
     /// creates a new client
+    ///
+    /// Note: this constructor always uses plaintext transports (`http` for the JSON-RPC
+    /// APIs, `grpc` for the gRPC APIs) and cannot connect to a node whose gRPC server has
+    /// `enable_tls` set. For a TLS-enabled JSON-RPC endpoint, build the client with
+    /// [`RpcClient::from_url`] and an `https` url instead.
     pub async fn new(
         ip: IpAddr,
         public_port: u16,
@@ -141,6 +146,9 @@ pub struct RpcClient {
 
 impl RpcClient {
     /// Default constructor
+    ///
+    /// The transport is selected by the scheme of `url`: an `https` url yields a TLS
+    /// client validating the server against the platform trust store.
     pub async fn from_url(url: &str, http_config: &HttpConfig) -> RpcClient {
         RpcClient {
             http_client: http_client_from_url(url, http_config),
@@ -476,6 +484,9 @@ pub struct ClientV2 {
 
 impl ClientV2 {
     /// creates a new client
+    ///
+    /// Note: this constructor always uses plaintext transports (`http` and `ws`), see
+    /// [`Client::new`].
     pub async fn new(
         ip: IpAddr,
         api_port: u16,
@@ -650,15 +661,8 @@ fn http_client_from_url(url: &str, http_config: &HttpConfig) -> HttpClient<HttpB
         .id_format(get_id_kind(http_config.client_config.id_kind.as_str()))
         .set_headers(get_headers(&http_config.client_config.headers));
 
-    // Note: use_*_rustls() are not available anymore
-    //       keep the config for compatibility reason but this will be unused
-    /*
-    match http_config.client_config.certificate_store.as_str() {
-        "Native" => builder = builder.use_native_rustls(),
-        "WebPki" => builder = builder.use_webpki_rustls(),
-        _ => {}
-    }
-    */
+    // Note: `client_config.certificate_store` is ignored here, see its documentation.
+    //       TLS is selected by the `https` scheme of `url`, using the platform trust store.
 
     builder
         .build(url)
@@ -678,15 +682,8 @@ where
         .max_buffer_capacity_per_subscription(ws_config.max_notifs_per_subscription)
         .max_redirections(ws_config.max_redirections);
 
-    // Note: use_*_rustls() are not available anymore
-    //       keep the config for compatibility reason but this will be unused
-    /*
-    match ws_config.client_config.certificate_store.as_str() {
-        "Native" => builder = builder.use_native_rustls(),
-        "WebPki" => builder = builder.use_webpki_rustls(),
-        _ => {}
-    }
-    */
+    // Note: `client_config.certificate_store` is ignored here, see its documentation.
+    //       TLS is selected by the `wss` scheme of `url`, using the platform trust store.
 
     builder
         .build(url)


### PR DESCRIPTION
… by the plaintext client constructors

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification