### PR TITLE
[F134] filter non-routable announced peer endpoints before probing an…

### DIFF
--- a/massa-protocol-exports/src/settings.rs
+++ b/massa-protocol-exports/src/settings.rs
@@ -179,3 +179,18 @@ pub struct ProtocolConfig {
     /// Chain id
     pub chain_id: u64,
 }
+
+impl ProtocolConfig {
+    /// Whether the node is configured to deal with peers that do not have a
+    /// globally routable address, i.e. local networks. Mirrors the
+    /// `allow_local_peers` category setting: as soon as one category accepts
+    /// local peers, non global endpoints are kept in the peer management
+    /// pipeline, the per category check being done when connecting out.
+    pub fn allow_local_peers(&self) -> bool {
+        self.default_category_info.allow_local_peers
+            || self
+                .peers_categories
+                .values()
+                .any(|category| category.allow_local_peers)
+    }
+}

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -27,6 +27,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::context::Context;
 use crate::handlers::peer_handler::models::PeerState;
+use crate::ip::filter_routable_listeners;
 use crate::messages::{Message, MessagesHandler, MessagesSerializer};
 use crate::wrap_network::ActiveConnectionsTrait;
 
@@ -55,6 +56,26 @@ pub mod models;
 mod tester;
 
 pub(crate) use messages::{PeerManagementMessage, PeerManagementMessageSerializer};
