### PR TITLE
ci: re-enable check_gas_cost_definitions xtask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,23 +116,23 @@ jobs:
           submodules: "recursive"
       - uses: crate-ci/typos@master
 
-  # misc:
-  #   if: github.ref != 'refs/heads/staging'
-  #   needs: sanity
-  #   runs-on: ubuntu-latest
-  #   continue-on-error: true
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         submodules: "recursive"
-  #     - uses: dtolnay/rust-toolchain@master
-  #       with:
-  #         toolchain: 1.81.0
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         shared-key: "clippy"
-  #         save-if: ${{ github.ref_name == 'main' }}
-  #     - run: cargo xtask check_gas_cost_definitions
+  misc:
+    if: github.ref != 'refs/heads/staging'
+    needs: sanity
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.81.0
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "clippy"
+          save-if: ${{ github.ref_name == 'main' }}
+      - run: cargo xtask check_gas_cost_definitions
 
   # Full tests required to merge on main branch (Linux; macOS covered by CD binary builds)
   full:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,6 +3819,7 @@ version = "5.0.0"
 dependencies = [
  "massa-sc-runtime",
  "massa_models",
+ "serde_json",
  "toml_edit 0.21.1",
  "walkdir",
 ]

--- a/massa-xtask/Cargo.toml
+++ b/massa-xtask/Cargo.toml
@@ -13,3 +13,4 @@ toml_edit = {workspace = true}   # BOM UPGRADE     Revert to "0.19.8" if problem
 walkdir = {workspace = true}
 # check_gas_costs dependencies
 massa-sc-runtime = {workspace = true}
+serde_json = {workspace = true}

--- a/massa-xtask/src/check_gas_cost_definitions.rs
+++ b/massa-xtask/src/check_gas_cost_definitions.rs
@@ -1,0 +1,42 @@
+use massa_sc_runtime::GasCosts;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+const ABI_GAS_COSTS_FILE: &str = "massa-node/base_config/gas_costs/abi_gas_costs.json";
+
+pub(crate) fn check_gas_cost_definitions() -> Result<(), String> {
+    // Check gas cost definitions between:
+    // massa-node/base_config/gas_costs/abi_gas_costs.json
+    // massa-sc-runtime GasCosts
+
+    // `GasCosts::new` fails if any cost required by the runtime is missing
+    // from the file, so this catches definitions the node needs but the
+    // shipped file lacks (the node would not start).
+    GasCosts::new(PathBuf::from(ABI_GAS_COSTS_FILE))
+        .map_err(|err| format!("failed to load {}: {}", ABI_GAS_COSTS_FILE, err))?;
+
+    // Detect stale definitions: a key that can be removed without making
+    // `GasCosts::new` fail is no longer used by the runtime. The runtime
+    // does not expose its expected key set, so probe by removing keys one
+    // at a time instead of maintaining a duplicate list here. Stale keys
+    // are harmless at runtime, so only warn about them.
+    let file_content = std::fs::read_to_string(ABI_GAS_COSTS_FILE)
+        .map_err(|err| format!("failed to read {}: {}", ABI_GAS_COSTS_FILE, err))?;
+    let costs: HashMap<String, u64> = serde_json::from_str(&file_content)
+        .map_err(|err| format!("failed to parse {}: {}", ABI_GAS_COSTS_FILE, err))?;
+
+    let probe_file = std::env::temp_dir().join("massa_xtask_abi_gas_costs_probe.json");
+    for key in costs.keys() {
+        let mut probe_costs = costs.clone();
+        probe_costs.remove(key);
+        let probe_content = serde_json::to_string(&probe_costs).map_err(|err| err.to_string())?;
+        std::fs::write(&probe_file, probe_content).map_err(|err| err.to_string())?;
+        if GasCosts::new(probe_file.clone()).is_ok() {
+            println!("Found in json but not used by the runtime: {key}");
+        }
+    }
+    let _ = std::fs::remove_file(&probe_file);
+
+    println!("Gas cost definitions OK");
+    Ok(())
+}

--- a/massa-xtask/src/main.rs
+++ b/massa-xtask/src/main.rs
@@ -1,5 +1,7 @@
+mod check_gas_cost_definitions;
 mod update_package_versions;
 
+use crate::check_gas_cost_definitions::check_gas_cost_definitions;
 use crate::update_package_versions::update_package_versions;
 use std::env;
 
@@ -11,6 +13,7 @@ fn main() {
     match task.as_deref() {
         // We can add more tasks here
         Some("update_package_versions") => update_package_versions(),
+        Some("check_gas_cost_definitions") => check_gas_cost_definitions().unwrap(),
         _ => panic!("Unknown task"),
     }
 }


### PR DESCRIPTION
## Summary

Closes #4943. The `check_gas_cost_definitions` xtask compared the ABI
gas cost keys of the shipped `abi_gas_costs.json` against
`massa-sc-runtime`. The runtime update shipped with MAIN.4.0 replaced
the internal ABI-costs map (and its accessor) with named struct fields,
the task stopped compiling, and the `misc` CI job was commented out.
This PR reimplements the check on the current `GasCosts` API and
re-enables the job.

## Change

- `massa-xtask/src/check_gas_cost_definitions.rs`: new implementation.
  - Missing definitions: loading the shipped file with `GasCosts::new`
    fails if any cost required by the runtime is absent (the node would
    not start), and fails the task. Same failure semantics as the old
    check.
  - Stale definitions: the runtime no longer exposes its expected key
    set, so the task probes `GasCosts::new` with each key removed in
    turn; a key whose removal does not break loading is unused. Warned
    about but not failing, as before. This replaces the old hardcoded
    exclude list and cannot drift.
- The task is no longer gated behind the `gas_calibration` feature: it
  no longer needs `GasCosts::default()`. It still works through the
  `cargo xtask` alias, which enables that feature.
- `.github/workflows/ci.yml`: the `misc` job is uncommented, unchanged.

## Testing

- `cargo xtask check_gas_cost_definitions` passes on the current file
  and reports no stale key.
- Removing a key from `abi_gas_costs.json` makes the task fail with
  "assembly_script_abort cost not found in ABI gas cost file".
- Adding a bogus key makes the task print
  "Found in json but not used by the runtime: bogus_stale_key" and
  still succeed.
- clippy and fmt clean on the crate.
- Full CI suite green on this PR, including the re-enabled `misc` job
  running `cargo xtask check_gas_cost_definitions` on itself.

## Risk

None at runtime: the change only touches the xtask and CI. The CI job
keeps `continue-on-error: true`, as before.

---

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet (not applicable, CI-only change)
* [ ] unit tests on the added/changed features (validated by running the
  task against altered inputs, see Testing)
* [x] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification (not applicable)

