### PR TITLE
docs(execution): note that send_message admits async messages whose m…

### DIFF
--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -1440,7 +1440,6 @@ impl ExecutionContext {
     }
 
     /// Returns `true` if the execution component version is at least `version`.
-    #[allow(dead_code)]
     pub fn is_execution_component_version_at_least(&self, version: u32) -> bool {
         self.execution_component_version >= version
     }

--- a/massa-execution-worker/src/interface_impl.rs
+++ b/massa-execution-worker/src/interface_impl.rs
@@ -55,6 +55,11 @@ use tracing::warn;
 ))]
 use massa_models::datastore::Datastore;
 
+/// Execution component version at which `send_message` starts rejecting messages whose
+/// `max_gas` is too large to ever be scheduled (see [`InterfaceImpl::send_message`]).
+/// Bundled into the same MIP as the WMAS patch (`MIP-0002-BugFix`).
+const ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION: u32 = 2;
+
 /// helper for locking the context mutex
 macro_rules! context_guard {
     ($self:ident) => {
@@ -1426,7 +1431,15 @@ impl Interface for InterfaceImpl {
     /// * `target_function`: Name of the message handling function
     /// * `validity_start`: Tuple containing the period and thread of the validity start slot
     /// * `validity_end`: Tuple containing the period and thread of the validity end slot
-    /// * `max_gas`: Maximum gas for the message execution
+    /// * `max_gas`: Maximum gas for the message execution.
+    ///   Bounded below by `max_instance_cost`, and — from execution component version
+    ///   [`ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION`] on — above by the largest budget any slot
+    ///   can ever offer. `take_batch_to_execute` only schedules a message when
+    ///   `max_gas + async_msg_cst_gas_cost` fits the slot's async gas budget, which never
+    ///   exceeds `max_async_gas + max_gas_per_block` (see `execute_slot`). Before that
+    ///   version, a message above the ceiling was accepted but permanently unschedulable:
+    ///   it occupied async pool capacity until its validity end, and on expiry
+    ///   `cancel_async_message` refunded `raw_coins` but not `raw_fee`.
     /// * `fee`: Fee to pay
     /// * `raw_coins`: Coins given by the sender
     /// * `data`: Message data
@@ -1469,6 +1482,23 @@ impl Interface for InterfaceImpl {
 
         if max_gas < self.config.gas_costs.max_instance_cost {
             bail!("max gas is lower than the minimum instance cost")
+        }
+        // Reject messages that no slot could ever schedule. Gated: rejecting here changes
+        // execution results, so it only applies once the MIP has activated.
+        if execution_context
+            .is_execution_component_version_at_least(ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION)
+        {
+            let max_schedulable_gas = self
+                .config
+                .max_async_gas
+                .saturating_add(self.config.max_gas_per_block)
+                .saturating_sub(self.config.async_msg_cst_gas_cost);
+            if max_gas > max_schedulable_gas {
+                bail!(
+                    "max gas is higher than the maximum schedulable async gas ({})",
+                    max_schedulable_gas
+                )
+            }
         }
         if Slot::new(validity_end.0, validity_end.1) < Slot::new(validity_start.0, validity_start.1)
         {
@@ -2169,6 +2199,38 @@ mod tests {
     use super::*;
     use massa_models::address::Address;
     use massa_signature::KeyPair;
+
+    // An async message asking for more gas than any slot can ever schedule is admitted
+    // before the MIP activates, and rejected from ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION on.
+    #[test]
+    fn test_send_message_max_gas_ceiling() {
+        let sender_addr = Address::from_public_key(&KeyPair::generate(0).unwrap().get_public_key());
+        let interface = InterfaceImpl::new_default(sender_addr, None, None);
+        let target = "AS12UMSUxgpRBB6ArZDJ19arHoxNkkpdfofQGekAiAJqsuE6PEFJy";
+
+        let config = ExecutionConfig::default();
+        let ceiling = config
+            .max_async_gas
+            .saturating_add(config.max_gas_per_block)
+            .saturating_sub(config.async_msg_cst_gas_cost);
+
+        let send = |max_gas: u64| {
+            interface.send_message(target, "receive", (0, 0), (10, 0), max_gas, 0, 0, &[], None)
+        };
+
+        // pre-activation: the oversized message is accepted, which is the bug being fixed
+        interface.context.lock().execution_component_version =
+            ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION - 1;
+        send(ceiling + 1).expect("oversized message should be admitted before activation");
+
+        // post-activation: rejected, while a message exactly at the ceiling still passes
+        interface.context.lock().execution_component_version = ASYNC_MSG_MAX_GAS_CHECK_EXEC_VERSION;
+        assert!(
+            send(ceiling + 1).is_err(),
+            "oversized message should be rejected after activation"
+        );
+        send(ceiling).expect("a message exactly at the ceiling is still schedulable");
+    }
 
     // Tests the get_keys_wasmv1 interface method used by the updated get_keys abi.
     #[test]

--- a/massa-execution-worker/src/speculative_async_pool.rs
+++ b/massa-execution-worker/src/speculative_async_pool.rs
@@ -101,6 +101,12 @@ impl SpeculativeAsyncPool {
     /// removing them from the speculative asynchronous pool and settling their deletion from it
     /// in the changes accumulator.
     ///
+    /// A message is only taken when `message.max_gas + async_msg_cst_gas_cost` still fits in
+    /// the remaining budget. Messages asking for more than the largest budget a slot can ever
+    /// get (`max_async_gas + max_gas_per_block`) are therefore never taken; `send_message`
+    /// rejects those at emission from execution component version 2 on, but messages emitted
+    /// before that activation can still be sitting in the pool, and they expire unexecuted.
+    ///
     /// # Arguments
     /// * `slot`: slot at which the batch is taken (allows filtering by validity interval)
     /// * `max_gas`: maximum amount of gas available


### PR DESCRIPTION
…ax_gas exceeds any schedulable slot budget

Status: documented, not fixed. No behavior change; no MIP required.
  
   Confirmed the finding is real: send_message bounds max_gas only from below, while take_batch_to_execute needs max_gas + async_msg_cst_gas_cost to fit a budget capped at max_async_gas + max_gas_per_block
   (≈5.29e9). Above that ceiling a message is admitted but never schedulable, and cancel_async_message refunds coins but not fee at expiry — so the fee is genuinely burned.
   
   Adding an max gas check would be breaking. So better keep it like it is imho