+
+/// Drops the endpoints we must not re-advertise from a peer list, along with the
+/// peers left without any announced listener. Peer listeners come from signed
+/// but peer controlled announcements: we only pass around endpoints we would
+/// probe ourselves (see [`filter_routable_listeners`]).
+fn filter_peers_listeners(
+    peers: Vec<(PeerId, HashMap<SocketAddr, TransportType>)>,
+    allow_local_peers: bool,
+) -> Vec<(PeerId, HashMap<SocketAddr, TransportType>)> {
+    peers
+        .into_iter()
+        .map(|(peer_id, listeners)| {
+            (
+                peer_id,
+                filter_routable_listeners(listeners, allow_local_peers),
+            )
+        })
+        .filter(|(_, listeners)| !listeners.is_empty())
+        .collect()
+}
 
 #[allow(dead_code)]
 pub struct PeerManagementHandler {
@@ -119,7 +140,10 @@ impl PeerManagementHandler {
                 loop {
                     select! {
                         recv(ticker) -> _ => {
-                            let peers_to_send = peer_db.read().get_rand_peers_to_send(100);
+                            let peers_to_send = filter_peers_listeners(
+                                peer_db.read().get_rand_peers_to_send(100),
+                                config.allow_local_peers(),
+                            );
                             if peers_to_send.is_empty() {
                                 continue;
                             }
@@ -152,7 +176,10 @@ impl PeerManagementHandler {
                                 }
                             },
                              Ok(PeerManagementCmd::GetBootstrapPeers { responder }) => {
-                                let mut peers = peer_db.read().get_rand_peers_to_send(100);
+                                let mut peers = filter_peers_listeners(
+                                    peer_db.read().get_rand_peers_to_send(100),
+                                    config.allow_local_peers(),
+                                );
                                 // Add myself
                                 if let Some(routable_ip) = config.routable_ip {
                                     let listeners = config.listeners.iter().map(|(addr, ty)| {
@@ -434,9 +461,14 @@ impl InitConnectionHandler<PeerId, Context, MessagesHandler> for MassaHandshake 
                         return Err(PeerNetError::HandshakeError
                             .error("Massa Handshake", Some("Invalid signature".to_string())));
                     }
+                    // The announcement is signed but its listeners are peer controlled:
+                    // only spread endpoints that are acceptable to probe.
                     let message = PeerManagementMessage::NewPeerConnected((
                         peer_id,
-                        announcement.clone().listeners,
+                        filter_routable_listeners(
+                            announcement.listeners.clone(),
+                            self.config.allow_local_peers(),
+                        ),
                     ));
                     let mut bytes = Vec::new();
                     let peer_management_message_serializer = MessagesSerializer::new()

--- a/massa-protocol-worker/src/handlers/peer_handler/tester.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/tester.rs
@@ -6,7 +6,10 @@ use std::{
     time::Duration,
 };
 
-use crate::{ip::to_canonical, messages::MessagesHandler};
+use crate::{
+    ip::{is_routable_peer_addr, to_canonical},
+    messages::MessagesHandler,
+};
 use massa_channel::{receiver::MassaReceiver, sender::MassaSender, MassaChannel};
 use massa_metrics::MassaMetrics;
 use massa_models::version::VersionDeserializer;
@@ -293,6 +296,7 @@ impl Tester {
 
             //let mut network_manager = PeerNetManager::new(config);
             let protocol_config = protocol_config.clone();
+            let allow_local_peers = protocol_config.allow_local_peers();
             'main_loop: loop {
                 crossbeam::select! {
                     recv(receiver) -> res => {
@@ -335,6 +339,11 @@ impl Tester {
                                     let db = db.clone();
                                     // receive new listener to test
                                     for (addr, _) in listener.1.iter() {
+                                        // Announced endpoints are peer controlled: never probe one
+                                        // that isn't a routable address (loopback, private, ...)
+                                        if !is_routable_peer_addr(addr, allow_local_peers) {
+                                            continue;
+                                        }
                                         if !db.write().insert_peer_in_test(addr) {
                                             // if the peer is already in test, we skip it
                                             continue;
@@ -433,6 +442,10 @@ impl Tester {
                         };
 
                         // we try to connect to all peer listener (For now we have only one listener)
+                        if !is_routable_peer_addr(&listener, allow_local_peers) {
+                            db.write().remove_peer_in_test(&listener);
+                            continue;
+                        }
                         let ip_canonical = to_canonical(listener.ip());
                         if active_connections.get_peers_connected().iter().any(|(_, (addr, _, _))| to_canonical(addr.ip()) == ip_canonical) {
                             db.write().remove_peer_in_test(&listener);

--- a/massa-protocol-worker/src/ip.rs
+++ b/massa-protocol-worker/src/ip.rs
@@ -1,4 +1,10 @@
-use std::net::IpAddr;
+use std::{
+    collections::HashMap,
+    net::{IpAddr, SocketAddr},
+};
+
+use ip_rfc::global;
+use peernet::transports::TransportType;
 
 // TODO: Use std one when stable
 pub(crate) fn to_canonical(ip: IpAddr) -> IpAddr {
@@ -10,5 +16,109 @@ pub(crate) fn to_canonical(ip: IpAddr) -> IpAddr {
             }
             IpAddr::V6(v6)
         }
+    }
+}
+
+/// Returns true if `addr` is an endpoint the peer management pipeline is allowed
+/// to probe or to re-advertise to other peers.
+///
+/// Announcements and peer lists are signed, but their content is entirely
+/// peer-controlled: without this check a peer could make us open connections to
+/// (or gossip around) loopback, private, link-local or otherwise reserved
+/// addresses. Only globally routable endpoints are kept, unless the node is
+/// configured to deal with local peers (see [`allow_local_peers`]).
+///
+/// [`allow_local_peers`]: massa_protocol_exports::ProtocolConfig::allow_local_peers
+pub(crate) fn is_routable_peer_addr(addr: &SocketAddr, allow_local_peers: bool) -> bool {
+    let ip = to_canonical(addr.ip());
+    // a null port is never connectable, whatever the address class
+    if addr.port() == 0 {
+        return false;
+    }
+    // multicast and broadcast are seen as global by `ip_rfc` but can never be a
+    // peer endpoint, so they are refused even when local peers are allowed
+    if ip.is_multicast() || matches!(ip, IpAddr::V4(ipv4) if ipv4.is_broadcast()) {
+        return false;
+    }
+    allow_local_peers || global(&ip)
+}
+
+/// Drops from `listeners` every endpoint we must not probe nor re-advertise.
+/// See [`is_routable_peer_addr`].
+pub(crate) fn filter_routable_listeners(
+    listeners: HashMap<SocketAddr, TransportType>,
+    allow_local_peers: bool,
+) -> HashMap<SocketAddr, TransportType> {
+    listeners
+        .into_iter()
+        .filter(|(addr, _)| is_routable_peer_addr(addr, allow_local_peers))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_routable_listeners, is_routable_peer_addr};
+    use peernet::transports::TransportType;
+    use std::collections::HashMap;
+    use std::net::SocketAddr;
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn test_only_global_addresses_are_routable() {
+        assert!(is_routable_peer_addr(&addr("1.2.3.4:31244"), false));
+        assert!(is_routable_peer_addr(&addr("[2001:db9::1]:31244"), false));
+
+        // non global address classes are refused
+        for non_global in [
+            "127.0.0.1:31244",
+            "0.0.0.0:31244",
+            "192.168.1.2:31244",
+            "10.0.0.1:31244",
+            "169.254.1.1:31244",
+            "224.0.0.1:31244",
+            "[::1]:31244",
+            "[fe80::1]:31244",
+            "[fc00::1]:31244",
+            // ipv4 mapped ipv6 must be canonicalized before being checked
+            "[::ffff:127.0.0.1]:31244",
+        ] {
+            assert!(
+                !is_routable_peer_addr(&addr(non_global), false),
+                "{} should not be routable",
+                non_global
+            );
+        }
+
+        // a null port is never connectable, even for a global address
+        assert!(!is_routable_peer_addr(&addr("1.2.3.4:0"), false));
+        assert!(!is_routable_peer_addr(&addr("1.2.3.4:0"), true));
+    }
+
+    #[test]
+    fn test_local_peers_allowed_by_configuration() {
+        assert!(is_routable_peer_addr(&addr("127.0.0.1:31244"), true));
+        assert!(is_routable_peer_addr(&addr("192.168.1.2:31244"), true));
+        // ... but multicast and broadcast never are
+        assert!(!is_routable_peer_addr(&addr("224.0.0.1:31244"), true));
+        assert!(!is_routable_peer_addr(&addr("255.255.255.255:31244"), true));
+        assert!(!is_routable_peer_addr(&addr("[ff02::1]:31244"), true));
+    }
+
+    #[test]
+    fn test_filter_routable_listeners() {
+        let listeners = HashMap::from([
+            (addr("1.2.3.4:31244"), TransportType::Tcp),
+            (addr("127.0.0.1:31245"), TransportType::Tcp),
+            (addr("192.168.1.2:31246"), TransportType::Quic),
+        ]);
+
+        let filtered = filter_routable_listeners(listeners.clone(), false);
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key(&addr("1.2.3.4:31244")));
+
+        assert_eq!(filter_routable_listeners(listeners, true).len(), 3);
     }
 }


### PR DESCRIPTION
…d re-advertising them

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification