### PR TITLE
[F8] bound bootstrap accepts per poll cycle and cap concurrent refusa…

### DIFF
--- a/massa-bootstrap/src/bindings/server.rs
+++ b/massa-bootstrap/src/bindings/server.rs
@@ -19,6 +19,7 @@ use massa_serialization::{DeserializeError, Deserializer, Serializer};
 use massa_signature::KeyPair;
 use massa_time::MassaTime;
 use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 use std::{
     convert::TryInto,
@@ -28,9 +29,44 @@ use std::{
     time::Duration,
 };
 use stream_limiter::{Limiter, LimiterOptions};
-use tracing::error;
+use tracing::{error, warn};
 
 use super::BindingWriteExact;
+
+/// Maximum number of refusal threads running concurrently.
+///
+/// Every refused connection is told why before being closed, and that send has
+/// to happen off the bootstrap main loop so a slow client cannot stall it. A
+/// connection flood produces refusals as fast as the listener can accept, so the
+/// helper threads are capped: past the cap the socket is simply closed, which is
+/// what the client would observe on a timed-out error send anyway.
+const MAX_CONCURRENT_ERROR_SENDS: usize = 32;
+
+/// Number of refusal threads currently alive, compared against
+/// [`MAX_CONCURRENT_ERROR_SENDS`].
+static ONGOING_ERROR_SENDS: AtomicUsize = AtomicUsize::new(0);
+
+/// Releases a claimed [`ONGOING_ERROR_SENDS`] slot, panics included, so that a
+/// failing refusal can never leak the budget it took.
+struct ErrorSendSlot;
+
+impl ErrorSendSlot {
+    /// Claims a slot, or returns `None` if the budget is exhausted.
+    fn claim() -> Option<Self> {
+        ONGOING_ERROR_SENDS
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |ongoing| {
+                (ongoing < MAX_CONCURRENT_ERROR_SENDS).then_some(ongoing + 1)
+            })
+            .ok()
+            .map(|_| ErrorSendSlot)
+    }
+}
+
+impl Drop for ErrorSendSlot {
+    fn drop(&mut self) {
+        ONGOING_ERROR_SENDS.fetch_sub(1, Ordering::AcqRel);
+    }
+}
 
 const KNOWN_PREFIX_FROM_CLIENT_LEN: usize =
     HASH_SIZE_BYTES + MAX_BOOTSTRAP_MESSAGE_FROM_CLIENT_SIZE_BYTES;
@@ -148,20 +184,34 @@ impl BootstrapServerBinder {
         })
     }
 
-    /// 1. Spawns a thread
+    /// 1. Spawns a thread, unless [`MAX_CONCURRENT_ERROR_SENDS`] are already running
     /// 2. blocks on the passed in runtime
     /// 3. uses passed in handle to send a message to the client
     /// 4. logs an error if the send times out
     /// 5. runs the passed in closure (typically a custom logging msg)
     ///
