### PR TITLE
[F112] mark blocks invalid when their committed operations fail conte…

### DIFF
--- a/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
@@ -52,7 +52,7 @@ use rand::{seq::SliceRandom, Rng};
 use tracing::{debug, info, warn};
 
 use super::{
-    super::operation_handler::note_operations_from_peer,
+    super::operation_handler::{is_block_intrinsic_operation_failure, note_operations_from_peer},
     cache::{BlockDataKind, SharedBlockCache},
     commands_propagation::BlockHandlerPropagationCommand,
     commands_retrieval::BlockHandlerRetrievalCommand,
@@ -900,9 +900,6 @@ impl RetrievalThread {
         // Here we know that we were looking for that block's operations and that the sender node sent us some of the missing ones.
 
         // Check the validity of the received operations.
-        // TODO: in the future if the validiy check fails for something non-malleable (eg. not sig verif),
-        //       we should stop retrieving the block and ban everyone who knows it
-        //       because we know for sure that this op's ID belongs to the block.
         if let Err(err) = note_operations_from_peer(
             &self.storage,
             &mut self.operation_cache,
@@ -912,6 +909,17 @@ impl RetrievalThread {
             &mut self.sender_propagation_ops,
             &mut self.pool_controller,
         ) {
+            if is_block_intrinsic_operation_failure(&err) {
+                // The failure is fully determined by operation contents that the block's operation IDs
+                // already commit to: no peer can ever deliver a valid version of this block.
+                // Stop retrieving it instead of asking around forever.
+                warn!(
+                    "block id {} is invalid: one of the operations it commits to failed a content-level check: {}",
+                    block_id, err
+                );
+                self.mark_block_as_invalid(&block_id);
+                return;
+            }
             warn!(
                 "Peer id {} sent us operations for block id {} but they failed validity checks: {}",
                 from_peer_id, block_id, err

--- a/massa-protocol-worker/src/handlers/operation_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/mod.rs
@@ -22,7 +22,7 @@ mod propagation;
 mod retrieval;
 
 pub(crate) use messages::{OperationMessage, OperationMessageSerializer};
-pub(crate) use retrieval::note_operations_from_peer;
+pub(crate) use retrieval::{is_block_intrinsic_operation_failure, note_operations_from_peer};
 
 use super::peer_handler::models::{PeerManagementCmd, PeerMessageTuple};
 

--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -468,6 +468,23 @@ impl RetrievalThread {
     }
 }
 
+/// Tells whether a `note_operations_from_peer` failure is caused by the operation contents
+/// themselves, rather than by the way the sender delivered them.
+///
+/// An operation ID commits to the operation contents, but not to its signature. A failure that
+/// depends only on those contents can therefore never be fixed by asking another peer: any
+/// operation carrying the same ID fails the same check. When such an operation is committed by a
+/// block's operation ID list, that block is permanently invalid and must not be retried.
+pub(crate) fn is_block_intrinsic_operation_failure(err: &ProtocolError) -> bool {
+    match err {
+        // the operation is bigger than a whole block is allowed to be: fully determined by its contents
+        ProtocolError::InvalidOperationError(_) => true,
+        // e.g. `WrongSignature`: the signature is not covered by the operation ID,
+        // so another peer may still deliver the same operation properly signed
+        _ => false,
+    }
+}
+
 pub(crate) fn note_operations_from_peer(
     base_storage: &Storage,
     operations_cache: &mut SharedOperationCache,

--- a/massa-protocol-worker/src/tests/ban_nodes_scenarios.rs
+++ b/massa-protocol-worker/src/tests/ban_nodes_scenarios.rs
@@ -742,6 +742,132 @@ fn test_protocol_does_not_ban_header_only_sender_of_an_invalid_block() {
     ban_waitpoint.wait();
 }
 
+/// A block whose operation contents fail a check that is fully determined by those contents
+/// (here: an operation bigger than a whole block may be) is unrecoverable: the block's operation
+/// ids commit to that content, so no peer can ever deliver a valid version of it. We must mark it
+/// invalid and stop retrieving it, not merely ban the sender and keep asking around.
+#[test]
+fn test_protocol_marks_block_invalid_on_intrinsically_invalid_full_operations() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        // any single operation is enough to overflow the block, making its contents invalid
+        max_serialized_operations_size_per_block: 1,
+        ..Default::default()
+    };
+
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+
+    let block_creator = KeyPair::generate(0).unwrap();
+    let op = tools::create_operation_with_expire_period(&block_creator, 5);
+    let op_thread = op
+        .content_creator_address
+        .get_thread(protocol_config.thread_count);
+    let block = ProtocolTestUniverse::create_block(
+        &block_creator,
+        Slot::new(1, op_thread),
+        vec![op.clone()],
+        vec![],
+        vec![],
+    );
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+
+    let waitpoint = WaitPoint::new();
+    let waitpoint_trigger_handle = waitpoint.get_trigger_handle();
+
+    peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_ban_peer()
+        .returning(move |_| {});
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_get_peers()
+        .return_const(HashMap::default());
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_get_peers_mut()
+        .times(0..1)
+        .returning(HashMap::default);
+    // the block must be reported as invalid to consensus: this is what stops the retrieval loop
+    let block_clone = block.clone();
+    foreign_controllers
+        .consensus_controller
+        .expect_mark_invalid_block()
+        .times(1)
+        .return_once(move |block_id, header| {
+            assert_eq!(block_id, block_clone.id);
+            assert_eq!(header.id, block_clone.content.header.id);
+            waitpoint_trigger_handle.trigger();
+        });
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    shared_active_connections.set_expectations(
+        |active_connections: &mut MockActiveConnectionsTrait| {
+            active_connections
+                .expect_get_peer_ids_connected()
+                .returning(move || {
+                    let mut peers = HashSet::new();
+                    peers.insert(node_a_peer_id);
+                    peers
+                });
+            active_connections
+                .expect_send_to_peer()
+                .returning(move |_, _, _, _| Ok(()));
+            active_connections
+                .expect_shutdown_connection()
+                .returning(move |_| {});
+        },
+    );
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    // start retrieving the block, which makes us ask node A for its operation ids
+    universe
+        .module_controller
+        .send_wishlist_delta(
+            vec![(block.id, Some(block.content.header.clone()))]
+                .into_iter()
+                .collect(),
+            PreHashSet::<BlockId>::default(),
+        )
+        .unwrap();
+
+    // TODO: Find a way to wait for the previous messages to be processed
+    std::thread::sleep(Duration::from_millis(1000));
+
+    // we do not know that operation locally, so the op id list alone cannot tell us the block is
+    // oversized: we go on and ask node A for the operation itself
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Block(Box::new(BlockMessage::DataResponse {
+            block_id: block.id,
+            block_info: BlockInfoReply::OperationIds(vec![op.id]),
+        })),
+    );
+
+    // TODO: Find a way to wait for the previous messages to be processed
+    std::thread::sleep(Duration::from_millis(1000));
+
+    // node A delivers the operation: it is over the max block size, which the block's operation
+    // ids already commit to, so the block is permanently invalid
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Block(Box::new(BlockMessage::DataResponse {
+            block_id: block.id,
+            block_info: BlockInfoReply::Operations(vec![op.clone()]),
+        })),
+    );
+
+    waitpoint.wait();
+}
+
 #[test]
 fn test_protocol_bans_all_nodes_propagating_an_attack_attempt() {
     let protocol_config = ProtocolConfig {


### PR DESCRIPTION
…nt-level checks

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification