### PR TITLE
[F136] reject future-dated peer announcements instead of treating the…

### DIFF
--- a/massa-protocol-worker/src/handlers/peer_handler/announcement.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/announcement.rs
@@ -24,6 +24,12 @@ use massa_serialization::{
     U64VarIntSerializer,
 };
 
+/// Maximum tolerated clock skew between our local clock and the timestamp carried by a
+/// remote peer's announcement. The timestamp is attacker-controlled and is used as the peer
+/// freshness signal, so an announcement dated arbitrarily far in the future would otherwise
+/// stay "fresh" (and thus eligible for peer sharing and bootstrap responses) forever.
+pub const MAX_ANNOUNCEMENT_CLOCK_SKEW_MS: u64 = 5 * 60 * 1_000;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Announcement {
     /// Listeners
@@ -170,6 +176,12 @@ impl Deserializer<Announcement> for AnnouncementDeserializer {
 }
 
 impl Announcement {
+    /// Check the announcement timestamp against the local clock: a peer cannot legitimately
+    /// announce more than `MAX_ANNOUNCEMENT_CLOCK_SKEW_MS` ahead of us.
+    pub fn is_future_dated(&self, now_millis: u64) -> bool {
+        self.timestamp > now_millis.saturating_add(MAX_ANNOUNCEMENT_CLOCK_SKEW_MS)
+    }
+
     pub fn new(
         listeners: HashMap<SocketAddr, TransportType>,
         routable_ip: Option<IpAddr>,

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -13,6 +13,7 @@ use massa_protocol_exports::{
 };
 use massa_serialization::{DeserializeError, Deserializer, Serializer};
 use massa_signature::Signature;
+use massa_time::MassaTime;
 use peernet::context::Context as _;
 use peernet::messages::MessagesSerializer as _;
 use rand::{rngs::StdRng, RngCore, SeedableRng};
@@ -460,6 +461,14 @@ impl InitConnectionHandler<PeerId, Context, MessagesHandler> for MassaHandshake 
                     {
                         return Err(PeerNetError::HandshakeError
                             .error("Massa Handshake", Some("Invalid signature".to_string())));
+                    }
+                    // the announcement timestamp is the freshness signal used to decide which
+                    // peers we keep sharing, so refuse one that is dated too far ahead of us
+                    if announcement.is_future_dated(MassaTime::now().as_millis()) {
+                        return Err(PeerNetError::HandshakeError.error(
+                            "Massa Handshake",
+                            Some("Announcement timestamp too far in the future".to_string()),
+                        ));
                     }
                     // The announcement is signed but its listeners are peer controlled:
                     // only spread endpoints that are acceptable to probe.

--- a/massa-protocol-worker/src/handlers/peer_handler/models.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/models.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use crate::wrap_peer_db::PeerDBTrait;
 
-use super::announcement::Announcement;
+use super::announcement::{Announcement, MAX_ANNOUNCEMENT_CLOCK_SKEW_MS};
 
 const THREE_DAYS_MS: u64 = 3 * 24 * 60 * 60 * 1_000;
 
@@ -248,6 +248,9 @@ impl PeerDBTrait for PeerDB {
         let now = MassaTime::now().as_millis();
 
         let min_time = now - THREE_DAYS_MS;
+        // defense in depth: announcement timestamps are peer-controlled, a future-dated one
+        // must not be treated as fresh even if it slipped past the handshake checks
+        let max_time = now.saturating_add(MAX_ANNOUNCEMENT_CLOCK_SKEW_MS);
 
         let mut keys = self.peers.keys().cloned().collect::<Vec<_>>();
         let mut rng = rand::thread_rng();
@@ -262,7 +265,7 @@ impl PeerDBTrait for PeerDB {
             if let Some(peer) = self.peers.get(&key) {
                 // skip old peers
                 if let Some(last_announce) = &peer.last_announce {
-                    if last_announce.timestamp < min_time {
+                    if last_announce.timestamp < min_time || last_announce.timestamp > max_time {
                         continue;
                     }
                     let listeners: HashMap<SocketAddr, TransportType> =
@@ -351,5 +354,64 @@ impl PeerDBTrait for PeerDB {
 
     fn get_tested_addresses(&self) -> &HashMap<SocketAddr, MassaTime> {
         &self.tested_addresses
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use massa_protocol_exports::PeerId;
+    use massa_signature::KeyPair;
+    use massa_time::MassaTime;
+    use peernet::transports::TransportType;
+    use std::collections::HashMap;
+
+    use super::super::announcement::{Announcement, MAX_ANNOUNCEMENT_CLOCK_SKEW_MS};
+    use super::{PeerDB, PeerInfo, PeerState, THREE_DAYS_MS};
+    use crate::wrap_peer_db::PeerDBTrait;
+
+    /// Build a peer announcing one listener, with its announcement timestamp forced to `timestamp`.
+    fn peer_announcing_at(timestamp: u64) -> (PeerId, PeerInfo) {
+        let keypair = KeyPair::generate(0).unwrap();
+        let mut listeners = HashMap::new();
+        listeners.insert("127.0.0.1:8081".parse().unwrap(), TransportType::Tcp);
+        let mut announcement =
+            Announcement::new(listeners, Some("1.2.3.4".parse().unwrap()), &keypair).unwrap();
+        announcement.timestamp = timestamp;
+        (
+            PeerId::from_public_key(keypair.get_public_key()),
+            PeerInfo {
+                last_announce: Some(announcement),
+                state: PeerState::Trusted,
+            },
+        )
+    }
+
+    #[test]
+    fn test_get_rand_peers_to_send_skips_out_of_window_announcements() {
+        let now = MassaTime::now().as_millis();
+        let mut peer_db = PeerDB::default();
+
+        let (fresh_id, fresh) = peer_announcing_at(now);
+        let (stale_id, stale) = peer_announcing_at(now - THREE_DAYS_MS - 1);
+        let (future_id, future) = peer_announcing_at(now + MAX_ANNOUNCEMENT_CLOCK_SKEW_MS + 60_000);
+        peer_db.peers.insert(fresh_id, fresh);
+        peer_db.peers.insert(stale_id, stale);
+        peer_db.peers.insert(future_id, future);
+
+        let sent: Vec<_> = peer_db
+            .get_rand_peers_to_send(10)
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(sent, vec![fresh_id]);
+    }
+
+    #[test]
+    fn test_is_future_dated() {
+        let now = MassaTime::now().as_millis();
+        let (_, within_skew) = peer_announcing_at(now + MAX_ANNOUNCEMENT_CLOCK_SKEW_MS);
+        assert!(!within_skew.last_announce.unwrap().is_future_dated(now));
+        let (_, beyond_skew) = peer_announcing_at(now + MAX_ANNOUNCEMENT_CLOCK_SKEW_MS + 1);
+        assert!(beyond_skew.last_announce.unwrap().is_future_dated(now));
     }
 }

--- a/massa-protocol-worker/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/tester.rs
@@ -189,6 +189,15 @@ impl Tester {
                                 Some(String::from("Invalid signature")),
                             ));
                         }
+                        // the announcement timestamp is the freshness signal used to decide
+                        // which peers we keep sharing, so refuse one that is dated too far
+                        // ahead of us
+                        if announcement.is_future_dated(MassaTime::now().as_millis()) {
+                            return Err(PeerNetError::HandshakeError.error(
+                                "Tester Handshake",
+                                Some(String::from("Announcement timestamp too far in the future")),
+                            ));
+                        }
                         //TODO: Check ip we are connected match one of the announced ips
                         {
                             let mut peer_db_write = peer_db.write();


### PR DESCRIPTION
…m as fresh

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification