### PR TITLE
[F43] Document expected behaviour: denounced validators still receive slot rewards

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -799,6 +799,8 @@ impl ExecutionState {
 
         context.insert_executed_denunciation(&de_idx);
 
+        // Punishment is roll slashing only; same-slot block/endorsement rewards are not forfeited
+        // (see comment after the denunciation loop in execute_slot).
         let slashed = context.try_slash_rolls(
             &addr_denounced,
             self.config.roll_count_to_slash_on_denunciation,
@@ -1782,6 +1784,12 @@ impl ExecutionState {
                     }
                 }
             }
+
+            // Denunciation punishment is limited to slashing locked rolls (see execute_denunciation).
+            // Addresses denounced in this block are intentionally still eligible for the slot's
+            // EndorsementCreatorReward, EndorsementTargetReward, and BlockCreatorReward below.
+            // Excluding them would make the effective penalty depend on whether the denounced
+            // address was also selected by draws for this slot, which is not a coherent punishment model.
 
             // Get block creator address
             let block_creator_addr = stored_block.content_creator_address;

--- a/massa-models/src/denunciation.rs
+++ b/massa-models/src/denunciation.rs
@@ -29,6 +29,15 @@
 //! balance or staked rolls, we will use 'locked' rolls` (or Deferred credits).
 //! Selling a roll will lock it for some time (== 4 cycles). Note that it restricts the time,
 //! a denunciation can be produced (A constant value will be defined for this).
+//!
+//! Punishment model
+//!
+//! A valid denunciation slashes locked rolls only. It does not forfeit slot rewards
+//! (`EndorsementCreatorReward`, `EndorsementTargetReward`, `BlockCreatorReward`) for the
+//! denouncing block. A validator denounced in a block may still receive those rewards in the
+//! same slot. That is intentional: excluding denounced addresses from same-slot rewards would
+//! make the effective penalty depend on whether they were also selected by draws for that slot,
+//! which is not a coherent punishment model.
 
 #![allow(missing_docs)]
 


### PR DESCRIPTION
For me this is clearly expected behaviour, adding in-code comments.