### PR TITLE
[F65] feat: prevent using stale production_stats during network-restart

### DIFF
--- a/massa-pos-exports/src/pos_final_state.rs
+++ b/massa-pos-exports/src/pos_final_state.rs
@@ -344,9 +344,19 @@ impl PoSFinalState {
         );
     }
 
-    /// Create the a cycle based off of another cycle_info.
+    /// Create a cycle based off of another cycle_info.
     ///
     /// Used for downtime interpolation, when restarting from a snapshot.
+    /// Roll counts are always carried over from `last_cycle_info`.
+    ///
+    /// `rng_seed` and `production_stats` are kept only when continuing the same
+    /// incomplete cycle (`last_cycle_info.cycle` matches the target cycle and
+    /// `first_slot` is not the first slot of that cycle). Otherwise the seed
+    /// starts fresh and `production_stats` are empty, so interpolated future
+    /// cycles do not inherit stale production results from the snapshot.
+    ///
+    /// In all cases, `rng_seed` is then extended with `false` bits for every
+    /// interpolated slot in `[first_slot, last_slot]`.
     pub fn create_new_cycle_from_last(
         &mut self,
         last_cycle_info: &CycleInfo,
@@ -354,13 +364,25 @@ impl PoSFinalState {
         last_slot: Slot,
         batch: &mut DBBatch,
     ) -> Result<(), PosError> {
-        let mut rng_seed = if first_slot.is_first_of_cycle(self.config.periods_per_cycle) {
-            BitVec::with_capacity(self.slots_per_cycle())
-        } else {
-            last_cycle_info.rng_seed.clone()
-        };
-
         let cycle = last_slot.get_cycle(self.config.periods_per_cycle);
+
+        // Keep seed/stats only when filling the gap in the same incomplete cycle.
+        // Require both same cycle id and a non-first first_slot (defense in depth:
+        // callers may reuse a snapshot CycleInfo across several target cycles).
+        let continuing_same_cycle = last_cycle_info.cycle == cycle
+            && !first_slot.is_first_of_cycle(self.config.periods_per_cycle);
+
+        let (mut rng_seed, production_stats) = if continuing_same_cycle {
+            (
+                last_cycle_info.rng_seed.clone(),
+                last_cycle_info.production_stats.clone(),
+            )
+        } else {
+            (
+                BitVec::with_capacity(self.slots_per_cycle()),
+                PreHashMap::default(),
+            )
+        };
 
         let num_slots = match last_slot.slots_since(&first_slot, self.config.thread_count) {
             Ok(slots_since) => slots_since.saturating_add(1),
@@ -379,6 +401,7 @@ impl PoSFinalState {
                 slots_per_cycle
             )));
         }
+        // Pad downtime slots; not the same as leaving the seed empty.
         let to_add = (num_slots as usize).min(slots_per_cycle.saturating_sub(rng_seed.len()));
         rng_seed.extend(vec![false; to_add]);
 
@@ -400,7 +423,7 @@ impl PoSFinalState {
                 complete,
                 last_cycle_info.roll_counts.clone(),
                 rng_seed,
-                last_cycle_info.production_stats.clone(),
+                production_stats,
             ),
             batch,
         );

--- a/massa-pos-exports/src/pos_final_state.rs
+++ b/massa-pos-exports/src/pos_final_state.rs
@@ -2852,6 +2852,8 @@ mod tests {
             max_history_length: 10,
             max_final_state_elements_size: 100_000,
             max_versioning_elements_size: 100_000,
+            max_final_state_elements_count: MAX_BOOTSTRAP_FINAL_STATE_ELEMENTS_COUNT as usize,
+            max_versioning_elements_count: MAX_BOOTSTRAP_VERSIONING_ELEMENTS_COUNT as usize,
             thread_count: 2,
             max_ledger_backups: 10,
             enable_metrics: false,

--- a/massa-pos-exports/src/pos_final_state.rs
+++ b/massa-pos-exports/src/pos_final_state.rs
@@ -2833,4 +2833,116 @@ mod tests {
         assert!(cycle_info.complete);
         assert_eq!(cycle_info.rng_seed.len(), 4);
     }
+
+    #[test]
+    fn test_create_new_cycle_from_last_production_stats() {
+        let pos_config = PoSConfig {
+            periods_per_cycle: 2,
+            thread_count: 2, // slots_per_cycle = 4
+            cycle_history_length: POS_SAVED_CYCLES,
+            max_rolls_length: MAX_ROLLS_COUNT_LENGTH,
+            max_production_stats_length: MAX_PRODUCTION_STATS_LENGTH,
+            max_credit_length: MAX_DEFERRED_CREDITS_LENGTH,
+            initial_deferred_credits_path: None,
+        };
+
+        let tempdir = TempDir::new().expect("cannot create temp directory");
+        let db_config = MassaDBConfig {
+            path: tempdir.path().to_path_buf(),
+            max_history_length: 10,
+            max_final_state_elements_size: 100_000,
+            max_versioning_elements_size: 100_000,
+            thread_count: 2,
+            max_ledger_backups: 10,
+            enable_metrics: false,
+        };
+        let db = Arc::new(RwLock::new(
+            Box::new(MassaDB::new(db_config)) as Box<(dyn MassaDBController + 'static)>
+        ));
+        let selector_controller = Box::new(MockSelectorController::new());
+        let init_seed = Hash::compute_from(b"");
+        let initial_seeds = vec![Hash::compute_from(init_seed.to_bytes()), init_seed];
+
+        let deferred_credits_deserializer =
+            DeferredCreditsDeserializer::new(pos_config.thread_count, pos_config.max_credit_length);
+        let cycle_info_deserializer = CycleHistoryDeserializer::new(
+            pos_config.cycle_history_length as u64,
+            pos_config.max_rolls_length,
+            pos_config.max_production_stats_length,
+        );
+
+        let mut pos_state = PoSFinalState {
+            config: pos_config,
+            db: db.clone(),
+            cycle_history_cache: Default::default(),
+            rng_seed_cache: None,
+            selector: selector_controller,
+            initial_rolls: Default::default(),
+            initial_seeds,
+            deferred_credits_serializer: DeferredCreditsSerializer::new(),
+            deferred_credits_deserializer,
+            cycle_info_serializer: CycleHistorySerializer::new(),
+            cycle_info_deserializer,
+        };
+
+        // Snapshot cycle 0 with non-empty production stats and a partial seed.
+        let stats_addr =
+            Address::from_str("AU12pAcVUzsgUBJHaYSAtDKVTYnUT9NorBDjoDovMfAFTLFa16MNa").unwrap();
+        let mut snapshot_stats = PreHashMap::default();
+        snapshot_stats.insert(
+            stats_addr,
+            ProductionStats {
+                block_success_count: 3,
+                block_failure_count: 1,
+            },
+        );
+        let snapshot = CycleInfo::new(
+            0,
+            false,
+            BTreeMap::default(),
+            bitvec![u8, Lsb0; 0, 0],
+            snapshot_stats,
+        );
+
+        // Filling the gap in the SAME incomplete cycle keeps the production stats.
+        let mut batch = DBBatch::new();
+        pos_state
+            .create_new_cycle_from_last(
+                &snapshot,
+                Slot::new(0, 1), // internal slot of cycle 0 (not first)
+                Slot::new(0, 1),
+                &mut batch,
+            )
+            .expect("same-cycle interpolation should succeed");
+        db.write()
+            .write_batch(batch, Default::default(), Some(Slot::new(0, 1)));
+
+        let cycle_0 = pos_state.get_cycle_info(0).expect("cycle 0 should exist");
+        let kept = cycle_0
+            .production_stats
+            .get(&stats_addr)
+            .expect("continuing the same incomplete cycle must keep production stats");
+        assert_eq!(kept.block_success_count, 3);
+        assert_eq!(kept.block_failure_count, 1);
+
+        // F65: interpolating a new cycle must NOT inherit the snapshot's production stats.
+        let mut batch = DBBatch::new();
+        pos_state
+            .create_new_cycle_from_last(
+                &snapshot,
+                Slot::new(2, 0), // first slot of cycle 1
+                Slot::new(3, 1), // last slot of cycle 1
+                &mut batch,
+            )
+            .expect("new cycle interpolation should succeed");
+        db.write()
+            .write_batch(batch, Default::default(), Some(Slot::new(3, 1)));
+
+        let cycle_1 = pos_state.get_cycle_info(1).expect("cycle 1 should exist");
+        assert!(
+            cycle_1.production_stats.is_empty(),
+            "interpolated new cycle must have empty production stats, got {:?}",
+            cycle_1.production_stats
+        );
+    }
 }


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification