### PR TITLE
[F89] docs: add comments regarding not rejecting unsorted datastore keys in operations

### DIFF
--- a/massa-models/src/datastore.rs
+++ b/massa-models/src/datastore.rs
@@ -139,6 +139,10 @@ impl Deserializer<Datastore> for DatastoreDeserializer {
                 )),
             ),
         )
+        // Note: Unsorted key/value pairs on the wire still deserialize to the same BTreeMap.
+        // That can yield different raw bytes / OperationIds for the same logical action.
+        // This is intentional malleability that Massa tolerates by construction and is not exploitable.
+        // As updating this behavior would be a breaking change, we do not reject it.
         .map(|elements| elements.into_iter().collect())
         .parse(buffer)
     }

--- a/massa-models/src/datastore.rs
+++ b/massa-models/src/datastore.rs
@@ -139,10 +139,12 @@ impl Deserializer<Datastore> for DatastoreDeserializer {
                 )),
             ),
         )
-        // Note: Unsorted key/value pairs on the wire still deserialize to the same BTreeMap.
-        // That can yield different raw bytes / OperationIds for the same logical action.
-        // This is intentional malleability that Massa tolerates by construction and is not exploitable.
-        // As updating this behavior would be a breaking change, we do not reject it.
+        // Note: unsorted key/value pairs, and duplicate keys (last occurrence wins), on the wire
+        // still deserialize to the same normalized BTreeMap. So different raw bytes / OperationIds can
+        // encode the same logical action. Massa is malleability-resistant by construction: nothing
+        // relies on canonical encodings, and only the signer can produce such variants (who can already
+        // produce distinct ids for the same action anyway), so this is not exploitable.
+        // Rejecting non-canonical encodings would be a breaking change for no security gain.
         .map(|elements| elements.into_iter().collect())
         .parse(buffer)
     }


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Note: following the discussion below, we're only keeping a small comment in the deserializer and rebased on top of main, and not implementing the finding's recommended changes as they don't improve security.