### PR TITLE
fix(execution): cancel incoming requests when the read-only queue is full

### DIFF
--- a/massa-execution-worker/src/request_queue.rs
+++ b/massa-execution-worker/src/request_queue.rs
@@ -232,8 +232,8 @@ mod tests {
 
         destination.extend(incoming);
 
-        // the first incoming request fits and must not have received anything
-        assert!(rx1.try_recv().is_err());
+        // the first incoming request fits: nothing received, sender still alive
+        assert!(rx1.try_recv().unwrap_err().is_empty());
         // the second one is in excess and must be cancelled with a clean error
         assert_cancelled_for_capacity(rx2);
         assert!(destination.is_full());

--- a/massa-execution-worker/src/request_queue.rs
+++ b/massa-execution-worker/src/request_queue.rs
@@ -82,20 +82,13 @@ impl<T, R> RequestQueue<T, R> {
         // compute the number of available item slots
         let free_slots = self.max_items.saturating_sub(self.queue.len());
 
-        // If there are no available slots remaining, cancel the whole incoming queue.
-        // `RequestQueue` does not cancel on drop, so returning without cancelling would
-        // drop the response senders silently: already-accepted requests would fail with
-        // a generic channel error instead of this clean capacity error.
-        if free_slots == 0 {
-            other.cancel(ExecutionError::ChannelError(
-                "maximal request queue capacity reached".into(),
-            ));
-            return;
-        }
-
         // if there are not enough available slots to fit the entire incoming queue
         if free_slots < other.queue.len() {
-            // truncate the incoming queue to the size that fits, cancelling excess items
+            // Truncate the incoming queue to the size that fits, cancelling excess items.
+            // When the destination is already full this cancels the whole incoming queue:
+            // `RequestQueue` does not cancel on drop, so dropping it instead would close
+            // the response senders silently and already-accepted requests would fail with
+            // a generic channel error instead of this clean capacity error.
             other.queue.drain(free_slots..).for_each(|req| {
                 req.cancel(ExecutionError::ChannelError(
                     "maximal request queue capacity reached".into(),

--- a/massa-execution-worker/src/request_queue.rs
+++ b/massa-execution-worker/src/request_queue.rs
@@ -82,8 +82,14 @@ impl<T, R> RequestQueue<T, R> {
         // compute the number of available item slots
         let free_slots = self.max_items.saturating_sub(self.queue.len());
 
-        // if there are no available slots remaining, do nothing
+        // If there are no available slots remaining, cancel the whole incoming queue.
+        // `RequestQueue` does not cancel on drop, so returning without cancelling would
+        // drop the response senders silently: already-accepted requests would fail with
+        // a generic channel error instead of this clean capacity error.
         if free_slots == 0 {
+            other.cancel(ExecutionError::ChannelError(
+                "maximal request queue capacity reached".into(),
+            ));
             return;
         }
 
@@ -160,5 +166,76 @@ impl<T, R> RequestQueue<T, R> {
     /// true if the queue is empty, false otherwise
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use massa_channel::receiver::MassaReceiver;
+    use massa_channel::MassaChannel;
+
+    fn make_request(
+        request: u32,
+    ) -> (
+        RequestWithResponseSender<u32, u32>,
+        MassaReceiver<Result<u32, ExecutionError>>,
+    ) {
+        let (response_tx, response_rx) = MassaChannel::new("test_request_queue".to_string(), None);
+        (
+            RequestWithResponseSender::new(request, response_tx),
+            response_rx,
+        )
+    }
+
+    /// Assert that the request behind `response_rx` was cancelled with a clean
+    /// capacity error, not silently dropped.
+    fn assert_cancelled_for_capacity(response_rx: MassaReceiver<Result<u32, ExecutionError>>) {
+        match response_rx.recv() {
+            Ok(Err(ExecutionError::ChannelError(msg))) => {
+                assert!(msg.contains("maximal request queue capacity reached"))
+            }
+            other => panic!("expected a capacity cancellation error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extend_cancels_incoming_when_destination_is_full() {
+        let mut destination = RequestQueue::<u32, u32>::new(1);
+        let (req, _rx_kept) = make_request(0);
+        destination.push(req);
+
+        let mut incoming = RequestQueue::<u32, u32>::new(2);
+        let (req1, rx1) = make_request(1);
+        let (req2, rx2) = make_request(2);
+        incoming.push(req1);
+        incoming.push(req2);
+
+        destination.extend(incoming);
+
+        assert_cancelled_for_capacity(rx1);
+        assert_cancelled_for_capacity(rx2);
+        assert!(destination.is_full());
+    }
+
+    #[test]
+    fn test_extend_cancels_only_the_excess_when_partially_full() {
+        let mut destination = RequestQueue::<u32, u32>::new(2);
+        let (req, _rx_kept) = make_request(0);
+        destination.push(req);
+
+        let mut incoming = RequestQueue::<u32, u32>::new(2);
+        let (req1, rx1) = make_request(1);
+        let (req2, rx2) = make_request(2);
+        incoming.push(req1);
+        incoming.push(req2);
+
+        destination.extend(incoming);
+
+        // the first incoming request fits and must not have received anything
+        assert!(rx1.try_recv().is_err());
+        // the second one is in excess and must be cancelled with a clean error
+        assert_cancelled_for_capacity(rx2);
+        assert!(destination.is_full());
     }
 }


### PR DESCRIPTION
## Summary

Closes #5114 (finding F49, related to F51 / #5110). `RequestQueue::extend`
cancels excess requests when the incoming queue only partially fits, but
when the destination queue is **already full** it returned early and
dropped the whole incoming queue without cancelling it. `RequestQueue`
does not cancel on drop, so during the handoff from the shared input
queue to the worker-owned `readonly_requests` queue, an already-accepted
read-only request could see its response channel close with a generic
channel error instead of a clean capacity error.

## Change

In the full-destination early return of `RequestQueue::extend`, cancel
the incoming queue with the same "maximal request queue capacity
reached" error already used by the partial-overflow path and by `push`.
This is the direction suggested in the issue.

Blast radius: `extend` has a single call site, the read-only handoff in
`worker.rs` (`update_readonly_requests`), so no other queue behavior
changes. Requesters now always get an explicit answer: executed,
cancelled with a capacity error, or cancelled on worker shutdown
(#5110).

## Testing

- Two new unit tests in `request_queue.rs`:
  - full destination: every incoming request receives the capacity
    error (this test fails against the previous code, verified);
  - partial overflow: the fitting request is kept untouched, only the
    excess is cancelled (guards the pre-existing behavior).
- `massa_execution_worker` clippy and fmt clean.

## Risk

Low: the change only turns a silent drop into the existing explicit
cancellation, on a path where the requests were already lost. Not
consensus-observable (read-only request plumbing), so `main` is the
right target.

---

* [x] document all added functions
* [ ] try in sandbox /simulation/labnet (not applicable, covered by unit tests)
* [x] unit tests on the added/changed features
  * [x] make tests compile
  * [x] make tests pass
* [x] add logs allowing easy debugging in case the changes caused problems (the error message is the log)
* [ ] if the API has changed, update the API specification (not applicable)
