### PR TITLE
5006 f53 trigger based async messages can be armed outside their validity window and miss execution on validity end

### DIFF
--- a/massa-execution-worker/src/speculative_async_pool.rs
+++ b/massa-execution-worker/src/speculative_async_pool.rs
@@ -211,6 +211,20 @@ impl SpeculativeAsyncPool {
         }
 
         // Activate the messages that can be activated (triggered)
+        //
+        // Note: arming is intentionally not restricted to the message validity interval. A trigger
+        //       observed before `validity_start` arms the message for good, and it then executes at
+        //       the first slot of its validity interval that has gas available. This is wanted: a
+        //       message is armed by an event that happened, and consistently with the fact that an
+        //       armed message can never be disarmed, that event is not forgotten just because it
+        //       came early. The validity interval bounds execution, not observation of the trigger.
+        //
+        // Note: activation happens here, i.e. after `take_batch_to_execute` already selected the
+        //       messages to execute at this slot, so a message armed at slot S is executable from
+        //       S+1 on. A trigger first observed at `validity_end` therefore never executes: the
+        //       message is armed and then expires at the next slot, its coins being reimbursed by
+        //       `cancel_async_message`. This cannot be avoided, since the ledger writes that arm
+        //       the message are only known once the slot has been executed.
         for (id, msg) in self.message_cache.iter_mut() {
             if let Some(filter) = &msg.trigger {
                 if is_triggered(filter, ledger_changes) {
@@ -268,7 +282,6 @@ fn is_triggered(filter: &AsyncMessageTrigger, ledger_changes: &LedgerChanges) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-
     // Test if is_message_expired & is_message_ready_to_execute are consistent
     #[test]
     fn test_validity() {

--- a/massa-models/src/async_msg.rs
+++ b/massa-models/src/async_msg.rs
@@ -149,7 +149,7 @@ pub struct AsyncMessage {
     /// Slot at which the message starts being valid (bound included in the validity range)
     pub validity_start: Slot,
 
-    /// Slot at which the message stops being valid (bound not included in the validity range)
+    /// Slot at which the message stops being valid (bound included in the validity range)
     pub validity_end: Slot,
 
     /// Raw payload parameters to call the function with
@@ -159,7 +159,9 @@ pub struct AsyncMessage {
     pub trigger: Option<AsyncMessageTrigger>,
 
     /// Boolean that determine if the message can be executed. For messages without filter this boolean is always true.
-    /// For messages with filter, this boolean is true if the filter has been matched between `validity_start` and current slot.
+    /// For messages with filter, this boolean is true if the filter has been matched at any slot up to
+    /// the current one, including before `validity_start`: arming is not restricted to the validity
+    /// interval, which only bounds execution. Once true, this boolean is never set back to false.
     pub can_be_executed: bool,
 }
 
@@ -547,7 +549,9 @@ pub struct AsyncMessageUpdate {
     pub trigger: SetOrKeep<Option<AsyncMessageTrigger>>,
 
     /// Boolean that determine if the message can be executed. For messages without filter this boolean is always true.
-    /// For messages with filter, this boolean is true if the filter has been matched between `validity_start` and current slot.
+    /// For messages with filter, this boolean is true if the filter has been matched at any slot up to
+    /// the current one, including before `validity_start`: arming is not restricted to the validity
+    /// interval, which only bounds execution. Once true, this boolean is never set back to false.
     pub can_be_executed: SetOrKeep<bool>,
 }
 


### PR DESCRIPTION
- A trigger first observed at validity_end still never executes. Within slot S, take_async_batch(S) (execution.rs:1906) runs before settle_slot(S) (execution.rs:1945), so activation from slot S's ledger changes is only usable from S+1; a message triggered at validity_end is armed and then eliminated at the next settle_slot. The coins are reimbursed via cancel_async_message (context.rs:1051), so this is a semantics gap, not a fund loss. Fixing it means evaluating the trigger at selection time against the partial speculative-ledger changes accumulated so far in the slot, which makes trigger firing sensitive to intra-slot ordering — a larger execution-semantics change deserving its own MIP and review.