### PR TITLE
[F115] validate the PoS endorsement draw on the public gRPC send_endo…

### DIFF
--- a/massa-grpc/src/stream/send_endorsements.rs
+++ b/massa-grpc/src/stream/send_endorsements.rs
@@ -5,6 +5,7 @@ use crate::server::MassaPublicGrpc;
 use futures_util::StreamExt;
 use massa_models::endorsement::{EndorsementDeserializer, SecureShareEndorsement};
 use massa_models::secure_share::SecureShareDeserializer;
+use massa_pos_exports::SelectorController;
 use massa_proto_rs::massa::api::v1 as grpc_api;
 use massa_proto_rs::massa::model::v1 as grpc_model;
 use massa_serialization::{DeserializeError, Deserializer};
@@ -31,6 +32,7 @@ pub(crate) async fn send_endorsements(
 ) -> Result<SendEndorsementsStreamType, GrpcError> {
     let mut pool_command_sender = grpc.pool_controller.clone();
     let protocol_command_sender = grpc.protocol_controller.clone();
+    let selector_controller = grpc.selector_controller.clone();
     let config = grpc.grpc_config.clone();
     let storage = grpc.storage.clone_without_refs();
 
@@ -100,6 +102,21 @@ pub(crate) async fn send_endorsements(
                             match verified_eds_res {
                                 // If all endorsements in the incoming message are valid, store and propagate them
                                 Ok(verified_eds) => {
+                                    // Check the PoS draws before letting those endorsements in: the
+                                    // propagation flow trusts its caller and does not check them again.
+                                    if let Err(error) = check_endorsement_draws(
+                                        &verified_eds,
+                                        selector_controller.as_ref(),
+                                    ) {
+                                        report_error(
+                                            tx.clone(),
+                                            tonic::Code::InvalidArgument,
+                                            error,
+                                        )
+                                        .await;
+                                        continue;
+                                    }
+
                                     let mut endorsement_storage = storage.clone_without_refs();
                                     endorsement_storage.store_endorsements(
                                         verified_eds.values().cloned().collect(),
@@ -180,6 +197,44 @@ pub(crate) async fn send_endorsements(
 
     let out_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
     Ok(Box::pin(out_stream) as SendEndorsementsStreamType)
+}
+
+/// Checks that each endorsement was created by the endorser drawn for its `(slot, index)` pair.
+///
+/// This mirrors the check done on endorsements received from peers (`note_endorsements_from_peer`)
+/// and in the endorsement pool: endorsements accepted here are handed over to the protocol
+/// propagation flow, which trusts its caller and rebroadcasts them without further validation.
+fn check_endorsement_draws(
+    endorsements: &HashMap<String, SecureShareEndorsement>,
+    selector_controller: &dyn SelectorController,
+) -> Result<(), String> {
+    for endorsement in endorsements.values() {
+        let selection = selector_controller
+            .get_selection(endorsement.content.slot)
+            .map_err(|e| {
+                format!(
+                    "failed to get the PoS draw at slot {}: {}",
+                    endorsement.content.slot, e
+                )
+            })?
+            .endorsements;
+        let Some(address) = selection.get(endorsement.content.index as usize) else {
+            return Err(format!(
+                "no selection at slot {} for index {}",
+                endorsement.content.slot, endorsement.content.index
+            ));
+        };
+        if address != &endorsement.content_creator_address {
+            return Err(format!(
+                "invalid endorsement producer selection at slot {} index {}: expected address {}, got {}",
+                endorsement.content.slot,
+                endorsement.content.index,
+                address,
+                endorsement.content_creator_address
+            ));
+        }
+    }
+    Ok(())
 }
 
 // This function reports an error to the sender by sending a gRPC response message to the client

--- a/massa-grpc/src/tests/stream.rs
+++ b/massa-grpc/src/tests/stream.rs
@@ -15,6 +15,7 @@ use massa_models::{
     types::{SetOrKeep, SetUpdateOrDelete},
 };
 use massa_pool_exports::MockPoolController;
+use massa_pos_exports::{MockSelectorController, Selection};
 use massa_proto_rs::massa::{
     api::v1::{
         public_service_client::PublicServiceClient, NewBlocksRequest, NewFilledBlocksRequest,
@@ -1743,8 +1744,27 @@ async fn send_endorsements() {
         ctrl
     });
 
+    let endorsement = create_endorsement();
+
+    // the endorsement is only propagated if its creator is the one drawn for its (slot, index)
+    let drawn_address = endorsement.content_creator_address;
+    let mut selector_ctrl = Box::new(MockSelectorController::new());
+    selector_ctrl.expect_clone_box().returning(move || {
+        let mut ctrl = Box::new(MockSelectorController::new());
+
+        ctrl.expect_get_selection().returning(move |_slot| {
+            Ok(Selection {
+                endorsements: vec![drawn_address],
+                producer: drawn_address,
+            })
+        });
+
+        ctrl
+    });
+
     public_server.pool_controller = pool_ctrl;
     public_server.protocol_controller = protocol_ctrl;
+    public_server.selector_controller = selector_ctrl;
 
     let (tx, rx) = tokio::sync::mpsc::channel(10);
     let request_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
@@ -1764,7 +1784,6 @@ async fn send_endorsements() {
         .unwrap()
         .into_inner();
 
-    let endorsement = create_endorsement();
     // serialize endorsement
     let mut buffer: Vec<u8> = Vec::new();
     SecureShareSerializer::new()
@@ -1801,6 +1820,34 @@ async fn send_endorsements() {
     match result.result.unwrap() {
         massa_proto_rs::massa::api::v1::send_endorsements_response::Result::Error(err) => {
             assert!(err.message.contains("failed to deserialize endorsement"))
+        }
+        _ => panic!("should be error"),
+    }
+
+    // an endorsement whose creator is not the drawn endorser must be rejected
+    let not_drawn_endorsement = create_endorsement();
+    let mut buffer: Vec<u8> = Vec::new();
+    SecureShareSerializer::new()
+        .serialize(&not_drawn_endorsement, &mut buffer)
+        .unwrap();
+
+    tx.send(SendEndorsementsRequest {
+        endorsements: vec![buffer],
+    })
+    .await
+    .unwrap();
+
+    let result = tokio::time::timeout(Duration::from_secs(5), resp_stream.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+
+    match result.result.unwrap() {
+        massa_proto_rs::massa::api::v1::send_endorsements_response::Result::Error(err) => {
+            assert!(err
+                .message
+                .contains("invalid endorsement producer selection"))
         }
         _ => panic!("should be error"),
     }

--- a/massa-protocol-exports/src/controller_trait.rs
+++ b/massa-protocol-exports/src/controller_trait.rs
@@ -55,6 +55,10 @@ pub trait ProtocolController: Send + Sync {
 
     /// Propagate a batch of endorsement (from pool).
     ///
+    /// The endorsements are propagated as-is: callers must have fully validated them beforehand
+    /// (valid signature and creator matching the PoS draw of their `(slot, index)` pair), as is
+    /// done for endorsements coming from peers in `note_endorsements_from_peer`.
+    ///
     /// # Arguments:
     /// * `endorsements`: endorsements to propagate
     fn propagate_endorsements(&self, endorsements: Storage) -> Result<(), ProtocolError>;


### PR DESCRIPTION
…rsements path

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification