### PR TITLE
[F88] return the sanitized datastore key query count so omitted API l…

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -1636,7 +1636,7 @@ fn get_address_datastore_keys_to_state_query_item(
         (Some(k), false) => std::ops::Bound::Excluded(k),
     };
 
-    let (prefix, start_key, end_key) = cleanup_datastore_key_range_query(
+    let (prefix, start_key, end_key, count) = cleanup_datastore_key_range_query(
         &value.prefix,
         start_key,
         end_key,
@@ -1657,7 +1657,7 @@ fn get_address_datastore_keys_to_state_query_item(
             prefix,
             start_key,
             end_key,
-            count: value.count,
+            count,
         })
     } else {
         Ok(ExecutionQueryRequestItem::AddressDatastoreKeysCandidate {
@@ -1665,7 +1665,7 @@ fn get_address_datastore_keys_to_state_query_item(
             prefix,
             start_key,
             end_key,
-            count: value.count,
+            count,
         })
     }
 }

--- a/massa-execution-exports/src/mapping_grpc.rs
+++ b/massa-execution-exports/src/mapping_grpc.rs
@@ -71,7 +71,7 @@ pub fn to_querystate_filter(
                     (Some(k), false) => std::ops::Bound::Excluded(k),
                 };
 
-                let (prefix, start_key, end_key) = cleanup_datastore_key_range_query(
+                let (prefix, start_key, end_key, count) = cleanup_datastore_key_range_query(
                     &value.prefix,
                     start_key,
                     end_key,
@@ -85,7 +85,7 @@ pub fn to_querystate_filter(
                     prefix,
                     start_key,
                     end_key,
-                    count: value.limit,
+                    count,
                 })
             }
             exec::RequestItem::AddressDatastoreKeysFinal(value) => {
@@ -102,7 +102,7 @@ pub fn to_querystate_filter(
                     (Some(k), false) => std::ops::Bound::Excluded(k),
                 };
 
-                let (prefix, start_key, end_key) = cleanup_datastore_key_range_query(
+                let (prefix, start_key, end_key, count) = cleanup_datastore_key_range_query(
                     &value.prefix,
                     start_key,
                     end_key,
@@ -116,7 +116,7 @@ pub fn to_querystate_filter(
                     prefix,
                     start_key,
                     end_key,
-                    count: value.limit,
+                    count,
                 })
             }
             exec::RequestItem::AddressDatastoreValueCandidate(value) => {

--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -660,7 +660,7 @@ impl ExecutionContext {
         let max_datastore_query = None;
 
         // cleanup bounds
-        let (prefix, start_key, end_key) = cleanup_datastore_key_range_query(
+        let (prefix, start_key, end_key, count) = cleanup_datastore_key_range_query(
             prefix,
             start_key,
             end_key,

--- a/massa-models/src/datastore.rs
+++ b/massa-models/src/datastore.rs
@@ -236,7 +236,10 @@ pub fn range_intersection<T: Ord>(
 }
 
 /// Checks and cleans up a datastore key range query
-/// Returns: (prefix, start_bound, end_bound) or error
+/// Returns: (prefix, start_bound, end_bound, count) or error
+/// The returned count is the sanitized item count: when the caller omitted it,
+/// it defaults to the configured maximum so that the query stays bounded.
+/// Callers must use the returned count, not the one they passed in.
 /// Note: only useful to cleanup user-supplied requests (API/ABI)
 #[allow(clippy::type_complexity)]
 pub fn cleanup_datastore_key_range_query(
@@ -246,7 +249,7 @@ pub fn cleanup_datastore_key_range_query(
     count: Option<u32>,
     max_datastore_key_length: u8,
     max_datastore_query_config: Option<u32>,
-) -> Result<(Vec<u8>, Bound<Vec<u8>>, Bound<Vec<u8>>), ModelsError> {
+) -> Result<(Vec<u8>, Bound<Vec<u8>>, Bound<Vec<u8>>, Option<u32>), ModelsError> {
     // check item count
     let count = count.or(max_datastore_query_config);
     if let (Some(cnt), Some(max_cnt)) = (count.as_ref(), max_datastore_query_config.as_ref()) {
@@ -265,6 +268,7 @@ pub fn cleanup_datastore_key_range_query(
             Vec::new(),
             std::ops::Bound::Excluded(Vec::new()),
             std::ops::Bound::Excluded(Vec::new()),
+            count,
         ));
     } else {
         prefix.to_vec()
@@ -308,7 +312,7 @@ pub fn cleanup_datastore_key_range_query(
         }
     };
 
-    Ok((prefix, start_bound, end_bound))
+    Ok((prefix, start_bound, end_bound, count))
 }
 
 #[cfg(test)]
@@ -497,10 +501,11 @@ mod tests {
             max_query_config,
         );
         assert!(result.is_ok());
-        let (res_prefix, res_start, res_end) = result.unwrap();
+        let (res_prefix, res_start, res_end, res_count) = result.unwrap();
         assert_eq!(res_prefix, prefix);
         assert_eq!(res_start, start_bound);
         assert_eq!(res_end, end_bound);
+        assert_eq!(res_count, count);
 
         // Case 2: Prefix length exceeds max length
         let long_prefix = vec![b'a'; 30];
@@ -513,8 +518,9 @@ mod tests {
             None,
         );
         assert!(result.is_ok());
-        let (res_prefix, res_start, res_end) = result.unwrap();
+        let (res_prefix, res_start, res_end, res_count) = result.unwrap();
         assert!(res_prefix.is_empty());
+        assert_eq!(res_count, None);
         assert_eq!(res_start, Bound::Excluded(Vec::new()));
         assert_eq!(res_end, Bound::Excluded(Vec::new()));
 
@@ -531,8 +537,9 @@ mod tests {
             None,
         );
         assert!(result.is_ok());
-        let (res_prefix, res_start, res_end) = result.unwrap();
+        let (res_prefix, res_start, res_end, res_count) = result.unwrap();
         assert_eq!(res_prefix, prefix);
+        assert_eq!(res_count, None);
         assert_eq!(
             res_start,
             Bound::Excluded(long_key[0..10].to_vec()) // Start key truncated
@@ -570,9 +577,49 @@ mod tests {
             None,
         );
         assert!(result.is_ok());
-        let (res_prefix, res_start, res_end) = result.unwrap();
+        let (res_prefix, res_start, res_end, res_count) = result.unwrap();
         assert_eq!(res_prefix, prefix);
         assert_eq!(res_start, Bound::Unbounded);
         assert_eq!(res_end, Bound::Unbounded);
+        assert_eq!(res_count, None);
+
+        // Case 6: omitted count falls back to the configured maximum
+        let result = cleanup_datastore_key_range_query(
+            &prefix,
+            Bound::Unbounded,
+            Bound::Unbounded,
+            None,
+            10,
+            Some(50),
+        );
+        assert!(result.is_ok());
+        let (_, _, _, res_count) = result.unwrap();
+        assert_eq!(res_count, Some(50));
+
+        // Case 7: the fallback is also applied when the prefix is too long
+        let result = cleanup_datastore_key_range_query(
+            &long_prefix,
+            Bound::Unbounded,
+            Bound::Unbounded,
+            None,
+            10,
+            Some(50),
+        );
+        assert!(result.is_ok());
+        let (_, _, _, res_count) = result.unwrap();
+        assert_eq!(res_count, Some(50));
+
+        // Case 8: an explicit count below the maximum is preserved
+        let result = cleanup_datastore_key_range_query(
+            &prefix,
+            Bound::Unbounded,
+            Bound::Unbounded,
+            Some(3),
+            10,
+            Some(50),
+        );
+        assert!(result.is_ok());
+        let (_, _, _, res_count) = result.unwrap();
+        assert_eq!(res_count, Some(3));
     }
 }


### PR DESCRIPTION
…imits stay bounded

 Breaking in effect:
  - A client that omits count/limit previously received every key for the address; it now receives at most max_datastore_keys_query (500 in base_config/config.toml:46 and :127, for JSON-RPC and gRPC
  respectively).
  - GetAddressDatastoreKeysResponse has only {address, is_final, keys} — no truncation flag. So such a client can't distinguish "that's all the keys" from "that's the first 500". It silently gets a short
  answer. That's the real sharp edge: a client with >500 keys under the queried prefix would need to switch to paginating via start_key, and nothing in the response tells it to.
  
  Because we build the getDatastoreKeys endpoint recently, I am pretty confident that pagination is well supported by clients