### PR TITLE
[F107] prune expired propagation entries before insert and warn on co…

### DIFF
--- a/massa-node/src/main.rs
+++ b/massa-node/src/main.rs
@@ -843,6 +843,24 @@ async fn launch(
         chain_id: *CHAINID,
     };
 
+    // Blocks are kept in the shared storage by consensus until they are older than
+    // `force_keep_final_periods` (past that point `strip_to_block` drops the storage
+    // reference, so the block is no longer servable to peers). That retention is what
+    // covers the tail of the propagation window when the propagation cache has to evict
+    // an entry early because of its `max_blocks_kept_for_propagation` size cap.
+    let consensus_block_retention = consensus_config
+        .t0
+        .saturating_mul(consensus_config.force_keep_final_periods);
+    if consensus_block_retention < protocol_config.max_block_propagation_time {
+        warn!(
+            "consensus only keeps blocks for {:?} (force_keep_final_periods={} * t0={:?}) which is shorter than max_block_propagation_time={:?}: a block evicted early by the max_blocks_kept_for_propagation cap will not be retrievable by peers anymore, consider raising force_keep_final_periods or lowering max_block_propagation_time",
+            consensus_block_retention.to_duration(),
+            consensus_config.force_keep_final_periods,
+            consensus_config.t0.to_duration(),
+            protocol_config.max_block_propagation_time.to_duration()
+        );
+    }
+
     let (consensus_event_sender, consensus_event_receiver) =
         MassaChannel::new("consensus_event".to_string(), Some(CHANNEL_SIZE));
     let consensus_channels = ConsensusChannels {

--- a/massa-protocol-worker/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/propagation.rs
@@ -10,6 +10,9 @@
 //!
 //! Here we need to announce block headers to other nodes that haven't sene them,
 //! and keep the blocks alive long enough for our peers to be able to retrieve them from us.
+//! That retention is best-effort: blocks are kept for `max_block_propagation_time` unless
+//! the `max_blocks_kept_for_propagation` size cap forces an earlier eviction. Blocks that
+//! are still active in the graph remain retrievable through consensus storage anyway.
 
 use super::{
     cache::SharedBlockCache, commands_propagation::BlockHandlerPropagationCommand,
@@ -53,7 +56,8 @@ pub struct PropagationThread {
     config: ProtocolConfig,
     /// Shared access to the block cache
     cache: SharedBlockCache,
-    /// Blocks stored for propagation
+    /// Blocks stored for propagation, bounded both by `max_block_propagation_time`
+    /// and by `max_blocks_kept_for_propagation` entries
     stored_for_propagation: LruMap<BlockId, BlockPropagationData>,
     /// Shared access to the list of peers connected to us
     active_connections: Box<dyn ActiveConnectionsTrait>,
@@ -104,11 +108,34 @@ impl PropagationThread {
                                 .insert(block_id, header.clone());
 
                             // Add the block and its dependencies to the propagation LRU
-                            // to ensure they are stored for the time of the propagation.
+                            // to keep them stored for the duration of the propagation.
+                            // Retention is best-effort: entries normally leave the map once
+                            // `max_block_propagation_time` has elapsed, but the map is also
+                            // capped at `max_blocks_kept_for_propagation` entries to bound
+                            // memory. Drop expired entries first so that the size cap only
+                            // ever cuts the propagation window short when the node really
+                            // integrates more blocks than the cap allows.
+                            let now = Instant::now();
+                            self.prune_expired_propagations(now);
+                            if self.stored_for_propagation.len()
+                                >= self.config.max_blocks_kept_for_propagation
+                            {
+                                if let Some((evicted_id, evicted)) =
+                                    self.stored_for_propagation.peek_oldest()
+                                {
+                                    warn!(
+                                        "block propagation cache full ({} entries): dropping block {} after only {:?} of propagation instead of {:?}, consider raising max_blocks_kept_for_propagation",
+                                        self.config.max_blocks_kept_for_propagation,
+                                        evicted_id,
+                                        now.saturating_duration_since(evicted.time_added),
+                                        self.config.max_block_propagation_time.to_duration()
+                                    );
+                                }
+                            }
                             self.stored_for_propagation.insert(
                                 block_id,
                                 BlockPropagationData {
-                                    time_added: Instant::now(),
+                                    time_added: now,
                                     _storage: storage,
                                     header,
                                 },
@@ -160,11 +187,10 @@ impl PropagationThread {
         }
     }
 
-    /// Propagate blocks to peers that need them
-    fn perform_propagations(&mut self) {
-        let now = Instant::now();
-
-        // stop propagating blocks that have been propagating for too long
+    /// Drop the blocks that have been propagating for longer than `max_block_propagation_time`.
+    /// Entries are inserted in chronological order and never promoted, so the LRU order
+    /// matches the insertion order and stopping at the first non-expired entry is enough.
+    fn prune_expired_propagations(&mut self, now: Instant) {
         while let Some(time_added) = self
             .stored_for_propagation
             .peek_oldest()
@@ -178,6 +204,14 @@ impl PropagationThread {
                 break;
             }
         }
+    }
+
+    /// Propagate blocks to peers that need them
+    fn perform_propagations(&mut self) {
+        let now = Instant::now();
+
+        // stop propagating blocks that have been propagating for too long
+        self.prune_expired_propagations(now);
 
         // update caches based on currently connected peers
         let peers_connected = self.active_connections.get_peer_ids_connected();


### PR DESCRIPTION
…unt-based eviction

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification