### PR TITLE
[F113] enforce endorsement freshness in the propagation thread so eve…

### DIFF
--- a/massa-protocol-worker/src/handlers/endorsement_handler/mod.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/mod.rs
@@ -2,10 +2,12 @@ use std::thread::JoinHandle;
 
 use massa_channel::{receiver::MassaReceiver, sender::MassaSender};
 use massa_metrics::MassaMetrics;
+use massa_models::{endorsement::SecureShareEndorsement, timeslots::get_block_slot_timestamp};
 use massa_pool_exports::PoolController;
 use massa_pos_exports::SelectorController;
 use massa_protocol_exports::ProtocolConfig;
 use massa_storage::Storage;
+use massa_time::MassaTime;
 
 use crate::wrap_network::ActiveConnectionsTrait;
 
@@ -26,6 +28,30 @@ pub(crate) use messages::{EndorsementMessage, EndorsementMessageSerializer};
 pub(crate) use retrieval::note_endorsements_from_peer;
 
 use super::peer_handler::models::{PeerManagementCmd, PeerMessageTuple};
+
+/// Returns true if the inclusion slot of the endorsement is recent enough for the
+/// endorsement to still be worth processing and relaying
+/// (see `max_endorsements_propagation_time`).
+///
+/// This is the single freshness policy for endorsements: it is applied both when receiving
+/// them from a peer and right before propagating them, so that callers reaching propagation
+/// directly (the factory, the gRPC `send_endorsements` endpoint) cannot make us rebroadcast
+/// obsolete endorsements.
+pub(crate) fn is_endorsement_fresh(
+    endorsement: &SecureShareEndorsement,
+    config: &ProtocolConfig,
+    now: MassaTime,
+) -> bool {
+    match get_block_slot_timestamp(
+        config.thread_count,
+        config.t0,
+        config.genesis_timestamp,
+        endorsement.content.slot,
+    ) {
+        Ok(t) => t.saturating_add(config.max_endorsements_propagation_time) >= now,
+        Err(_) => false,
+    }
+}
 
 pub struct EndorsementHandler {
     pub endorsement_retrieval_thread: Option<(

--- a/massa-protocol-worker/src/handlers/endorsement_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/propagation.rs
@@ -1,13 +1,15 @@
 use super::{
     cache::SharedEndorsementCache, commands_propagation::EndorsementHandlerPropagationCommand,
-    messages::EndorsementMessageSerializer, EndorsementMessage,
+    is_endorsement_fresh, messages::EndorsementMessageSerializer, EndorsementMessage,
 };
 use crate::{messages::MessagesSerializer, wrap_network::ActiveConnectionsTrait};
 use massa_channel::receiver::MassaReceiver;
+use massa_models::endorsement::SecureShareEndorsement;
 use massa_protocol_exports::ProtocolConfig;
 use massa_storage::Storage;
+use massa_time::MassaTime;
 use std::thread::JoinHandle;
-use tracing::{info, log::warn};
+use tracing::{debug, info, log::warn};
 
 // protocol-endorsement-handler-propagation
 const THREAD_NAME: &str = "peh-propagation";
@@ -72,6 +74,16 @@ impl PropagationThread {
                 .collect()
         };
 
+        // Drop endorsements whose inclusion slot is already too old to be worth relaying.
+        // The retrieval thread already filters those out, but other callers reach us directly
+        // (the endorsement factory, the gRPC `send_endorsements` endpoint), so applying the
+        // policy here makes it hold for every source: obsolete endorsements neither consume
+        // propagation bandwidth nor pollute `checked_endorsements`.
+        let endorsements = filter_fresh_endorsements(endorsements, &self.config);
+        if endorsements.is_empty() {
+            return;
+        }
+
         // get connected peers
         let peers_connected = self.active_connections.get_peer_ids_connected();
 
@@ -128,6 +140,28 @@ impl PropagationThread {
             }
         }
     }
+}
+
+/// Keep only the endorsements that are still fresh enough to be propagated, logging the
+/// discarded ones (see `is_endorsement_fresh`).
+fn filter_fresh_endorsements(
+    endorsements: Vec<SecureShareEndorsement>,
+    config: &ProtocolConfig,
+) -> Vec<SecureShareEndorsement> {
+    let now = MassaTime::now();
+    endorsements
+        .into_iter()
+        .filter(|endorsement| {
+            let fresh = is_endorsement_fresh(endorsement, config, now);
+            if !fresh {
+                debug!(
+                    "not propagating endorsement {}: its inclusion slot {} is too old",
+                    endorsement.id, endorsement.content.slot
+                );
+            }
+            fresh
+        })
+        .collect()
 }
 
 /// Merge the queued `PropagateEndorsements` commands into `endorsements` until the channel is
@@ -198,9 +232,14 @@ mod tests {
 
     /// Build an endorsement, `index` making it unique so that the storage does not deduplicate it
     fn endorsement(index: u32) -> SecureShareEndorsement {
+        endorsement_at_slot(index, Slot::new(1, 0))
+    }
+
+    /// Build an endorsement for the given inclusion slot
+    fn endorsement_at_slot(index: u32, slot: Slot) -> SecureShareEndorsement {
         let keypair = KeyPair::generate(0).unwrap();
         let content = Endorsement {
-            slot: Slot::new(1, 0),
+            slot,
             index,
             endorsed_block: BlockId::generate_from_hash(Hash::compute_from(b"block")),
         };
@@ -212,6 +251,26 @@ mod tests {
         let mut storage = root.clone_without_refs();
         storage.store_endorsements((0..count).map(endorsement).collect());
         storage
+    }
+
+    #[test]
+    fn test_filter_fresh_endorsements_drops_obsolete_slots() {
+        let config = ProtocolConfig {
+            thread_count: 32,
+            t0: MassaTime::from_millis(16000),
+            max_endorsements_propagation_time: MassaTime::from_millis(32000),
+            // genesis is far in the past, so the first slots are long obsolete
+            genesis_timestamp: MassaTime::now().saturating_sub(MassaTime::from_millis(1_000_000)),
+            ..Default::default()
+        };
+
+        let stale = endorsement_at_slot(0, Slot::new(1, 0));
+        // a slot far in the future is not obsolete
+        let fresh = endorsement_at_slot(1, Slot::new(100, 0));
+
+        let kept = filter_fresh_endorsements(vec![stale.clone(), fresh.clone()], &config);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, fresh.id);
     }
 
     #[test]

--- a/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
+++ b/massa-protocol-worker/src/handlers/endorsement_handler/retrieval.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     handlers::{
-        endorsement_handler::messages::EndorsementMessage,
+        endorsement_handler::{is_endorsement_fresh, messages::EndorsementMessage},
         peer_handler::models::{PeerManagementCmd, PeerMessageTuple},
     },
     sig_verifier::verify_sigs_batch,
@@ -173,24 +173,6 @@ impl RetrievalThread {
         self.peer_cmd_sender
             .try_send(PeerManagementCmd::Ban(vec![*peer_id]))
             .map_err(|err| ProtocolError::SendError(err.to_string()))
-    }
-}
-
-/// Returns true if the inclusion slot of the endorsement is recent enough for the
-/// endorsement to still be worth processing (see `max_endorsements_propagation_time`).
-fn is_endorsement_fresh(
-    endorsement: &SecureShareEndorsement,
-    config: &ProtocolConfig,
-    now: MassaTime,
-) -> bool {
-    match get_block_slot_timestamp(
-        config.thread_count,
-        config.t0,
-        config.genesis_timestamp,
-        endorsement.content.slot,
-    ) {
-        Ok(t) => t.saturating_add(config.max_endorsements_propagation_time) >= now,
-        Err(_) => false,
     }
 }
 


### PR DESCRIPTION
…ry caller is subject to max_endorsements_propagation_time

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification