### PR TITLE
[F127][F131] time-bound per-peer operation ask state to dedupe deferr…

### DIFF
--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -51,11 +51,52 @@ pub struct OperationBatchItem {
     pub operations_prefix_ids: OperationPrefixIds,
 }
 
+/// State of a peer with respect to an announced operation prefix.
+#[derive(Clone, Copy)]
+enum PeerAskState {
+    /// an `AskForOperations` was sent to that peer at that instant
+    Asked(Instant),
+    /// a deferred ask for that peer is waiting in `op_batch_buffer`
+    Buffered,
+}
+
+/// Ask state of an announced operation prefix.
+struct AskedOperation {
+    /// last instant at which that prefix was asked to any peer
+    last_ask: Instant,
+    /// state of the peers that announced that prefix.
+    /// Kept as a `Vec` because it holds at most one entry per connected peer.
+    peers: Vec<(PeerId, PeerAskState)>,
+}
+
+impl AskedOperation {
+    fn peer_state(&self, peer_id: &PeerId) -> Option<PeerAskState> {
+        self.peers
+            .iter()
+            .find(|(id, _)| id == peer_id)
+            .map(|(_, state)| *state)
+    }
+
+    fn set_peer_state(&mut self, peer_id: &PeerId, state: PeerAskState) {
+        match self.peers.iter_mut().find(|(id, _)| id == peer_id) {
+            Some(entry) => entry.1 = state,
+            None => self.peers.push((*peer_id, state)),
+        }
+    }
+
+    /// Drop the `Buffered` marker of a peer, if any, so that a new announcement
+    /// of that prefix by that peer is processed again.
+    fn clear_buffered(&mut self, peer_id: &PeerId) {
+        self.peers
+            .retain(|(id, state)| id != peer_id || !matches!(state, PeerAskState::Buffered));
+    }
+}
+
 pub struct RetrievalThread {
     receiver: MassaReceiver<PeerMessageTuple>,
     pool_controller: Box<dyn PoolController>,
     cache: SharedOperationCache,
-    asked_operations: LruMap<OperationPrefixId, (Instant, Vec<PeerId>)>,
+    asked_operations: LruMap<OperationPrefixId, AskedOperation>,
     active_connections: Box<dyn ActiveConnectionsTrait>,
     op_batch_buffer: VecDeque<OperationBatchItem>,
     storage: Storage,
@@ -183,17 +224,30 @@ impl RetrievalThread {
     ///    future_set = void HashSet<OperationId>
     ///    for op_id in op_batch:
     ///        if not is_op_received(op_id):
-    ///            if (op_id not in asked_ops) or (peer_id not in asked_ops(op_id)[1]):
-    ///                if (op_id not in asked_ops) or (asked_ops(op_id)[0] < now - op_batch_proc_period:
-    ///                    ask_set.add(op_id)
-    ///                    asked_ops(op_id)[0] = now
-    ///                    asked_ops(op_id)[1].add(peer_id)
-    ///                else:
-    ///                    future_set.add(op_id)
+    ///            # a deferred ask is already queued for that peer, or that peer was
+    ///            # asked less than op_batch_proc_period ago: nothing to do
+    ///            if peer_state(op_id, peer_id) is Buffered:
+    ///                continue
+    ///            if peer_state(op_id, peer_id) is Asked(t) and t >= now - op_batch_proc_period:
+    ///                continue
+    ///            if (op_id not in asked_ops) or (asked_ops(op_id).last_ask < now - op_batch_proc_period):
+    ///                ask_set.add(op_id)
+    ///                asked_ops(op_id).last_ask = now
+    ///                peer_state(op_id, peer_id) = Asked(now)
+    ///            else:
+    ///                future_set.add(op_id)
     ///    if op_batch_buf is not full:
     ///        op_batch_buf.push(now+op_batch_proc_period, peer_id, future_set)
+    ///        for op_id in future_set:
+    ///            peer_state(op_id, peer_id) = Buffered
     ///    ask ask_set to peer_id
     ///```
+    ///
+    /// Peer states are time-bounded on purpose: an `Asked` entry only silences that
+    /// peer for `op_batch_proc_period`, so a peer that disconnects before answering
+    /// and reconnects gets asked again on its next announcement. The `Buffered`
+    /// marker prevents repeated announcements from queueing the same deferred ask
+    /// several times in `op_batch_buffer`.
     fn on_operations_announcements_received(
         &mut self,
         mut op_batch: OperationPrefixIds,
@@ -223,37 +277,62 @@ impl RetrievalThread {
         let mut future_set = OperationPrefixIds::with_capacity(op_batch.len());
         // exactitude isn't important, we want to have a now for that function call
         let now = Instant::now();
+        let proc_period = self.config.operation_batch_proc_period.to_duration();
         let mut count_reask = 0;
         for op_id in op_batch {
-            let opt_previous_ask = match self.asked_operations.get(&op_id) {
-                Some(previous_ask) => {
-                    if previous_ask.1.contains(peer_id) {
-                        continue; // already asked to the origin `peer_id` => ignore
+            let mut first_announcement = false;
+            let ask_now = match self.asked_operations.get(&op_id) {
+                Some(asked) => {
+                    match asked.peer_state(peer_id) {
+                        // a deferred ask is already queued for that peer: don't queue it twice
+                        Some(PeerAskState::Buffered) => continue,
+                        // that peer was asked recently: let the ask time out before asking again.
+                        // The check is time-based (and not "was that peer ever asked"), so a peer
+                        // that reconnects without having answered is asked again.
+                        Some(PeerAskState::Asked(previous_peer_ask_time))
+                            if now
+                                .checked_duration_since(previous_peer_ask_time)
+                                .unwrap_or_default()
+                                <= proc_period =>
+                        {
+                            continue
+                        }
+                        _ => {}
+                    }
+                    // Ask now if latest ask instant < now - operation_batch_proc_period
+                    // otherwise add in future_set
+                    if now
+                        .checked_duration_since(asked.last_ask)
+                        .unwrap_or_default()
+                        > proc_period
+                    {
+                        count_reask += 1;
+                        asked.last_ask = now;
+                        asked.set_peer_state(peer_id, PeerAskState::Asked(now));
+                        true
                     } else {
-                        Some(previous_ask) // already asked but to someone else
+                        false
                     }
                 }
-                None => None,
-            };
-            if let Some((previous_ask_time, previous_ask_peers)) = opt_previous_ask {
-                // Ask now if latest ask instant < now - operation_batch_proc_period
-                // otherwise add in future_set
-                if now
-                    .checked_duration_since(*previous_ask_time)
-                    .unwrap_or_default()
-                    > self.config.operation_batch_proc_period.to_duration()
-                {
-                    count_reask += 1;
-                    ask_set.insert(op_id);
-                    *previous_ask_time = now;
-                    previous_ask_peers.push(*peer_id);
-                } else {
-                    future_set.insert(op_id);
+                None => {
+                    // never announced to us before, ask immediately
+                    first_announcement = true;
+                    true
                 }
-            } else {
-                // the same peer announced this op for a second time, ask them immediately
+            };
+            if first_announcement {
+                self.asked_operations.insert(
+                    op_id,
+                    AskedOperation {
+                        last_ask: now,
+                        peers: vec![(*peer_id, PeerAskState::Asked(now))],
+                    },
+                );
+            }
+            if ask_now {
                 ask_set.insert(op_id);
-                self.asked_operations.insert(op_id, (now, vec![*peer_id]));
+            } else {
+                future_set.insert(op_id);
             }
         } // EndOf for op_id in op_batch:
 
@@ -263,6 +342,15 @@ impl RetrievalThread {
         if self.op_batch_buffer.len() < self.config.operation_batch_buffer_capacity
             && !future_set.is_empty()
         {
+            // Record the deferred ask so that repeated announcements of the same
+            // prefixes by the same peer don't fill the buffer with duplicates.
+            // Nothing is recorded when the batch is dismissed below (buffer full),
+            // so the peer is free to announce those prefixes again.
+            for prefix in future_set.iter() {
+                if let Some(asked) = self.asked_operations.get(prefix) {
+                    asked.set_peer_state(peer_id, PeerAskState::Buffered);
+                }
+            }
             self.op_batch_buffer.push_back(OperationBatchItem {
                 instant: now
                     .checked_add(self.config.operation_batch_proc_period.into())
@@ -308,6 +396,14 @@ impl RetrievalThread {
             && now >= self.op_batch_buffer.front().unwrap().instant
         {
             let op_batch_item = self.op_batch_buffer.pop_front().unwrap();
+            // The deferred ask is no longer buffered: drop the markers, otherwise the
+            // announcement replayed just below (or any later one from that peer) would
+            // be ignored forever.
+            for prefix in op_batch_item.operations_prefix_ids.iter() {
+                if let Some(asked) = self.asked_operations.get(prefix) {
+                    asked.clear_buffered(&op_batch_item.peer_id);
+                }
+            }
             self.on_operations_announcements_received(
                 op_batch_item.operations_prefix_ids,
                 &op_batch_item.peer_id,
@@ -533,4 +629,173 @@ pub fn start_retrieval_thread(
             retrieval_thread.run();
         })
         .expect("OS failed to start operation retrieval thread")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wrap_network::MockActiveConnectionsTraitWrapper;
+    use massa_channel::MassaChannel;
+    use massa_models::operation::OperationId;
+    use massa_pool_exports::MockPoolControllerWrapper;
+    use massa_signature::KeyPair;
+    use parking_lot::RwLock;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::super::cache::OperationCache;
+
+    fn new_peer_id() -> PeerId {
+        PeerId::from_public_key(KeyPair::generate(0).unwrap().get_public_key())
+    }
+
+    fn new_prefix(seed: u8) -> OperationPrefixId {
+        OperationId::new(massa_hash::Hash::compute_from(&[seed])).into_prefix()
+    }
+
+    /// Build a retrieval thread whose peers are all connected, recording every
+    /// `AskForOperations` sent in the returned vector.
+    #[allow(clippy::type_complexity)]
+    fn new_retrieval_thread(
+        config: ProtocolConfig,
+        connected: HashSet<PeerId>,
+    ) -> (RetrievalThread, Arc<RwLock<Vec<(PeerId, usize)>>>) {
+        let asks: Arc<RwLock<Vec<(PeerId, usize)>>> = Arc::new(RwLock::new(Vec::new()));
+        let asks_clone = asks.clone();
+        let mut active_connections = MockActiveConnectionsTraitWrapper::new();
+        active_connections.set_expectations(|active_connections| {
+            active_connections
+                .expect_get_peer_ids_connected()
+                .returning(move || connected.clone());
+            active_connections.expect_send_to_peer().returning(
+                move |peer_id, _serializer, message, _high_priority| {
+                    if let crate::messages::Message::Operation(
+                        OperationMessage::AskForOperations(prefixes),
+                    ) = message
+                    {
+                        asks_clone.write().push((*peer_id, prefixes.len()));
+                    }
+                    Ok(())
+                },
+            );
+        });
+
+        let (_sender, receiver) = MassaChannel::new("test_network".to_string(), None);
+        let (_sender_ext, receiver_ext) = MassaChannel::new("test_ext".to_string(), None);
+        let (internal_sender, _internal_receiver) =
+            MassaChannel::new("test_internal".to_string(), None);
+        let (peer_cmd_sender, _peer_cmd_receiver) =
+            MassaChannel::new("test_peers".to_string(), None);
+
+        let asked_operations = LruMap::new(ByLength::new(
+            config
+                .asked_operations_buffer_capacity
+                .try_into()
+                .expect("asked_operations_buffer_capacity in config must be > 0"),
+        ));
+        let thread = RetrievalThread {
+            receiver,
+            pool_controller: Box::new(MockPoolControllerWrapper::new()),
+            cache: Arc::new(RwLock::new(OperationCache::new(1000, 1000))),
+            asked_operations,
+            active_connections: Box::new(active_connections),
+            op_batch_buffer: VecDeque::new(),
+            storage: Storage::create_root(),
+            config,
+            internal_sender,
+            receiver_ext,
+            operation_message_serializer: MessagesSerializer::new()
+                .with_operation_message_serializer(OperationMessageSerializer::new()),
+            peer_cmd_sender,
+            _massa_metrics: MassaMetrics::new(
+                false,
+                "0.0.0.0:9898".parse().unwrap(),
+                32,
+                std::time::Duration::from_secs(5),
+            )
+            .0,
+        };
+        (thread, asks)
+    }
+
+    /// F127: while an announced prefix is on cooldown, a peer repeating the same
+    /// announcement must not queue several deferred asks in `op_batch_buffer`.
+    #[test]
+    fn test_duplicate_announcements_during_cooldown_do_not_grow_the_batch_buffer() {
+        let peer_a = new_peer_id();
+        let peer_b = new_peer_id();
+        let (mut thread, asks) =
+            new_retrieval_thread(ProtocolConfig::default(), HashSet::from([peer_a, peer_b]));
+        let prefix = new_prefix(1);
+        let batch: OperationPrefixIds = [prefix].into_iter().collect();
+
+        // peer A announces first: asked right away
+        thread
+            .on_operations_announcements_received(batch.clone(), &peer_a)
+            .unwrap();
+        assert_eq!(asks.read().len(), 1);
+        assert!(thread.op_batch_buffer.is_empty());
+
+        // peer B announces the same prefix during the cooldown: the ask is deferred once
+        for _ in 0..10 {
+            thread
+                .on_operations_announcements_received(batch.clone(), &peer_b)
+                .unwrap();
+        }
+        assert_eq!(
+            thread.op_batch_buffer.len(),
+            1,
+            "repeated announcements must not queue several deferred asks"
+        );
+        assert_eq!(asks.read().len(), 1, "peer B must not be asked yet");
+
+        // once the deferred batch is processed, peer B is asked and the buffer is empty
+        std::thread::sleep(
+            ProtocolConfig::default()
+                .operation_batch_proc_period
+                .to_duration(),
+        );
+        thread.update_ask_operation().unwrap();
+        assert!(thread.op_batch_buffer.is_empty());
+        assert_eq!(asks.read().last().unwrap().0, peer_b);
+    }
+
+    /// F131: a peer that was asked but never answered (typically because it
+    /// disconnected in between) must be asked again when it announces the prefix
+    /// after the ask cooldown, instead of being ignored forever.
+    #[test]
+    fn test_peer_is_asked_again_after_cooldown() {
+        let peer_a = new_peer_id();
+        let (mut thread, asks) =
+            new_retrieval_thread(ProtocolConfig::default(), HashSet::from([peer_a]));
+        let prefix = new_prefix(2);
+        let batch: OperationPrefixIds = [prefix].into_iter().collect();
+
+        thread
+            .on_operations_announcements_received(batch.clone(), &peer_a)
+            .unwrap();
+        assert_eq!(asks.read().len(), 1);
+
+        // same peer re-announcing during the cooldown changes nothing
+        thread
+            .on_operations_announcements_received(batch.clone(), &peer_a)
+            .unwrap();
+        assert_eq!(asks.read().len(), 1);
+        assert!(thread.op_batch_buffer.is_empty());
+
+        // after the cooldown (peer disconnected and reconnected without answering),
+        // its announcement triggers a fresh ask
+        std::thread::sleep(
+            ProtocolConfig::default()
+                .operation_batch_proc_period
+                .to_duration()
+                + Duration::from_millis(50),
+        );
+        thread
+            .on_operations_announcements_received(batch, &peer_a)
+            .unwrap();
+        assert_eq!(asks.read().len(), 2);
+        assert_eq!(asks.read().last().unwrap().0, peer_a);
+    }
 }


### PR DESCRIPTION
…ed asks and allow re-asking

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification