### PR TITLE
[F54] feat: reorder ASCs priority based on real gas usage

### DIFF
--- a/massa-async-pool/src/lib.rs
+++ b/massa-async-pool/src/lib.rs
@@ -42,6 +42,9 @@
 //! ## How is the `AsyncPool` handled
 //! ```md
 //! * In the AsyncPool, Messages are kept sorted by `priority = AsyncMessageId(rev(Ratio(msg.fee, max(msg.max_gas,1))), rev(msg.slot), rev(msg.emission_index))`
+//!   From execution component version 2 (MIP-0002), batch selection and overflow eviction
+//!   re-rank with `fee / max(max_gas + async_msg_cst_gas_cost, 1)` so priority matches the
+//!   gas actually charged when taking a batch.
 //!
 //! * when an AsyncMessage is added to the AsyncPool:
 //!   * if the AsyncPool length has exceeded config.max_async_pool_length:

--- a/massa-execution-worker/src/context.rs
+++ b/massa-execution-worker/src/context.rs
@@ -8,7 +8,9 @@
 //! and does not write anything persistent to the consensus state.
 
 use crate::active_history::HistorySearchResult;
-use crate::speculative_async_pool::SpeculativeAsyncPool;
+use crate::speculative_async_pool::{
+    SpeculativeAsyncPool, ASYNC_MSG_EFFECTIVE_GAS_PRIORITY_EXEC_VERSION,
+};
 use crate::speculative_deferred_calls::{
     SpeculativeDeferredCallRegistry, DEFERRED_CALL_INDEX_FIX_EXEC_VERSION,
 };
@@ -482,6 +484,9 @@ impl ExecutionContext {
             self.slot,
             max_gas,
             async_msg_cst_gas_cost,
+            self.is_execution_component_version_at_least(
+                ASYNC_MSG_EFFECTIVE_GAS_PRIORITY_EXEC_VERSION,
+            ),
         )
     }
 
