### PR TITLE
[F73] refuse to start the gRPC API when enable_mtls is set without en…

### DIFF
--- a/massa-grpc/src/error.rs
+++ b/massa-grpc/src/error.rs
@@ -43,6 +43,8 @@ pub enum GrpcError {
     InternalServerError(String),
     /// Invalid argument error: {0}
     InvalidArgument(String),
+    /// Invalid configuration error: {0}
+    ConfigError(String),
     /// Not implemented error: {0}
     Unimplemented(String),
 }
@@ -63,6 +65,7 @@ impl From<GrpcError> for tonic::Status {
             GrpcError::InternalServerError(e) => tonic::Status::internal(e),
             GrpcError::ReflectionError(e) => tonic::Status::internal(e.to_string()),
             GrpcError::InvalidArgument(e) => tonic::Status::invalid_argument(e),
+            GrpcError::ConfigError(e) => tonic::Status::internal(e),
             GrpcError::Unimplemented(e) => tonic::Status::unimplemented(e),
         }
     }

--- a/massa-grpc/src/server.rs
+++ b/massa-grpc/src/server.rs
@@ -169,6 +169,19 @@ async fn massa_service_status(mut reporter: HealthReporter) {
         .await;
 }
 
+/// mTLS is a strict extension of TLS: reject the combination rather than silently serving in
+/// plaintext a service the operator meant to protect with client certificates.
+pub(crate) fn check_mtls_requires_tls(config: &GrpcConfig) -> Result<(), GrpcError> {
+    if config.enable_mtls && !config.enable_tls {
+        return Err(GrpcError::ConfigError(format!(
+            "gRPC {:?} API: `enable_mtls` requires `enable_tls` to be enabled, refusing to start in plaintext",
+            config.name
+        )));
+    }
+
+    Ok(())
+}
+
 // Configure and start the gRPC API with the given service
 async fn serve<S>(service: S, config: &GrpcConfig) -> Result<StopHandle, GrpcError>
 where
@@ -179,6 +192,8 @@ where
         + 'static,
     S::Future: Send + 'static,
 {
+    check_mtls_requires_tls(config)?;
+
     let (shutdown_send, shutdown_recv) = oneshot::channel::<()>();
 
     let mut server_builder = tonic::transport::Server::builder()

--- a/massa-grpc/src/tests/mod.rs
+++ b/massa-grpc/src/tests/mod.rs
@@ -6,4 +6,6 @@ pub mod mock;
 #[cfg(test)]
 mod public;
 #[cfg(test)]
+mod server;
+#[cfg(test)]
 mod stream;

--- a/massa-grpc/src/tests/server.rs
+++ b/massa-grpc/src/tests/server.rs
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 MASSA LABS <info@massa.net>
+
+use crate::server::check_mtls_requires_tls;
+use crate::tests::mock::grpc_public_service;
+
+#[test]
+fn test_mtls_requires_tls() {
+    let addr = "[::]:2222".parse().unwrap();
+    let mut config = grpc_public_service(&addr).grpc_config;
+
+    // plaintext, the default: accepted
+    config.enable_tls = false;
+    config.enable_mtls = false;
+    assert!(check_mtls_requires_tls(&config).is_ok());
+
+    // mTLS on top of TLS: accepted
+    config.enable_tls = true;
+    config.enable_mtls = true;
+    assert!(check_mtls_requires_tls(&config).is_ok());
+
+    // TLS without mTLS: accepted
+    config.enable_tls = true;
+    config.enable_mtls = false;
+    assert!(check_mtls_requires_tls(&config).is_ok());
+
+    // mTLS without TLS: rejected, this would silently serve in plaintext
+    config.enable_tls = false;
+    config.enable_mtls = true;
+    let err = check_mtls_requires_tls(&config).unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("`enable_mtls` requires `enable_tls`"));
+}

--- a/massa-node/base_config/config.toml
+++ b/massa-node/base_config/config.toml
@@ -141,7 +141,7 @@
         # whether to enable TLS
         enable_tls = false
         # whether to enable mTLS (requires `enable_tls` to be true)
-        enable_mtls = true
+        enable_mtls = false
         # whether to generate a self-signed certificate if none is provided(ignored if `enable_tls` is false)
         generate_self_signed_certificates = true
         # list of subject alternative names for the server certificate(requires `generate_self_signed_certificates` to be true)


### PR DESCRIPTION
…able_tls

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification