### PR TITLE
fix(protocol): ban peers sending messages with trailing bytes

### DIFF
--- a/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/retrieval.rs
@@ -151,12 +151,16 @@ impl RetrievalThread {
                                 // A valid message prefix followed by trailing bytes must not
                                 // tear down this long-lived shared retrieval thread (doing so
                                 // would let a single peer deny block handling for everyone).
-                                // Skip the malformed message and keep serving other peers.
+                                // A compliant peer never sends trailing bytes, so ban the
+                                // sender and keep serving other peers.
                                 warn!(
-                                    "peer {} sent a block message with {} unexpected trailing byte(s); ignoring it",
+                                    "peer {} sent a block message with {} unexpected trailing byte(s); banning it",
                                     peer_id,
                                     rest.len()
                                 );
+                                if let Err(err) = self.ban_peers(&[peer_id]) {
+                                    warn!("Error while banning peer {} err: {:?}", peer_id, err);
+                                }
                                 continue;
                             }
                             match message {

--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -116,7 +116,15 @@ impl RetrievalThread {
             }
         };
         if !rest.is_empty() {
-            debug!("Message not fully consumed");
+            // A compliant peer never sends trailing bytes, so ban the sender.
+            warn!(
+                "peer {} sent an endorsement message with {} unexpected trailing byte(s); banning it",
+                peer_id,
+                rest.len()
+            );
+            if let Err(err) = self.ban_peer(&peer_id) {
+                warn!("Error while banning peer {} err: {:?}", peer_id, err);
+            }
             return;
         }
         match message {

--- a/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/operation_handler/retrieval.rs
@@ -142,12 +142,16 @@ impl RetrievalThread {
                                 // A valid message prefix followed by trailing bytes must not
                                 // tear down this long-lived shared retrieval thread (doing so
                                 // would let a single peer deny operation handling for everyone).
-                                // Skip the malformed message and keep serving other peers.
+                                // A compliant peer never sends trailing bytes, so ban the
+                                // sender and keep serving other peers.
                                 warn!(
-                                    "peer {} sent an operation message with {} unexpected trailing byte(s); ignoring it",
+                                    "peer {} sent an operation message with {} unexpected trailing byte(s); banning it",
                                     peer_id,
                                     rest.len()
                                 );
+                                if let Err(e) = self.ban_node(&peer_id) {
+                                    warn!("Error when banning node: {}", e);
+                                }
                                 continue;
                             }
                             match message {

--- a/massa-protocol-worker/src/handlers/peer_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/peer_handler/mod.rs
@@ -226,7 +226,14 @@ impl PeerManagementHandler {
                                 }
                             };
                             if !rest.is_empty() {
-                                warn!("message not fully deserialized");
+                                // A compliant peer never sends trailing bytes, so ban the sender.
+                                warn!(
+                                    "peer {} sent a peer management message with {} unexpected trailing byte(s); banning it",
+                                    peer_id,
+                                    rest.len()
+                                );
+                                active_connections.shutdown_connection(&peer_id);
+                                peer_db.write().ban_peer(&peer_id);
                                 continue;
                             }
                             match message {

--- a/massa-protocol-worker/src/tests/ban_nodes_scenarios.rs
+++ b/massa-protocol-worker/src/tests/ban_nodes_scenarios.rs
@@ -20,7 +20,9 @@ use crate::wrap_peer_db::MockPeerDBTrait;
 use crate::{
     handlers::{
         block_handler::{BlockInfoReply, BlockMessage},
+        endorsement_handler::EndorsementMessage,
         operation_handler::OperationMessage,
+        peer_handler::PeerManagementMessage,
     },
     messages::Message,
 };
@@ -890,5 +892,159 @@ fn test_protocol_bans_all_nodes_propagating_an_attack_attempt() {
         .notify_block_attack(block.id)
         .unwrap();
 
+    ban_waitpoint.wait();
+}
+
+/// Common mock setup for the trailing-bytes ban tests: the peer must be
+/// disconnected and banned, and nothing else must happen.
+fn trailing_bytes_ban_setup(
+    foreign_controllers: &mut ProtocolForeignControllers,
+    node_a_peer_id: PeerId,
+    ban_waitpoint: &WaitPoint,
+) {
+    let ban_waitpoint_trigger_handle = ban_waitpoint.get_trigger_handle();
+    ProtocolTestUniverse::peer_db_boilerplate(&mut foreign_controllers.peer_db.write());
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_ban_peer()
+        .returning(move |peer_id| {
+            assert_eq!(peer_id, &node_a_peer_id);
+            ban_waitpoint_trigger_handle.trigger();
+        });
+    let mut shared_active_connections = MockActiveConnectionsTraitWrapper::new();
+    ProtocolTestUniverse::active_connections_boilerplate(
+        &mut shared_active_connections,
+        [node_a_peer_id].into_iter().collect(),
+    );
+    shared_active_connections.set_expectations(|active_connections| {
+        active_connections
+            .expect_shutdown_connection()
+            .returning(move |peer_id| {
+                assert_eq!(peer_id, &node_a_peer_id);
+            });
+    });
+    foreign_controllers
+        .network_controller
+        .expect_get_active_connections()
+        .returning(move || Box::new(shared_active_connections.clone()));
+}
+
+#[test]
+fn test_protocol_bans_node_sending_block_message_with_trailing_bytes() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let block_creator = KeyPair::generate(0).unwrap();
+    let block =
+        ProtocolTestUniverse::create_block(&block_creator, Slot::new(1, 1), vec![], vec![], vec![]);
+
+    let ban_waitpoint = WaitPoint::new();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    trailing_bytes_ban_setup(&mut foreign_controllers, node_a_peer_id, &ban_waitpoint);
+    // the message must be dropped, not processed
+    foreign_controllers
+        .consensus_controller
+        .expect_register_block_header()
+        .never();
+
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive_with_trailing_bytes(
+        &node_a_peer_id,
+        Message::Block(Box::new(BlockMessage::Header(block.content.header.clone()))),
+    );
+    ban_waitpoint.wait();
+}
+
+#[test]
+fn test_protocol_bans_node_sending_operation_message_with_trailing_bytes() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let op_creator = KeyPair::generate(0).unwrap();
+    let operation = tools::create_operation_with_expire_period(&op_creator, 1);
+
+    let ban_waitpoint = WaitPoint::new();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    trailing_bytes_ban_setup(&mut foreign_controllers, node_a_peer_id, &ban_waitpoint);
+    // the message must be dropped, not processed
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller.expect_add_operations().never();
+        });
+
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive_with_trailing_bytes(
+        &node_a_peer_id,
+        Message::Operation(OperationMessage::Operations(vec![operation])),
+    );
+    ban_waitpoint.wait();
+}
+
+#[test]
+fn test_protocol_bans_node_sending_endorsement_message_with_trailing_bytes() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+    let endorsement_creator = KeyPair::generate(0).unwrap();
+    let endorsement =
+        ProtocolTestUniverse::create_endorsement(&endorsement_creator, Slot::new(1, 1));
+
+    let ban_waitpoint = WaitPoint::new();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    trailing_bytes_ban_setup(&mut foreign_controllers, node_a_peer_id, &ban_waitpoint);
+    // the message must be dropped, not processed
+    foreign_controllers
+        .pool_controller
+        .set_expectations(|pool_controller| {
+            pool_controller.expect_add_endorsements().never();
+        });
+
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive_with_trailing_bytes(
+        &node_a_peer_id,
+        Message::Endorsement(EndorsementMessage::Endorsements(vec![endorsement])),
+    );
+    ban_waitpoint.wait();
+}
+
+#[test]
+fn test_protocol_bans_node_sending_peer_management_message_with_trailing_bytes() {
+    let protocol_config = ProtocolConfig {
+        thread_count: 2,
+        ..Default::default()
+    };
+    let node_a_keypair = KeyPair::generate(0).unwrap();
+    let node_a_peer_id = PeerId::from_public_key(node_a_keypair.get_public_key());
+
+    let ban_waitpoint = WaitPoint::new();
+    let mut foreign_controllers = ProtocolForeignControllers::new_with_mocks();
+    trailing_bytes_ban_setup(&mut foreign_controllers, node_a_peer_id, &ban_waitpoint);
+    // banned-state lookup done by the peer handler before deserializing
+    foreign_controllers
+        .peer_db
+        .write()
+        .expect_get_peers()
+        .return_const(HashMap::new());
+
+    let universe = ProtocolTestUniverse::new(foreign_controllers, protocol_config);
+
+    universe.mock_message_receive_with_trailing_bytes(
+        &node_a_peer_id,
+        Message::PeerManagement(Box::new(PeerManagementMessage::ListPeers(vec![]))),
+    );
     ban_waitpoint.wait();
 }

--- a/massa-protocol-worker/src/tests/universe.rs
+++ b/massa-protocol-worker/src/tests/universe.rs
@@ -122,6 +122,21 @@ impl ProtocolTestUniverse {
             .unwrap();
     }
 
+    /// Like `mock_message_receive` but appends junk bytes after the valid
+    /// serialized message, to simulate a peer sending trailing bytes.
+    pub fn mock_message_receive_with_trailing_bytes(&self, peer_id: &PeerId, message: Message) {
+        let mut data = Vec::new();
+        self.message_serializer
+            .serialize(&message, &mut data)
+            .map_err(|err| ProtocolError::GeneralProtocolError(err.to_string()))
+            .unwrap();
+        data.extend_from_slice(&[42, 42, 42]);
+        self.messages_handler
+            .handle(&data, peer_id)
+            .map_err(|err| ProtocolError::GeneralProtocolError(err.to_string()))
+            .unwrap();
+    }
+
     pub fn peer_db_boilerplate(mock_peer_db: &mut RwLockWriteGuard<MockPeerDBTrait>) {
         mock_peer_db
             .expect_get_peers_in_test()


### PR DESCRIPTION
## Summary

Follow-up of #5105, closes #5147. That PR stopped messages with trailing
bytes from tearing down the shared retrieval threads, but deliberately
kept the change minimal and did not sanction the sender. This PR adds the
ban.

## Change

The four deserialization sites that detect trailing bytes (block,
operation, endorsement and peer management handlers) now warn with the
peer id and trailing byte count, then ban the sender, following the
existing "critically incorrect payload → warn + ban" pattern already used
for invalid signatures. Block, operation and endorsement handlers reuse
their existing ban helpers; the peer management loop bans directly since
it owns `peer_db` and `active_connections`.

## Testing

- Four new tests in `ban_nodes_scenarios` (one per handler), using a new
  test-universe helper that appends junk bytes after a valid serialized
  message. Each test asserts the peer is disconnected and banned, and
  that the message content is not processed (`.never()` on the downstream
  controllers).
- Verified the tests fail (hang on the ban waitpoint) without the fix.
- Full `massa_protocol_worker` suite passes (64 tests), clippy and fmt
  clean.
- Full CI suite green on this PR (including the `full` test job).

## Risk

Low: compliant peers never send trailing bytes, and the path is only
reachable for messages that deserialize successfully with leftover bytes.
One point for reviewers: with this change, extending an existing message
type by appending fields would make old nodes ban newer peers; message
evolution must keep going through new message type ids instead.

---

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification (not applicable)

