### PR TITLE
[F118] bound conflicting endorsements per draw on the protocol retrie…

### DIFF
--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -147,6 +147,27 @@ pub const INITIAL_DRAW_SEED: &str = "massa_genesis_seed";
 pub const THREAD_COUNT: u8 = 32;
 /// Number of endorsement
 pub const ENDORSEMENT_COUNT: u32 = 16;
+/// Maximum number of endorsements kept for a given `(slot, index)` draw, whatever the endorsed
+/// block is. Enforced both by the endorsement pool and by the protocol propagation path, which
+/// share this bound so that neither becomes the tighter of the two.
+///
+/// An honest endorser signs exactly one endorsement per `(slot, index)`: the factory walks slots
+/// strictly monotonically and never re-endorses after a reorg. So several entries under the same
+/// key mean the drawn endorser equivocated. The endorsed block is not constrained at ingress and
+/// the endorsement id is derived from the whole signed content, so without a bound such an endorser
+/// could mint arbitrarily many valid endorsements differing only by their endorsed block, growing
+/// the pool without limit and having every node relay each variant.
+///
+/// The bound is kept above 1 for two reasons. The denunciation pool needs two conflicting
+/// endorsements to build a denunciation, so a bound of 1 would silently disable endorsement
+/// equivocation denunciation. And `EndorsementPool::get_block_endorsements` only returns the
+/// endorsement matching the parent the block factory settled on, so keeping a single variant makes
+/// insertion first-write-wins, letting an equivocating endorser deliberately send the variant that
+/// does not match our parent and permanently deny us that endorsement slot, which costs block
+/// fitness and rewards. A few variants cover the competing blockclique tips of a real fork while
+/// keeping the worst-case pool size within a small multiple of
+/// `max_endorsements_pool_size_per_thread`.
+pub const MAX_ENDORSEMENTS_PER_SLOT_INDEX: usize = 4;
 /// Threshold for fitness.
 pub const DELTA_F0: u64 = 64 * (ENDORSEMENT_COUNT as u64 + 1);
 /// Maximum number of operations per block

--- a/massa-pool-worker/src/endorsement_pool.rs
+++ b/massa-pool-worker/src/endorsement_pool.rs
@@ -2,6 +2,7 @@
 
 use massa_models::{
     block_id::BlockId,
+    config::MAX_ENDORSEMENTS_PER_SLOT_INDEX,
     endorsement::EndorsementId,
     prehash::{CapacityAllocator, PreHashMap, PreHashSet},
     slot::Slot,
@@ -15,21 +16,6 @@ use std::{
     sync::Arc,
 };
 use tracing::{trace, warn};
-
-/// Maximum number of endorsements kept for a given `(slot, index)` pair, whatever the endorsed
-/// block is. An honest endorser signs exactly one endorsement per `(slot, index)`: the factory
-/// walks slots strictly monotonically and never re-endorses after a reorg. So several entries
-/// under the same key mean the drawn endorser equivocated, and the endorsed block is not
-/// constrained at ingress: without a bound such an endorser could mint arbitrarily many valid
-/// endorsements differing only by their endorsed block and grow the pool without limit.
-///
-/// The bound is kept above 1 because [`EndorsementPool::get_block_endorsements`] only returns the
-/// endorsement matching the parent the block factory settled on. Keeping a single variant makes
-/// insertion first-write-wins, letting an equivocating endorser deliberately send the variant that
-/// does not match our parent and permanently deny us that endorsement slot, which costs block
-/// fitness and rewards. A few variants cover the competing blockclique tips of a real fork while
-/// keeping the worst-case pool size within a small multiple of `max_endorsements_pool_size_per_thread`.
-pub(crate) const MAX_ENDORSEMENTS_PER_SLOT_INDEX: usize = 4;
 
 #[derive(Clone)]
 pub struct EndorsementPool {

--- a/massa-pool-worker/src/tests/endorsement_pool_tests.rs
+++ b/massa-pool-worker/src/tests/endorsement_pool_tests.rs
@@ -8,7 +8,7 @@ use massa_signature::KeyPair;
 use super::tools::{
     create_endorsement, create_endorsement_on_block, default_mock_execution_controller, pool_test,
 };
-use crate::endorsement_pool::MAX_ENDORSEMENTS_PER_SLOT_INDEX;
+use massa_models::config::MAX_ENDORSEMENTS_PER_SLOT_INDEX;
 
 fn create_selector_mock_with_address(address: Address) -> MockSelectorController {
     let mut res = MockSelectorController::new();

--- a/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
@@ -3,22 +3,13 @@ use std::{
     sync::Arc,
 };
 
-use massa_models::{endorsement::EndorsementId, prehash::PreHashSet, slot::Slot};
+use massa_models::{
+    config::MAX_ENDORSEMENTS_PER_SLOT_INDEX, endorsement::EndorsementId, prehash::PreHashSet,
+    slot::Slot,
+};
 use massa_protocol_exports::PeerId;
 use parking_lot::RwLock;
 use schnellru::{ByLength, LruMap};
-
-/// Maximum number of distinct endorsements we accept and propagate for a given `(slot, index)`
-/// endorsement draw. An honest drawn endorser signs exactly one endorsement per draw, so several
-/// distinct ones mean it equivocated.
-///
-/// The bound is kept above 1 for two reasons: the denunciation pool needs to see two conflicting
-/// endorsements to build a denunciation, and dropping everything after the first variant would let
-/// an equivocating endorser pick which variant we keep, denying us the endorsement slot when it
-/// endorses a block that is not the parent our block factory settles on. It matches the pool-side
-/// bound (`MAX_ENDORSEMENTS_PER_SLOT_INDEX`) so that the propagation path never becomes the tighter
-/// of the two limits.
-pub const MAX_ENDORSEMENTS_PER_DRAW: usize = 4;
 
 /// Cache of endorsements
 pub struct EndorsementCache {
@@ -38,11 +29,11 @@ impl EndorsementCache {
     pub fn new(max_known_endorsements: u32, max_known_endorsements_by_peer: u32) -> Self {
         Self {
             checked_endorsements: LruMap::new(ByLength::new(max_known_endorsements)),
-            // one entry per draw holds up to `MAX_ENDORSEMENTS_PER_DRAW` ids, so scaling the
+            // one entry per draw holds up to `MAX_ENDORSEMENTS_PER_SLOT_INDEX` ids, so scaling the
             // capacity down keeps this index's memory in line with `checked_endorsements` while
             // covering the same horizon of endorsements
             endorsements_by_draw: LruMap::new(ByLength::new(std::cmp::max(
-                max_known_endorsements / MAX_ENDORSEMENTS_PER_DRAW as u32,
+                max_known_endorsements / MAX_ENDORSEMENTS_PER_SLOT_INDEX as u32,
                 1,
             ))),
             endorsements_known_by_peer: HashMap::new(),
@@ -75,7 +66,7 @@ impl EndorsementCache {
     /// The endorsement id is derived from the whole signed content, so an equivocating endorser can
     /// mint unlimited distinct-but-valid endorsements for the draw it won just by varying the
     /// endorsed block: deduplicating on `checked_endorsements` alone does not stop them from being
-    /// noted and gossiped further. Returns `false` once `MAX_ENDORSEMENTS_PER_DRAW` distinct
+    /// noted and gossiped further. Returns `false` once `MAX_ENDORSEMENTS_PER_SLOT_INDEX` distinct
     /// endorsements have already been registered for that draw.
     ///
     /// Registering the id rather than only counting keeps this idempotent, so an endorsement that
@@ -96,7 +87,7 @@ impl EndorsementCache {
         if draw_endorsements.contains(&endorsement_id) {
             return true;
         }
-        if draw_endorsements.len() >= MAX_ENDORSEMENTS_PER_DRAW {
+        if draw_endorsements.len() >= MAX_ENDORSEMENTS_PER_SLOT_INDEX {
             return false;
         }
         draw_endorsements.insert(endorsement_id);

--- a/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/cache.rs
@@ -3,15 +3,30 @@ use std::{
     sync::Arc,
 };
 
-use massa_models::endorsement::EndorsementId;
+use massa_models::{endorsement::EndorsementId, prehash::PreHashSet, slot::Slot};
 use massa_protocol_exports::PeerId;
 use parking_lot::RwLock;
 use schnellru::{ByLength, LruMap};
+
+/// Maximum number of distinct endorsements we accept and propagate for a given `(slot, index)`
+/// endorsement draw. An honest drawn endorser signs exactly one endorsement per draw, so several
+/// distinct ones mean it equivocated.
+///
+/// The bound is kept above 1 for two reasons: the denunciation pool needs to see two conflicting
+/// endorsements to build a denunciation, and dropping everything after the first variant would let
+/// an equivocating endorser pick which variant we keep, denying us the endorsement slot when it
+/// endorses a block that is not the parent our block factory settles on. It matches the pool-side
+/// bound (`MAX_ENDORSEMENTS_PER_SLOT_INDEX`) so that the propagation path never becomes the tighter
+/// of the two limits.
+pub const MAX_ENDORSEMENTS_PER_DRAW: usize = 4;
 
 /// Cache of endorsements
 pub struct EndorsementCache {
     /// List of endorsements we checked recently
     pub checked_endorsements: LruMap<EndorsementId, ()>,
+    /// Endorsements accepted for a given `(inclusion slot, index)` draw, used to bound how many
+    /// conflicting variants a single drawn endorser can push through us
+    pub endorsements_by_draw: LruMap<(Slot, u32), PreHashSet<EndorsementId>>,
     /// List of endorsements known by peers
     pub endorsements_known_by_peer: HashMap<PeerId, LruMap<EndorsementId, ()>>,
     /// Maximum number of endorsements known by a peer
@@ -23,6 +38,13 @@ impl EndorsementCache {
     pub fn new(max_known_endorsements: u32, max_known_endorsements_by_peer: u32) -> Self {
         Self {
             checked_endorsements: LruMap::new(ByLength::new(max_known_endorsements)),
+            // one entry per draw holds up to `MAX_ENDORSEMENTS_PER_DRAW` ids, so scaling the
+            // capacity down keeps this index's memory in line with `checked_endorsements` while
+            // covering the same horizon of endorsements
+            endorsements_by_draw: LruMap::new(ByLength::new(std::cmp::max(
+                max_known_endorsements / MAX_ENDORSEMENTS_PER_DRAW as u32,
+                1,
+            ))),
             endorsements_known_by_peer: HashMap::new(),
             max_known_endorsements_by_peer,
         }
@@ -46,6 +68,39 @@ impl EndorsementCache {
     /// Mark an endorsement ID as checked by us
     pub fn insert_checked_endorsement(&mut self, enrodsement_id: EndorsementId) {
         self.checked_endorsements.insert(enrodsement_id, ());
+    }
+
+    /// Register an endorsement against its `(slot, index)` draw and tell whether we accept it.
+    ///
+    /// The endorsement id is derived from the whole signed content, so an equivocating endorser can
+    /// mint unlimited distinct-but-valid endorsements for the draw it won just by varying the
+    /// endorsed block: deduplicating on `checked_endorsements` alone does not stop them from being
+    /// noted and gossiped further. Returns `false` once `MAX_ENDORSEMENTS_PER_DRAW` distinct
+    /// endorsements have already been registered for that draw.
+    ///
+    /// Registering the id rather than only counting keeps this idempotent, so an endorsement that
+    /// gets re-checked after being evicted from `checked_endorsements` does not consume the budget
+    /// twice.
+    pub fn register_draw_endorsement(
+        &mut self,
+        slot: Slot,
+        index: u32,
+        endorsement_id: EndorsementId,
+    ) -> bool {
+        let Some(draw_endorsements) = self
+            .endorsements_by_draw
+            .get_or_insert((slot, index), PreHashSet::default)
+        else {
+            return false;
+        };
+        if draw_endorsements.contains(&endorsement_id) {
+            return true;
+        }
+        if draw_endorsements.len() >= MAX_ENDORSEMENTS_PER_DRAW {
+            return false;
+        }
+        draw_endorsements.insert(endorsement_id);
+        true
     }
 
     /// Update caches to remove all data from disconnected peers

--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -204,8 +204,8 @@ fn is_endorsement_fresh(
 /// Checks performed:
 /// - Valid signature.
 /// - The creator is the endorser drawn for the endorsement's `(slot, index)` pair.
-/// - At most `MAX_ENDORSEMENTS_PER_DRAW` distinct endorsements are noted for a given draw, so that
-///   an equivocating endorser cannot have us relay unlimited variants of its endorsement.
+/// - At most `MAX_ENDORSEMENTS_PER_SLOT_INDEX` distinct endorsements are noted for a given draw,
+///   so that an equivocating endorser cannot have us relay unlimited variants of its endorsement.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn note_endorsements_from_peer(
     endorsements: Vec<SecureShareEndorsement>,

--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -203,6 +203,9 @@ fn is_endorsement_fresh(
 ///
 /// Checks performed:
 /// - Valid signature.
+/// - The creator is the endorser drawn for the endorsement's `(slot, index)` pair.
+/// - At most `MAX_ENDORSEMENTS_PER_DRAW` distinct endorsements are noted for a given draw, so that
+///   an equivocating endorser cannot have us relay unlimited variants of its endorsement.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn note_endorsements_from_peer(
     endorsements: Vec<SecureShareEndorsement>,
@@ -268,6 +271,12 @@ pub(crate) fn note_endorsements_from_peer(
         }
     }
 
+    // From there we note new endorsements and propagate them
+
+    // Filter out endorsements if they are too old (max age of the inclusion slot: `max_endorsements_propagation_time`)
+    let now = MassaTime::now();
+    new_endorsements.retain(|_id, endorsement| is_endorsement_fresh(endorsement, config, now));
+
     {
         let mut cache_write = cache.write();
 
@@ -281,13 +290,28 @@ pub(crate) fn note_endorsements_from_peer(
             from_peer_id,
             &all_endorsement_ids.iter().copied().collect::<Vec<_>>(),
         );
+
+        // Drop conflicting endorsements beyond the per-draw bound. Nothing here constrains the
+        // endorsed block, so the drawn endorser of a `(slot, index)` pair can sign arbitrarily many
+        // valid endorsements differing only by that field, each with its own id: without this bound
+        // they would all be treated as new data, noted and gossiped further. We keep a few variants
+        // so the denunciation pool still gets to see the equivocation, and silently ignore the
+        // rest: equivocating is denounceable, not a reason to ban the peer that relayed it to us.
+        new_endorsements.retain(|id, endorsement| {
+            let accepted = cache_write.register_draw_endorsement(
+                endorsement.content.slot,
+                endorsement.content.index,
+                *id,
+            );
+            if !accepted {
+                debug!(
+                    "ignoring endorsement {} from peer {}: too many conflicting endorsements for the draw at slot {} index {}",
+                    id, from_peer_id, endorsement.content.slot, endorsement.content.index
+                );
+            }
+            accepted
+        });
     }
-
-    // From there we note new endorsements and propagate them
-
-    // Filter out endorsements if they are too old (max age of the inclusion slot: `max_endorsements_propagation_time`)
-    let now = MassaTime::now();
-    new_endorsements.retain(|_id, endorsement| is_endorsement_fresh(endorsement, config, now));
 
     if new_endorsements.is_empty() {
         // no endorsements to note or propagate

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -1,5 +1,6 @@
 use massa_hash::Hash;
 use massa_models::block_id::BlockId;
+use massa_models::config::MAX_ENDORSEMENTS_PER_SLOT_INDEX;
 use massa_models::endorsement::{Endorsement, EndorsementSerializer};
 use massa_models::secure_share::SecureShareContent;
 use massa_models::slot::Slot;
@@ -13,10 +14,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 
 use crate::{
-    handlers::{
-        block_handler::BlockMessage,
-        endorsement_handler::{cache::MAX_ENDORSEMENTS_PER_DRAW, EndorsementMessage},
-    },
+    handlers::{block_handler::BlockMessage, endorsement_handler::EndorsementMessage},
     messages::Message,
     wrap_network::MockActiveConnectionsTraitWrapper,
 };
@@ -406,7 +404,7 @@ fn test_protocol_bounds_conflicting_endorsements_for_the_same_draw() {
     let endorsement_creator = KeyPair::generate(0).unwrap();
 
     // the drawn endorser equivocates: same (slot, index), one endorsement per endorsed block
-    let endorsements: Vec<_> = (0..(MAX_ENDORSEMENTS_PER_DRAW + 2))
+    let endorsements: Vec<_> = (0..(MAX_ENDORSEMENTS_PER_SLOT_INDEX + 2))
         .map(|i| {
             let mut endorsement =
                 ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(1, 1));
@@ -446,7 +444,7 @@ fn test_protocol_bounds_conflicting_endorsements_for_the_same_draw() {
                     // only the per-draw bound worth of variants make it through
                     assert_eq!(
                         endorsements_storage.get_endorsement_refs().len(),
-                        MAX_ENDORSEMENTS_PER_DRAW
+                        MAX_ENDORSEMENTS_PER_SLOT_INDEX
                     );
                     waitpoint_trigger_handle.trigger();
                 });

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -1,3 +1,7 @@
+use massa_hash::Hash;
+use massa_models::block_id::BlockId;
+use massa_models::endorsement::{Endorsement, EndorsementSerializer};
+use massa_models::secure_share::SecureShareContent;
 use massa_models::slot::Slot;
 use massa_pos_exports::Selection;
 use massa_protocol_exports::PeerId;
@@ -9,7 +13,10 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 
 use crate::{
-    handlers::{block_handler::BlockMessage, endorsement_handler::EndorsementMessage},
+    handlers::{
+        block_handler::BlockMessage,
+        endorsement_handler::{cache::MAX_ENDORSEMENTS_PER_DRAW, EndorsementMessage},
+    },
     messages::Message,
     wrap_network::MockActiveConnectionsTraitWrapper,
 };
@@ -385,4 +392,82 @@ fn test_protocol_does_not_check_stale_endorsements_it_receives() {
     waitpoint.wait();
     // the stale endorsement must never have reached the PoS draws check
     assert_eq!(*queried_slots.lock(), vec![fresh_slot]);
+}
+
+#[test]
+fn test_protocol_bounds_conflicting_endorsements_for_the_same_draw() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let peer_ids = [node_a_peer_id];
+    let endorsement_creator = KeyPair::generate(0).unwrap();
+
+    // the drawn endorser equivocates: same (slot, index), one endorsement per endorsed block
+    let endorsements: Vec<_> = (0..(MAX_ENDORSEMENTS_PER_DRAW + 2))
+        .map(|i| {
+            let mut endorsement =
+                ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(1, 1));
+            endorsement.content.endorsed_block = BlockId::generate_from_hash(Hash::compute_from(
+                format!("conflicting parent {}", i).as_bytes(),
+            ));
+            Endorsement::new_verifiable(
+                endorsement.content,
+                EndorsementSerializer::new(),
+                &endorsement_creator,
+                0,
+            )
+            .unwrap()
+        })
+        .collect();
+    let endorser_address = endorsements[0].content_creator_address;
+
+    let waitpoint = WaitPoint::new();
+    let waitpoint_trigger_handle = waitpoint.get_trigger_handle();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    ProtocolTestUniverse::peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    ProtocolTestUniverse::active_connections_boilerplate(
+        &mut shared_active_connections,
+        peer_ids.into_iter().collect(),
+    );
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller
+                .expect_add_endorsements()
+                .return_once(move |endorsements_storage| {
+                    // only the per-draw bound worth of variants make it through
+                    assert_eq!(
+                        endorsements_storage.get_endorsement_refs().len(),
+                        MAX_ENDORSEMENTS_PER_DRAW
+                    );
+                    waitpoint_trigger_handle.trigger();
+                });
+        });
+    foreign_controllers
+        .selector_controller
+        .set_expectations(move |selector_controller| {
+            selector_controller
+                .expect_get_selection()
+                .returning(move |_| {
+                    Ok(Selection {
+                        endorsements: vec![endorser_address; 1],
+                        producer: endorser_address,
+                    })
+                });
+        });
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Endorsement(EndorsementMessage::Endorsements(endorsements)),
+    );
+    waitpoint.wait();
 }


### PR DESCRIPTION
…val path

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification