### PR TITLE
[F117] drop stale endorsements before signature and PoS draw verifica…

### DIFF
--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -122,6 +122,19 @@ impl RetrievalThread {
         match message {
             EndorsementMessage::Endorsements(endorsements) => {
                 debug!("Received endorsement message: Endorsement from {}", peer_id);
+                // Discard endorsements that are already too old to be useful before doing
+                // any expensive work on them (signature verification, PoS draw lookup):
+                // otherwise a peer could replay arbitrary amounts of old endorsements
+                // to make us burn CPU, cycling through IDs faster than the
+                // `checked_endorsements` cache can remember them.
+                let now = MassaTime::now();
+                let endorsements: Vec<_> = endorsements
+                    .into_iter()
+                    .filter(|endorsement| is_endorsement_fresh(endorsement, &self.config, now))
+                    .collect();
+                if endorsements.is_empty() {
+                    return;
+                }
                 if let Err(err) = note_endorsements_from_peer(
                     endorsements,
                     &peer_id,
@@ -152,6 +165,24 @@ impl RetrievalThread {
         self.peer_cmd_sender
             .try_send(PeerManagementCmd::Ban(vec![*peer_id]))
             .map_err(|err| ProtocolError::SendError(err.to_string()))
+    }
+}
+
+/// Returns true if the inclusion slot of the endorsement is recent enough for the
+/// endorsement to still be worth processing (see `max_endorsements_propagation_time`).
+fn is_endorsement_fresh(
+    endorsement: &SecureShareEndorsement,
+    config: &ProtocolConfig,
+    now: MassaTime,
+) -> bool {
+    match get_block_slot_timestamp(
+        config.thread_count,
+        config.t0,
+        config.genesis_timestamp,
+        endorsement.content.slot,
+    ) {
+        Ok(t) => t.saturating_add(config.max_endorsements_propagation_time) >= now,
+        Err(_) => false,
     }
 }
 
@@ -248,17 +279,7 @@ pub(crate) fn note_endorsements_from_peer(
 
     // Filter out endorsements if they are too old (max age of the inclusion slot: `max_endorsements_propagation_time`)
     let now = MassaTime::now();
-    new_endorsements.retain(|_id, endorsement| {
-        match get_block_slot_timestamp(
-            config.thread_count,
-            config.t0,
-            config.genesis_timestamp,
-            endorsement.content.slot,
-        ) {
-            Ok(t) => t.saturating_add(config.max_endorsements_propagation_time) >= now,
-            Err(_) => false,
-        }
-    });
+    new_endorsements.retain(|_id, endorsement| is_endorsement_fresh(endorsement, config, now));
 
     if new_endorsements.is_empty() {
         // no endorsements to note or propagate

--- a/massa-protocol-worker/src/tests/endorsements_scenarios.rs
+++ b/massa-protocol-worker/src/tests/endorsements_scenarios.rs
@@ -4,6 +4,9 @@ use massa_protocol_exports::PeerId;
 use massa_protocol_exports::ProtocolConfig;
 use massa_signature::KeyPair;
 use massa_test_framework::{TestUniverse, WaitPoint};
+use massa_time::MassaTime;
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 use crate::{
     handlers::{block_handler::BlockMessage, endorsement_handler::EndorsementMessage},
@@ -306,4 +309,80 @@ fn test_protocol_propagates_endorsements_only_to_nodes_that_dont_know_about_it_b
         Message::Block(Box::new(BlockMessage::Header(block.content.header))),
     );
     waitpoint.wait();
+}
+
+#[test]
+fn test_protocol_does_not_check_stale_endorsements_it_receives() {
+    // genesis is far enough in the past for slot (1, 1) to be stale
+    // while slot (100, 1) is still fresh
+    let t0 = MassaTime::from_millis(16000);
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        t0,
+        genesis_timestamp: MassaTime::now().saturating_sub(t0.saturating_mul(100)),
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let peer_ids = [node_a_peer_id];
+    let endorsement_creator = KeyPair::generate(0).unwrap();
+    let stale_endorsement =
+        ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(1, 1));
+    let fresh_slot = Slot::new(100, 1);
+    let fresh_endorsement =
+        ProtocolTestUniverse::create_endorsement(&endorsement_creator, fresh_slot);
+
+    let waitpoint = WaitPoint::new();
+    let waitpoint_trigger_handle = waitpoint.get_trigger_handle();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    ProtocolTestUniverse::peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    ProtocolTestUniverse::active_connections_boilerplate(
+        &mut shared_active_connections,
+        peer_ids.into_iter().collect(),
+    );
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller
+                .expect_add_endorsements()
+                .return_once(move |endorsements_storage| {
+                    let stored_endorsements = endorsements_storage.get_endorsement_refs();
+                    assert_eq!(stored_endorsements.len(), 1);
+                    assert!(stored_endorsements.contains(&fresh_endorsement.id));
+                    waitpoint_trigger_handle.trigger();
+                });
+        });
+    // record the slots the PoS draws have been looked up for
+    let queried_slots = Arc::new(Mutex::new(Vec::new()));
+    let queried_slots_handle = queried_slots.clone();
+    foreign_controllers
+        .selector_controller
+        .set_expectations(|selector_controller| {
+            selector_controller
+                .expect_get_selection()
+                .returning(move |slot| {
+                    queried_slots_handle.lock().push(slot);
+                    Ok(Selection {
+                        endorsements: vec![fresh_endorsement.content_creator_address; 1],
+                        producer: fresh_endorsement.content_creator_address,
+                    })
+                });
+        });
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive(
+        &node_a_peer_id,
+        Message::Endorsement(EndorsementMessage::Endorsements(vec![
+            stale_endorsement.clone(),
+            fresh_endorsement.clone(),
+        ])),
+    );
+    waitpoint.wait();
+    // the stale endorsement must never have reached the PoS draws check
+    assert_eq!(*queried_slots.lock(), vec![fresh_slot]);
 }


### PR DESCRIPTION
…tion

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification