### PR TITLE
[F116] bound endorsement slots by an acceptance window instead of ban…

### DIFF
--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -199,11 +199,13 @@ fn is_endorsement_fresh(
 ///
 /// Caches knowledge of valid ones.
 ///
-/// Does not ban if the endorsement is invalid
+/// Returns an error if the peer must be banned.
 ///
 /// Checks performed:
 /// - Valid signature.
-/// - The creator is the endorser drawn for the endorsement's `(slot, index)` pair.
+/// - Endorsement slot not too far in the future (peer offense if it is).
+/// - The creator is the endorser drawn for the endorsement's `(slot, index)` pair, when the draws
+///   of that slot are locally available.
 /// - At most `MAX_ENDORSEMENTS_PER_SLOT_INDEX` distinct endorsements are noted for a given draw,
 ///   so that an equivocating endorser cannot have us relay unlimited variants of its endorsement.
 #[allow(clippy::too_many_arguments)]
@@ -252,15 +254,68 @@ pub(crate) fn note_endorsements_from_peer(
             .collect::<Vec<_>>(),
     )?;
 
-    // Check PoS draws
-    for endorsement in new_endorsements.values() {
-        let selection = selector_controller
-            .get_selection(endorsement.content.slot)?
-            .endorsements;
+    let now = MassaTime::now();
+
+    // Check the endorsement slots and the PoS draws.
+    //
+    // An endorsement is created at its own slot, so its slot can only be as far ahead of our clock
+    // as the propagation window, plus one period of tolerance for clock drift. Beyond that the
+    // endorsement is invalid whatever our local state is, and propagating it would amplify it, so we
+    // fail the whole batch and the caller bans the peer.
+    //
+    // Endorsements that are too old, and endorsements whose cycle draws are not available locally,
+    // are only dropped: both cases happen to honest peers (respectively a slow propagation and a
+    // selector of ours that has not caught up yet). They are not marked as checked either, so that
+    // they get validated again if we see them later.
+    let slot_acceptance_margin = config
+        .max_endorsements_propagation_time
+        .saturating_add(config.t0);
+    let mut unchecked_endorsements = PreHashSet::with_capacity(new_endorsements.len());
+    for (endorsement_id, endorsement) in new_endorsements.iter() {
+        let slot = endorsement.content.slot;
+        let slot_timestamp = get_block_slot_timestamp(
+            config.thread_count,
+            config.t0,
+            config.genesis_timestamp,
+            slot,
+        )
+        .map_err(|err| {
+            ProtocolError::GeneralProtocolError(format!(
+                "Endorsement slot {} does not have a valid timestamp: {}",
+                slot, err
+            ))
+        })?;
+        if slot_timestamp > now.saturating_add(slot_acceptance_margin) {
+            return Err(ProtocolError::GeneralProtocolError(format!(
+                "Endorsement slot {} is too far in the future",
+                slot
+            )));
+        }
+        if slot_timestamp.saturating_add(slot_acceptance_margin) < now {
+            debug!(
+                "Ignoring endorsement {} from peer {}: its slot {} is too old",
+                endorsement_id, from_peer_id, slot
+            );
+            unchecked_endorsements.insert(*endorsement_id);
+            continue;
+        }
+
+        let selection = match selector_controller.get_selection(slot) {
+            Ok(selection) => selection.endorsements,
+            Err(err) => {
+                debug!(
+                    "Could not check the PoS draws of endorsement {} at slot {} because our local \
+                    selector is not ready: {}. Ignoring it without banning peer {}.",
+                    endorsement_id, slot, err, from_peer_id
+                );
+                unchecked_endorsements.insert(*endorsement_id);
+                continue;
+            }
+        };
         let Some(address) = selection.get(endorsement.content.index as usize) else {
             return Err(ProtocolError::GeneralProtocolError(format!(
                 "No selection on slot {} for index {}",
-                endorsement.content.slot, endorsement.content.index
+                slot, endorsement.content.index
             )));
         };
         if address != &endorsement.content_creator_address {
@@ -270,18 +325,21 @@ pub(crate) fn note_endorsements_from_peer(
             )));
         }
     }
+    new_endorsements.retain(|endorsement_id, _| !unchecked_endorsements.contains(endorsement_id));
 
     // From there we note new endorsements and propagate them
 
     // Filter out endorsements if they are too old (max age of the inclusion slot: `max_endorsements_propagation_time`)
-    let now = MassaTime::now();
     new_endorsements.retain(|_id, endorsement| is_endorsement_fresh(endorsement, config, now));
 
     {
         let mut cache_write = cache.write();
 
         // add to the cache of endorsements we have checked
-        for endorsement_id in all_endorsement_ids.iter() {
+        for endorsement_id in all_endorsement_ids
+            .iter()
+            .filter(|endorsement_id| !unchecked_endorsements.contains(endorsement_id))
+        {
             cache_write.insert_checked_endorsement(*endorsement_id);
         }
 

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -4,14 +4,16 @@ use massa_models::config::MAX_ENDORSEMENTS_PER_SLOT_INDEX;
 use massa_models::endorsement::{Endorsement, EndorsementSerializer};
 use massa_models::secure_share::SecureShareContent;
 use massa_models::slot::Slot;
-use massa_pos_exports::Selection;
+use massa_pos_exports::{PosError, Selection};
 use massa_protocol_exports::PeerId;
 use massa_protocol_exports::ProtocolConfig;
 use massa_signature::KeyPair;
 use massa_test_framework::{TestUniverse, WaitPoint};
 use massa_time::MassaTime;
 use parking_lot::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::{
     handlers::{block_handler::BlockMessage, endorsement_handler::EndorsementMessage},
@@ -466,6 +468,135 @@ fn test_protocol_bounds_conflicting_endorsements_for_the_same_draw() {
     universe.mock_message_receive(
         &node_a_peer_id,
         Message::Endorsement(EndorsementMessage::Endorsements(endorsements)),
+    );
+    waitpoint.wait();
+}
+
+#[test]
+fn test_protocol_does_not_ban_peer_when_local_selector_is_not_ready() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let peer_ids = [node_a_peer_id];
+    let endorsement_creator = KeyPair::generate(0).unwrap();
+    let endorsement =
+        ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(1, 1));
+
+    let waitpoint = WaitPoint::new();
+    let waitpoint_trigger_handle = waitpoint.get_trigger_handle();
+    let banned = Arc::new(AtomicBool::new(false));
+    let banned_clone = banned.clone();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    ProtocolTestUniverse::peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    ProtocolTestUniverse::active_connections_boilerplate(
+        &mut shared_active_connections,
+        peer_ids.into_iter().collect(),
+    );
+    shared_active_connections.set_expectations(|active_connections| {
+        active_connections
+            .expect_shutdown_connection()
+            .returning(move |_| ());
+    });
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_ban_peer()
+        .returning(move |_peer_id| {
+            banned_clone.store(true, Ordering::Relaxed);
+        });
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller.expect_add_endorsements().never();
+        });
+    // the draws of that cycle are not available locally: this is our own problem, not the peer's
+    foreign_controllers
+        .selector_controller
+        .set_expectations(|selector_controller| {
+            selector_controller
+                .expect_get_selection()
+                .return_once(move |slot| {
+                    assert_eq!(slot, endorsement.content.slot);
+                    waitpoint_trigger_handle.trigger();
+                    Err(PosError::CycleUnavailable(0))
+                });
+        });
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Endorsement(EndorsementMessage::Endorsements(vec![endorsement.clone()])),
+    );
+    waitpoint.wait();
+    // leave some time for a ban to reach the peer db, if one was wrongly emitted
+    std::thread::sleep(Duration::from_millis(500));
+    assert!(!banned.load(Ordering::Relaxed));
+}
+
+#[test]
+fn test_protocol_bans_peer_sending_endorsement_with_slot_too_far_in_the_future() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let peer_ids = [node_a_peer_id];
+    let endorsement_creator = KeyPair::generate(0).unwrap();
+    // way beyond the acceptance window: no honest peer can endorse that slot yet
+    let endorsement =
+        ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(100_000, 1));
+
+    let waitpoint = WaitPoint::new();
+    let waitpoint_trigger_handle = waitpoint.get_trigger_handle();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    ProtocolTestUniverse::peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    ProtocolTestUniverse::active_connections_boilerplate(
+        &mut shared_active_connections,
+        peer_ids.into_iter().collect(),
+    );
+    shared_active_connections.set_expectations(|active_connections| {
+        active_connections
+            .expect_shutdown_connection()
+            .returning(move |_| ());
+    });
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_ban_peer()
+        .returning(move |peer_id| {
+            assert_eq!(peer_id, &node_a_peer_id);
+            waitpoint_trigger_handle.trigger();
+        });
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller.expect_add_endorsements().never();
+        });
+    // the slot is rejected without any local state being involved
+    foreign_controllers
+        .selector_controller
+        .set_expectations(|selector_controller| {
+            selector_controller.expect_get_selection().never();
+        });
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Endorsement(EndorsementMessage::Endorsements(vec![endorsement.clone()])),
     );
     waitpoint.wait();
 }


### PR DESCRIPTION
…ning peers on local selector errors

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification