### PR TITLE
[F63] fix: update shutdown timing to contain last_start_period

### DIFF
--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -439,14 +439,10 @@ fn shutdown_range(
                 last_slot_before_downtime, e
             ))
         })?;
-    let shutdown_end = Slot::new(last_start_period, 0)
-        .get_prev_slot(cfg.thread_count)
-        .map_err(|e| {
-            BootstrapError::GeneralError(format!(
-                "the server announced a downtime ending at period {}, which has no previous slot: {}",
-                last_start_period, e
-            ))
-        })?;
+    // Include the entire last_start_period as downtime: interpolation attaches at
+    // Slot(last_start_period, thread_count - 1) and block production resumes only
+    // at Slot(last_start_period + 1, 0).
+    let shutdown_end = Slot::new(last_start_period, cfg.thread_count.saturating_sub(1));
     Ok((shutdown_start, shutdown_end))
 }
 

--- a/massa-final-state/src/final_state.rs
+++ b/massa-final-state/src/final_state.rs
@@ -748,14 +748,10 @@ impl FinalState {
                     e
                 ))
             })?;
-        let shutdown_end = Slot::new(last_start_period, 0)
-            .get_prev_slot(config.thread_count)
-            .map_err(|e| {
-                FinalStateError::InvalidSlot(format!(
-                    "Unable to compute prev slot from last start period: {:?}",
-                    e
-                ))
-            })?;
+        // Include the entire last_start_period as downtime: interpolation attaches at
+        // Slot(last_start_period, thread_count - 1) and block production resumes only
+        // at Slot(last_start_period + 1, 0).
+        let shutdown_end = Slot::new(last_start_period, config.thread_count.saturating_sub(1));
         debug!(
             "Checking if MIP store is consistent against shutdown period: {} - {}",
             shutdown_start, shutdown_end


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

This fixes the check we do to make sure no MIP starts or ends during a downtime.