@@ -1066,9 +1071,14 @@ impl ExecutionContext {
         let deferred_credits_transfers = self.execute_deferred_credits(&slot);
 
         // settle emitted async messages and reimburse the senders of deleted messages
-        let deleted_messages = self
-            .speculative_async_pool
-            .settle_slot(&slot, &self.speculative_ledger.added_changes);
+        let deleted_messages = self.speculative_async_pool.settle_slot(
+            &slot,
+            &self.speculative_ledger.added_changes,
+            self.config.async_msg_cst_gas_cost,
+            self.is_execution_component_version_at_least(
+                ASYNC_MSG_EFFECTIVE_GAS_PRIORITY_EXEC_VERSION,
+            ),
+        );
 
         let mut cancel_async_message_transfers = vec![];
         for (_msg_id, msg) in deleted_messages {

--- a/massa-execution-worker/src/speculative_async_pool.rs
+++ b/massa-execution-worker/src/speculative_async_pool.rs
@@ -417,13 +417,21 @@ mod tests {
 
     // Low-max_gas messages look better under fee/max_gas, but worse once the fixed
     // async_msg_cst_gas_cost is included — the MIP-0002 ranking must prefer the latter.
+    //
+    // Values are ABI-reachable: `send_message` rejects `max_gas < max_instance_cost` (2.1M).
+    // Old ratio 25_000/2.1M ≈ 0.0119 vs 1_000_000/100M = 0.0100 (attacker first);
+    // new ratio 25_000/3.1M ≈ 0.00806 vs 1_000_000/101M ≈ 0.0099 (honest first).
+    const MAX_INSTANCE_COST: u64 = 2_100_000;
+    const ATTACKER_MAX_GAS: u64 = MAX_INSTANCE_COST;
+    const ATTACKER_FEE: u64 = 25_000;
+    const HONEST_MAX_GAS: u64 = 100_000_000;
+    const HONEST_FEE: u64 = 1_000_000;
+
     #[test]
     fn test_take_batch_effective_gas_priority() {
         let cst = 1_000_000u64;
-        // Old ratio 100/1 = 100; effective 100 / 1_000_001 ≈ 0.0001
-        let cheap_looking = test_message(0, 1, 100);
-        // Old ratio 50_000 / 1_000_000 = 0.05; effective 50_000 / 2_000_000 = 0.025
-        let honest = test_message(1, 1_000_000, 50_000);
+        let cheap_looking = test_message(0, ATTACKER_MAX_GAS, ATTACKER_FEE);
+        let honest = test_message(1, HONEST_MAX_GAS, HONEST_FEE);
 
         assert!(
             cheap_looking.compute_id() < honest.compute_id(),
@@ -468,8 +476,8 @@ mod tests {
     #[test]
     fn test_settle_slot_effective_gas_eviction() {
         let cst = 1_000_000u64;
-        let cheap_looking = test_message(0, 1, 100);
-        let honest = test_message(1, 1_000_000, 50_000);
+        let cheap_looking = test_message(0, ATTACKER_MAX_GAS, ATTACKER_FEE);
+        let honest = test_message(1, HONEST_MAX_GAS, HONEST_FEE);
 
         let mut pool = test_pool();
         pool.async_pool_max_length = 1;

--- a/massa-execution-worker/src/speculative_async_pool.rs
+++ b/massa-execution-worker/src/speculative_async_pool.rs
@@ -14,6 +14,12 @@ use massa_models::types::{Applicable, SetUpdateOrDelete};
 use parking_lot::RwLock;
 use std::{collections::BTreeMap, sync::Arc};
 
+/// Execution component version (MIP-0002-BugFix) from which async-message batch selection
+/// and pool eviction rank by `fee / (max_gas + async_msg_cst_gas_cost)` instead of
+/// `fee / max_gas`, matching the gas actually charged per message in
+/// [`SpeculativeAsyncPool::take_batch_to_execute`].
+pub const ASYNC_MSG_EFFECTIVE_GAS_PRIORITY_EXEC_VERSION: u32 = 2;
+
 pub(crate) struct SpeculativeAsyncPool {
     /// Async pool max length
     async_pool_max_length: u64,
@@ -107,9 +113,16 @@ impl SpeculativeAsyncPool {
     /// rejects those at emission from execution component version 2 on, but messages emitted
     /// before that activation can still be sitting in the pool, and they expire unexecuted.
     ///
+    /// When `rank_by_effective_gas` is true (MIP-0002 / execution component version
+    /// [`ASYNC_MSG_EFFECTIVE_GAS_PRIORITY_EXEC_VERSION`]), candidates are ordered by
+    /// `fee / (max_gas + async_msg_cst_gas_cost)` so priority matches the budget charge.
+    /// Otherwise ordering follows the stored [`AsyncMessageId`] (`fee / max_gas`).
+    ///
     /// # Arguments
     /// * `slot`: slot at which the batch is taken (allows filtering by validity interval)
     /// * `max_gas`: maximum amount of gas available
+    /// * `async_msg_cst_gas_cost`: fixed per-message gas surcharge charged on execution
+    /// * `rank_by_effective_gas`: use effective gas in the fee/gas ranking
     ///
     /// # Returns
     /// A vector of `AsyncMessage` to execute
@@ -118,28 +131,39 @@ impl SpeculativeAsyncPool {
         slot: Slot,
         max_gas: u64,
         async_msg_cst_gas_cost: u64,
+        rank_by_effective_gas: bool,
     ) -> Vec<(AsyncMessageId, AsyncMessage)> {
         let mut available_gas = max_gas;
 
         // Choose which messages to take based on the message_cache
         // (all messages are considered: finals, in active_history and in speculative)
-
-        let mut wanted_ids = Vec::new();
-        for (message_id, message) in self.message_cache.iter() {
-            let corrected_max_gas = message.max_gas.saturating_add(async_msg_cst_gas_cost);
-            // Note: SecureShareOperation.get_validity_range(...) returns RangeInclusive
-            //       so to be consistent here, use >= & <= checks
-            if available_gas >= corrected_max_gas
-                && Self::is_message_ready_to_execute(
+        let mut candidates: Vec<(AsyncMessageId, &AsyncMessage)> = self
+            .message_cache
+            .iter()
+            .filter(|(_, message)| {
+                Self::is_message_ready_to_execute(
                     &slot,
                     &message.validity_start,
                     &message.validity_end,
-                )
-                && message.can_be_executed
-            {
-                available_gas -= corrected_max_gas;
+                ) && message.can_be_executed
+            })
+            .map(|(id, message)| (*id, message))
+            .collect();
 
-                wanted_ids.push(*message_id);
+        if rank_by_effective_gas {
+            candidates
+                .sort_by_key(|(_, message)| message.compute_priority_id(async_msg_cst_gas_cost));
+        }
+        // else: BTreeMap iteration already yields stored AsyncMessageId order
+
+        let mut wanted_ids = Vec::new();
+        for (message_id, message) in candidates {
+            let corrected_max_gas = message.max_gas.saturating_add(async_msg_cst_gas_cost);
+            // Note: SecureShareOperation.get_validity_range(...) returns RangeInclusive
+            //       so to be consistent here, use >= & <= checks
+            if available_gas >= corrected_max_gas {
+                available_gas -= corrected_max_gas;
+                wanted_ids.push(message_id);
             }
         }
 
@@ -162,6 +186,8 @@ impl SpeculativeAsyncPool {
     /// # Arguments
     /// * slot: slot that is being settled
     /// * ledger_changes: ledger changes for that slot, used to see if we can activate some messages
+    /// * async_msg_cst_gas_cost: fixed per-message gas surcharge (used when ranking for eviction)
+    /// * rank_by_effective_gas: when true, truncate by effective fee/gas (MIP-0002)
     ///
     /// # Returns
     /// the list of deleted `(message_id, message)`, used for reimbursement
@@ -169,6 +195,8 @@ impl SpeculativeAsyncPool {
         &mut self,
         slot: &Slot,
         ledger_changes: &LedgerChanges,
+        async_msg_cst_gas_cost: u64,
+        rank_by_effective_gas: bool,
     ) -> Vec<(AsyncMessageId, AsyncMessage)> {
         // Update eliminated_msgs: remove messages that should be removed
         // Filter out all messages for which the validity end is expired.
@@ -212,8 +240,26 @@ impl SpeculativeAsyncPool {
             .saturating_sub(self.async_pool_max_length as usize);
 
         eliminated_msgs.reserve_exact(excess_count);
-        for _ in 0..excess_count {
-            eliminated_msgs.push(self.message_cache.pop_last().unwrap()); // will not panic (checked at excess_count computation)
+        if rank_by_effective_gas {
+            // Same ordering key as take_batch_to_execute: lowest effective priority last
+            let mut ranked: Vec<_> = self
+                .message_cache
+                .iter()
+                .map(|(id, msg)| (*id, msg.compute_priority_id(async_msg_cst_gas_cost)))
+                .collect();
+            ranked.sort_by_key(|(_, prio)| *prio);
+            for (id, _) in ranked.into_iter().rev().take(excess_count) {
+                eliminated_msgs.push((
+                    id,
+                    self.message_cache
+                        .remove(&id)
+                        .expect("message listed for eviction must be in cache"),
+                ));
+            }
+        } else {
+            for _ in 0..excess_count {
+                eliminated_msgs.push(self.message_cache.pop_last().unwrap()); // will not panic (checked at excess_count computation)
+            }
         }
 
         // Activate the messages that can be activated (triggered)
@@ -288,6 +334,10 @@ fn is_triggered(filter: &AsyncMessageTrigger, ledger_changes: &LedgerChanges) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use massa_models::address::Address;
+    use massa_models::amount::Amount;
+    use std::str::FromStr;
+
     // Test if is_message_expired & is_message_ready_to_execute are consistent
     #[test]
     fn test_validity() {
@@ -335,5 +385,106 @@ mod tests {
             &slot_validity_start,
             &slot_validity_end,
         ));
+    }
+
+    fn test_pool() -> SpeculativeAsyncPool {
+        SpeculativeAsyncPool {
+            async_pool_max_length: 100,
+            pool_changes: Default::default(),
+            message_cache: Default::default(),
+        }
+    }
+
+    fn test_message(emission_index: u64, max_gas: u64, fee_raw: u64) -> AsyncMessage {
+        let addr =
+            Address::from_str("AU12dG5xP1RDEB5ocdHkymNVvvSJmUL9BgHwCksDowqmGWxfpm93x").unwrap();
+        AsyncMessage::new(
+            Slot::new(1, 0),
+            emission_index,
+            addr,
+            addr,
+            String::from("recv"),
+            max_gas,
+            Amount::from_raw(fee_raw),
+            Amount::from_raw(0),
+            Slot::new(0, 0),
+            Slot::new(10, 0),
+            vec![],
+            None,
+            Some(true),
+        )
+    }
+
+    // Low-max_gas messages look better under fee/max_gas, but worse once the fixed
+    // async_msg_cst_gas_cost is included — the MIP-0002 ranking must prefer the latter.
+    #[test]
+    fn test_take_batch_effective_gas_priority() {
+        let cst = 1_000_000u64;
+        // Old ratio 100/1 = 100; effective 100 / 1_000_001 ≈ 0.0001
+        let cheap_looking = test_message(0, 1, 100);
+        // Old ratio 50_000 / 1_000_000 = 0.05; effective 50_000 / 2_000_000 = 0.025
+        let honest = test_message(1, 1_000_000, 50_000);
+
+        assert!(
+            cheap_looking.compute_id() < honest.compute_id(),
+            "without the surcharge, the low-max_gas message ranks first"
+        );
+        assert!(
+            honest.compute_priority_id(cst) < cheap_looking.compute_priority_id(cst),
+            "with the surcharge, the honest message ranks first"
+        );
+
+        let slot = Slot::new(1, 0);
+        // Budget fits only one of the two once the fixed cost is added to each
+        let budget = honest.max_gas.saturating_add(cst);
+
+        let mut pool_legacy = test_pool();
+        pool_legacy
+            .message_cache
+            .insert(cheap_looking.compute_id(), cheap_looking.clone());
+        pool_legacy
+            .message_cache
+            .insert(honest.compute_id(), honest.clone());
+        let taken_legacy = pool_legacy.take_batch_to_execute(slot, budget, cst, false);
+        assert_eq!(taken_legacy.len(), 1);
+        assert_eq!(
+            taken_legacy[0].1.emission_index, 0,
+            "pre-MIP ranking prefers the low-max_gas message"
+        );
+
+        let mut pool_mip = test_pool();
+        pool_mip
+            .message_cache
+            .insert(cheap_looking.compute_id(), cheap_looking);
+        pool_mip.message_cache.insert(honest.compute_id(), honest);
+        let taken_mip = pool_mip.take_batch_to_execute(slot, budget, cst, true);
+        assert_eq!(taken_mip.len(), 1);
+        assert_eq!(
+            taken_mip[0].1.emission_index, 1,
+            "MIP-0002 ranking prefers the better effective fee/gas"
+        );
+    }
+
+    #[test]
+    fn test_settle_slot_effective_gas_eviction() {
+        let cst = 1_000_000u64;
+        let cheap_looking = test_message(0, 1, 100);
+        let honest = test_message(1, 1_000_000, 50_000);
+
+        let mut pool = test_pool();
+        pool.async_pool_max_length = 1;
+        pool.message_cache
+            .insert(cheap_looking.compute_id(), cheap_looking.clone());
+        pool.message_cache
+            .insert(honest.compute_id(), honest.clone());
+
+        let eliminated = pool.settle_slot(&Slot::new(1, 0), &LedgerChanges::default(), cst, true);
+        assert_eq!(eliminated.len(), 1);
+        assert_eq!(
+            eliminated[0].1.emission_index, 0,
+            "MIP-0002 eviction drops the worse effective fee/gas message"
+        );
+        assert_eq!(pool.message_cache.len(), 1);
+        assert!(pool.message_cache.contains_key(&honest.compute_id()));
     }
 }

--- a/massa-models/src/async_msg.rs
+++ b/massa-models/src/async_msg.rs
@@ -219,7 +219,12 @@ impl AsyncMessage {
     /// Compute the ID of the message for use when choosing which operations to keep in priority (highest score) on pool overflow.
     ///
     /// Uses `fee / max(max_gas, 1)`. Prefer [`Self::compute_priority_id`] when ranking must
-    /// match the gas actually charged at execution (`max_gas + async_msg_cst_gas_cost`).
+    /// match the gas actually charged at execution (`max_gas + async_msg_cst_gas_cost`) to avoid any pricing issue.
+    /// The pricing mismatch between the two functions is real, but small in practice: `send_message` rejects `max_gas` below
+    /// `gas_costs.max_instance_cost` (2.1M gas), so the skew `(max_gas + cst) / max_gas` is at
+    /// most `1 + 1M/2.1M ≈ 1.48×`. Emitting costs 40M gas of ABI per message (~107 per block
+    /// at most, by taking the whole block), so the priority advantage tops out around 48% for a
+    /// sender paying full blocks.
     pub fn compute_id(&self) -> AsyncMessageId {
         self.compute_priority_id(0)
     }

--- a/massa-models/src/async_msg.rs
+++ b/massa-models/src/async_msg.rs
@@ -217,8 +217,23 @@ impl AsyncMessage {
     }
 
     /// Compute the ID of the message for use when choosing which operations to keep in priority (highest score) on pool overflow.
+    ///
+    /// Uses `fee / max(max_gas, 1)`. Prefer [`Self::compute_priority_id`] when ranking must
+    /// match the gas actually charged at execution (`max_gas + async_msg_cst_gas_cost`).
     pub fn compute_id(&self) -> AsyncMessageId {
-        let denom = if self.max_gas > 0 { self.max_gas } else { 1 };
+        self.compute_priority_id(0)
+    }
+
+    /// Priority key used for pool ordering / batch selection.
+    ///
+    /// Ranks by `fee / max(max_gas + extra_gas_cost, 1)`, then `emission_slot`, then
+    /// `emission_index`. Pass the fixed per-message gas surcharge as `extra_gas_cost` so
+    /// priority matches the budget consumed in `take_batch_to_execute`.
+    pub fn compute_priority_id(&self, extra_gas_cost: u64) -> AsyncMessageId {
+        let denom = match self.max_gas.saturating_add(extra_gas_cost) {
+            0 => 1,
+            d => d,
+        };
         (
             std::cmp::Reverse(Ratio::new(self.fee.to_raw(), denom)),
             self.emission_slot,

--- a/massa-models/src/async_msg_id.rs
+++ b/massa-models/src/async_msg_id.rs
@@ -16,6 +16,11 @@ const ASYNC_MESSAGE_ID_PREFIX: &str = "ASC";
 /// Unique identifier of a message.
 /// Also has the property of ordering by priority (highest first) following the triplet:
 /// `(rev(Ratio(msg.fee, max(msg.max_gas,1))), emission_slot, emission_index)`
+///
+/// From `MipComponent::Execution` version 2 (MIP-0002), batch selection and pool eviction
+/// re-rank with `fee / max(max_gas + async_msg_cst_gas_cost, 1)` via
+/// [`crate::async_msg::AsyncMessage::compute_priority_id`]; stored ids keep the historical
+/// formula so identity of already-emitted messages is unchanged.
 pub type AsyncMessageId = (std::cmp::Reverse<Ratio<u64>>, Slot, u64);
 
 #[derive(Clone)]


### PR DESCRIPTION
The current PR reorders the ASC priority when `take_async_batch` is called, without changing the AsyncMessageId type to ensure smooth transition.
I see three options:
1. Either we consider that this PR is too risky to merge for the benefits (I don't expect the orders to change too much in practice?), and we just add comments in code
2. Or we merge this implementation (it adds a sorting step but it should not impact performances too much)
3. Or we update AsyncMessageId to implement a new `Ord` implem, keeping the BTreeMap sort. However, we need to add, at version activation, a migration step to update all legacy ids to the new ones, which may be more prone to errors.

What do you think is best @damip? Personnaly I would lean towards 1.

Going with option 2 as discussed below.

As outlined below the impact is bounded, which is why this is not urgent: send_message REJECTS max_gas < gas_costs.max_instance_cost (2.1M gas), so the skew (max_gas + cst) / max_gas is at most 1 + 1M/2.1M = ~1.48x, and emitting costs 40M gas of ABI per message (~107 per block max, by taking the WHOLE block). So a 48% priority advantage at most, for someone paying full blocks to get it. Still a mispricing and the fix is cheap, so let's align selection with what we actually charge.