-    /// consumes the binding in the process
+    /// consumes the binding in the process. When the refusal budget is exhausted
+    /// or the OS refuses the spawn, the binding is dropped instead, closing the
+    /// connection without the courtesy message.
     pub(crate) fn close_and_send_error<F>(mut self, msg: String, addr: SocketAddr, close_fn: F)
     where
         F: FnOnce() + Send + 'static,
     {
-        thread::Builder::new()
+        // Claim a refusal slot, or drop the connection outright rather than let
+        // a flood of refusals spawn an unbounded number of threads.
+        let Some(slot) = ErrorSendSlot::claim() else {
+            warn!(
+                "bootstrap server closing connection from {} without sending error '{}': too many refusals in flight",
+                addr, msg
+            );
+            return;
+        };
+
+        let spawned = thread::Builder::new()
             .name("bootstrap-error-send".to_string())
             .spawn(move || {
+                // Held for the lifetime of the thread, released on the way out.
+                let _slot = slot;
                 let msg_cloned = msg.clone();
                 let err_send = self.send_error_timeout(msg_cloned);
                 match err_send {
@@ -176,10 +226,17 @@ impl BootstrapServerBinder {
                     Ok(_) => {}
                 }
                 close_fn();
-            })
-            // the non-builder spawn doesn't return a Result, and documentation states that
-            // it's an error at the OS level.
-            .unwrap();
+            });
+
+        // A failed spawn is an OS-level resource error: the slot is released with
+        // the dropped closure, and the connection closes on its own rather than
+        // taking the whole server down.
+        if let Err(e) = spawned {
+            error!(
+                "bootstrap server failed to spawn the error-send thread for addr {}: {}",
+                addr, e
+            );
+        }
     }
     pub fn send_error_timeout(&mut self, error: String) -> Result<(), BootstrapError> {
         self.send_timeout(

--- a/massa-bootstrap/src/listener.rs
+++ b/massa-bootstrap/src/listener.rs
@@ -2,6 +2,7 @@ use mio::net::TcpListener;
 use mio::{Events, Interest, Poll, Token, Waker};
 use std::io::ErrorKind;
 use std::net::{SocketAddr, TcpStream};
+use std::time::Duration;
 use tracing::{info, warn};
 
 use crate::error::BootstrapError;
@@ -10,33 +11,56 @@ use crate::tools::mio_stream_to_std;
 const NEW_CONNECTION: Token = Token(0);
 const STOP_LISTENER: Token = Token(10);
 
+/// Maximum number of connections accepted in a single `poll` cycle.
+///
+/// Draining the whole pending backlog at once would let a connection flood move
+/// the entire listen queue (1024 entries) into process-owned file descriptors
+/// before the server has had any chance to apply admission control, and would
+/// hand the server a batch of that size to refuse in one go. Accepting in
+/// bounded batches keeps the burst small; the remainder stays in the kernel
+/// backlog and is picked up by the following cycles.
+const MAX_ACCEPTS_PER_POLL: usize = 32;
+
 /// TODO: this should be crate-private. currently needed for models testing
 pub struct BootstrapTcpListener {
     poll: Poll,
     events: Events,
     server: TcpListener,
+    /// Set when the last drain stopped at [`MAX_ACCEPTS_PER_POLL`]. The mio
+    /// registration is edge-triggered, so a backlog left behind does not
+    /// re-arm readiness on its own: the next `poll` has to look for it instead
+    /// of blocking.
+    backlog_pending: bool,
 }
 
 pub struct BootstrapListenerStopHandle(pub(crate) Waker);
 
-/// Drain all currently-ready connections from `accept` into `out`.
+/// Drain at most `max` currently-ready connections from `accept` into `out`.
 ///
 /// The drain ends on the first error, whether it is `WouldBlock` (no more
 /// pending connections) or any other error such as a persistent `EMFILE` /
 /// `ENFILE`. Ending the drain on a non-`WouldBlock` error (instead of
 /// `continue`-ing) is what prevents a sticky listener-level failure from
 /// spinning `poll()` forever and starving the `STOP_LISTENER` token.
-fn drain_accept<S>(mut accept: impl FnMut() -> std::io::Result<S>, out: &mut Vec<S>) {
-    loop {
+///
+/// Returns `true` if the drain stopped because `max` was reached, meaning the
+/// backlog may still hold connections that the caller has to come back for.
+fn drain_accept<S>(
+    mut accept: impl FnMut() -> std::io::Result<S>,
+    out: &mut Vec<S>,
+    max: usize,
+) -> bool {
+    for _ in 0..max {
         match accept() {
             Ok(item) => out.push(item),
-            Err(ref e) if e.kind() == ErrorKind::WouldBlock => break,
+            Err(ref e) if e.kind() == ErrorKind::WouldBlock => return false,
             Err(e) => {
                 warn!("Error accepting connection in bootstrap: {:?}", e);
-                break;
+                return false;
             }
         }
     }
+    true
 }
 
 pub enum PollEvent {
@@ -90,39 +114,56 @@ impl BootstrapTcpListener {
                 poll,
                 server,
                 events,
+                backlog_pending: false,
             },
         ))
     }
 
     /// Poll the listener for new connections
+    ///
+    /// At most [`MAX_ACCEPTS_PER_POLL`] connections are returned per call, so
+    /// that the caller gets to apply admission control before the rest of the
+    /// backlog is pulled into the process.
     pub fn poll(&mut self) -> Result<PollEvent, BootstrapError> {
-        self.poll.poll(&mut self.events, None).unwrap();
+        // Only block when the backlog is known to be empty: a backlog left over
+        // from the previous cycle would otherwise wait for an unrelated
+        // readiness event before being served.
+        let timeout = if self.backlog_pending {
+            Some(Duration::ZERO)
+        } else {
+            None
+        };
+        self.poll.poll(&mut self.events, timeout).unwrap();
 
-        let mut results = Vec::with_capacity(self.events.iter().count());
-
-        // Process each event.
+        let mut accept_ready = self.backlog_pending;
         for event in self.events.iter() {
             match event.token() {
-                NEW_CONNECTION => {
-                    // Drain the currently-ready connections, borrowing only
-                    // `self.server`, then post-process them (which borrows
-                    // `self.poll`). The drain never spins on a persistent
-                    // accept error, so control always returns to the poller and
-                    // the STOP token can be serviced.
-                    let mut accepted = Vec::new();
-                    drain_accept(|| self.server.accept(), &mut accepted);
-                    for (mut stream, remote_addr) in accepted {
-                        let _ = self.poll.registry().deregister(&mut stream);
-                        let stream: std::net::TcpStream = mio_stream_to_std(stream);
-                        stream.set_nonblocking(false)?;
-                        results.push((stream, remote_addr));
-                    }
-                }
+                NEW_CONNECTION => accept_ready = true,
                 STOP_LISTENER => {
                     return Ok(PollEvent::Stop);
                 }
                 _ => unreachable!(),
             }
+        }
+
+        if !accept_ready {
+            return Ok(PollEvent::NewConnections(Vec::new()));
+        }
+
+        // Drain the ready connections, borrowing only `self.server`, then
+        // post-process them (which borrows `self.poll`). The drain never spins
+        // on a persistent accept error, so control always returns to the poller
+        // and the STOP token can be serviced.
+        let mut accepted = Vec::with_capacity(MAX_ACCEPTS_PER_POLL);
+        self.backlog_pending =
+            drain_accept(|| self.server.accept(), &mut accepted, MAX_ACCEPTS_PER_POLL);
+
+        let mut results = Vec::with_capacity(accepted.len());
+        for (mut stream, remote_addr) in accepted {
+            let _ = self.poll.registry().deregister(&mut stream);
+            let stream: std::net::TcpStream = mio_stream_to_std(stream);
+            stream.set_nonblocking(false)?;
+            results.push((stream, remote_addr));
         }
 
         Ok(PollEvent::NewConnections(results))
@@ -138,26 +179,28 @@ impl BootstrapListenerStopHandle {
 
 #[cfg(test)]
 mod tests {
-    use super::drain_accept;
+    use super::{drain_accept, MAX_ACCEPTS_PER_POLL};
     use std::io::{Error, ErrorKind};
 
     #[test]
     fn drain_stops_on_persistent_error_instead_of_spinning() {
         let mut calls = 0u32;
         let mut out: Vec<u8> = Vec::new();
-        drain_accept(
+        let capped = drain_accept(
             || {
                 calls += 1;
                 // A persistent non-WouldBlock error (e.g. EMFILE/ENFILE).
                 Err::<u8, _>(Error::from(ErrorKind::Other))
             },
             &mut out,
+            MAX_ACCEPTS_PER_POLL,
         );
         assert_eq!(
             calls, 1,
             "a persistent accept error must break the drain, not loop forever"
         );
         assert!(out.is_empty());
+        assert!(!capped, "an errored drain leaves no known backlog");
     }
 
     #[test]
@@ -170,8 +213,30 @@ mod tests {
         ]
         .into_iter();
         let mut out = Vec::new();
-        drain_accept(|| seq.next().unwrap(), &mut out);
+        let capped = drain_accept(|| seq.next().unwrap(), &mut out, MAX_ACCEPTS_PER_POLL);
         // Stops at the WouldBlock, leaving the trailing item untouched.
         assert_eq!(out, vec![1, 2]);
+        assert!(!capped, "a drained backlog must not be reported as pending");
+    }
+
+    #[test]
+    fn drain_stops_at_the_batch_limit() {
+        // An endless supply of pending connections, as a backlog flood would.
+        let mut accepted = 0usize;
+        let mut out = Vec::new();
+        let capped = drain_accept(
+            || {
+                accepted += 1;
+                Ok::<u8, Error>(0)
+            },
+            &mut out,
+            MAX_ACCEPTS_PER_POLL,
+        );
+        assert_eq!(out.len(), MAX_ACCEPTS_PER_POLL);
+        assert_eq!(
+            accepted, MAX_ACCEPTS_PER_POLL,
+            "the drain must not accept beyond the batch limit"
+        );
+        assert!(capped, "a capped drain must report the remaining backlog");
     }
 }


### PR DESCRIPTION
…l threads

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification