### PR TITLE
[F41] feat: implem cumulative budget for query_state

### DIFF
--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -28,7 +28,7 @@ use massa_api_exports::{
 use massa_consensus_exports::block_status::DiscardReason;
 use massa_consensus_exports::ConsensusController;
 use massa_execution_exports::{
-    ExecutionController, ExecutionQueryRequest, ExecutionQueryRequestItem,
+    ExecutionController, ExecutionQueryRequest, ExecutionQueryRequestItem, ExecutionQueryResponse,
     ExecutionQueryResponseItem, ExecutionStackElement, ReadOnlyExecutionRequest,
     ReadOnlyExecutionTarget,
 };
@@ -95,6 +95,15 @@ impl API<Public> {
             storage,
             keypair_factory: KeyPairFactory { mip_store },
         })
+    }
+
+    fn exec_query(&self, requests: Vec<ExecutionQueryRequestItem>) -> ExecutionQueryResponse {
+        self.0
+            .execution_controller
+            .query_state(ExecutionQueryRequest {
+                requests,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            })
     }
 }
 
@@ -1034,13 +1043,7 @@ impl MassaRpcServer for API<Public> {
 
         let mut result: Vec<GetAddressDatastoreKeysResponse> = Vec::with_capacity(requests.len());
 
-        let response = self
-            .0
-            .execution_controller
-            .query_state(ExecutionQueryRequest {
-                requests,
-                max_response_size: self.0.api_settings.max_response_body_size as usize,
-            });
+        let response = self.exec_query(requests);
 
         for response_item in response.responses {
             match response_item {
@@ -1256,14 +1259,7 @@ impl MassaRpcServer for API<Public> {
             return Err(ApiError::BadRequest(format!("too many arguments received. Only a maximum of {} arguments are accepted per request", self.0.api_settings.max_arguments)).into());
         }
 
-        let responses = self
-            .0
-            .execution_controller
-            .query_state(ExecutionQueryRequest {
-                requests: queries,
-                max_response_size: self.0.api_settings.max_response_body_size as usize,
-            })
-            .responses;
+        let responses = self.exec_query(queries).responses;
 
         let res: Result<Vec<Vec<u8>>, ApiError> = responses
             .into_iter()
@@ -1299,12 +1295,7 @@ impl MassaRpcServer for API<Public> {
             .collect();
 
         let result = self
-            .0
-            .execution_controller
-            .query_state(ExecutionQueryRequest {
-                requests: queries,
-                max_response_size: self.0.api_settings.max_response_body_size as usize,
-            })
+            .exec_query(queries)
             .responses
             .into_iter()
             .map(|response| match response {
@@ -1347,12 +1338,7 @@ impl MassaRpcServer for API<Public> {
             .collect::<Result<_, _>>()?;
 
         let result: Vec<DeferredCallResponse> = self
-            .0
-            .execution_controller
-            .query_state(ExecutionQueryRequest {
-                requests,
-                max_response_size: self.0.api_settings.max_response_body_size as usize,
-            })
+            .exec_query(requests)
             .responses
             .into_iter()
             .map(|exec| match exec {
@@ -1387,16 +1373,7 @@ impl MassaRpcServer for API<Public> {
 
         let mut slot_calls = Vec::new();
 
-        for exec in self
-            .0
-            .execution_controller
-            .query_state(ExecutionQueryRequest {
-                requests,
-                max_response_size: self.0.api_settings.max_response_body_size as usize,
-            })
-            .responses
-            .into_iter()
-        {
+        for exec in self.exec_query(requests).responses.into_iter() {
             match exec {
                 Ok(ExecutionQueryResponseItem::DeferredCallsBySlot(slot, result)) => {
                     let call_ids = result.into_iter().map(|id| id.to_string()).collect();

--- a/massa-api/src/public.rs
+++ b/massa-api/src/public.rs
@@ -1037,7 +1037,10 @@ impl MassaRpcServer for API<Public> {
         let response = self
             .0
             .execution_controller
-            .query_state(ExecutionQueryRequest { requests });
+            .query_state(ExecutionQueryRequest {
+                requests,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            });
 
         for response_item in response.responses {
             match response_item {
@@ -1256,7 +1259,10 @@ impl MassaRpcServer for API<Public> {
         let responses = self
             .0
             .execution_controller
-            .query_state(ExecutionQueryRequest { requests: queries })
+            .query_state(ExecutionQueryRequest {
+                requests: queries,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            })
             .responses;
 
         let res: Result<Vec<Vec<u8>>, ApiError> = responses
@@ -1295,7 +1301,10 @@ impl MassaRpcServer for API<Public> {
         let result = self
             .0
             .execution_controller
-            .query_state(ExecutionQueryRequest { requests: queries })
+            .query_state(ExecutionQueryRequest {
+                requests: queries,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            })
             .responses
             .into_iter()
             .map(|response| match response {
@@ -1340,7 +1349,10 @@ impl MassaRpcServer for API<Public> {
         let result: Vec<DeferredCallResponse> = self
             .0
             .execution_controller
-            .query_state(ExecutionQueryRequest { requests })
+            .query_state(ExecutionQueryRequest {
+                requests,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            })
             .responses
             .into_iter()
             .map(|exec| match exec {
@@ -1378,7 +1390,10 @@ impl MassaRpcServer for API<Public> {
         for exec in self
             .0
             .execution_controller
-            .query_state(ExecutionQueryRequest { requests })
+            .query_state(ExecutionQueryRequest {
+                requests,
+                max_response_size: self.0.api_settings.max_response_body_size as usize,
+            })
             .responses
             .into_iter()
         {

--- a/massa-execution-exports/src/error.rs
+++ b/massa-execution-exports/src/error.rs
@@ -77,4 +77,6 @@ pub enum ExecutionError {
 pub enum ExecutionQueryError {
     /// Not found: {0}
     NotFound(String),
+    /// Cumulative response size limit exceeded: {0}
+    TooLargeResponse(String),
 }

--- a/massa-execution-exports/src/mapping_grpc.rs
+++ b/massa-execution-exports/src/mapping_grpc.rs
@@ -466,6 +466,10 @@ impl From<ExecutionQueryError> for grpc_model::Error {
                 code: 404,
                 message: error,
             },
+            ExecutionQueryError::TooLargeResponse(error) => grpc_model::Error {
+                code: 413,
+                message: error,
+            },
         }
     }
 }

--- a/massa-execution-exports/src/types.rs
+++ b/massa-execution-exports/src/types.rs
@@ -42,6 +42,11 @@ pub struct ExecutionBlockMetadata {
 pub struct ExecutionQueryRequest {
     /// List of requests
     pub requests: Vec<ExecutionQueryRequestItem>,
+    /// Maximum aggregate size (bytes) of large payload items (`Bytecode`, `DatastoreValue`)
+    /// allowed in the response. Callers should pass their transport limit
+    /// (e.g. JSON-RPC `max_response_body_size` or gRPC `max_encoding_message_size`).
+    /// Other response variants are treated as zero-cost for this budget.
+    pub max_response_size: usize,
 }
 
 /// Response to a list of execution queries

--- a/massa-execution-worker/src/controller.rs
+++ b/massa-execution-worker/src/controller.rs
@@ -138,6 +138,11 @@ impl ExecutionController for ExecutionControllerImpl {
 
     /// Atomically query the execution state with multiple requests.
     ///
+    /// INVARIANT: all items MUST be computed under the single `execution_state` read lock taken below,
+    /// because the returned cursors and fingerprint describe the whole batch and clients rely on this
+    /// to read a consistent state. Never release the lock between items to reduce contention:
+    /// bound the cost of a batch via budgets (per-item errors) instead.
+    ///
     /// Large payload responses (`Bytecode`, `DatastoreValue`) are counted toward
     /// `req.max_response_size`. Other response variants are treated as 0 bytes.
     /// When appending a large payload would exceed the budget, that item is returned

--- a/massa-execution-worker/src/controller.rs
+++ b/massa-execution-worker/src/controller.rs
@@ -136,7 +136,12 @@ impl ExecutionController for ExecutionControllerImpl {
         self.input_data.0.notify_one();
     }
 
-    /// Atomically query the execution state with multiple requests
+    /// Atomically query the execution state with multiple requests.
+    ///
+    /// Large payload responses (`Bytecode`, `DatastoreValue`) are counted toward
+    /// `req.max_response_size`. Other response variants are treated as 0 bytes.
+    /// When appending a large payload would exceed the budget, that item is returned
+    /// as `ExecutionQueryError::TooLargeResponse` and its bytes are not retained.
     fn query_state(&self, req: ExecutionQueryRequest) -> ExecutionQueryResponse {
         let execution_lock = self.execution_state.read();
         let mut resp: ExecutionQueryResponse = ExecutionQueryResponse {
@@ -145,6 +150,8 @@ impl ExecutionController for ExecutionControllerImpl {
             final_cursor: execution_lock.final_cursor,
             final_state_fingerprint: execution_lock.get_final_state_fingerprint(),
         };
+        // Cumulative size of bytecode / datastore-value payloads kept in `resp`.
+        let mut response_payload_size: usize = 0;
         for req_item in req.requests {
             let resp_item = match req_item {
                 ExecutionQueryRequestItem::AddressExistsCandidate(addr) => {
@@ -183,7 +190,12 @@ impl ExecutionController for ExecutionControllerImpl {
                     let (_final_v, speculative_v) =
                         execution_lock.get_final_and_active_bytecode(&addr);
                     match speculative_v {
-                        Some(bytecode) => Ok(ExecutionQueryResponseItem::Bytecode(bytecode)),
+                        Some(bytecode) => account_large_payload(
+                            &mut response_payload_size,
+                            req.max_response_size,
+                            bytecode.0.len(),
+                        )
+                        .map(|()| ExecutionQueryResponseItem::Bytecode(bytecode)),
                         None => Err(ExecutionQueryError::NotFound(format!("Account {}", addr))),
                     }
                 }
@@ -191,7 +203,12 @@ impl ExecutionController for ExecutionControllerImpl {
                     let (final_v, _speculative_v) =
                         execution_lock.get_final_and_active_bytecode(&addr);
                     match final_v {
-                        Some(bytecode) => Ok(ExecutionQueryResponseItem::Bytecode(bytecode)),
+                        Some(bytecode) => account_large_payload(
+                            &mut response_payload_size,
+                            req.max_response_size,
+                            bytecode.0.len(),
+                        )
+                        .map(|()| ExecutionQueryResponseItem::Bytecode(bytecode)),
                         None => Err(ExecutionQueryError::NotFound(format!("Account {}", addr))),
                     }
                 }
@@ -239,7 +256,12 @@ impl ExecutionController for ExecutionControllerImpl {
                     let (_final_v, speculative_v) =
                         execution_lock.get_final_and_active_data_entry(&addr, &key);
                     match speculative_v {
-                        Some(value) => Ok(ExecutionQueryResponseItem::DatastoreValue(value)),
+                        Some(value) => account_large_payload(
+                            &mut response_payload_size,
+                            req.max_response_size,
+                            value.len(),
+                        )
+                        .map(|()| ExecutionQueryResponseItem::DatastoreValue(value)),
                         None => Err(ExecutionQueryError::NotFound(format!(
                             "Account {} datastore entry {:?}",
                             addr, key
@@ -250,7 +272,12 @@ impl ExecutionController for ExecutionControllerImpl {
                     let (final_v, _speculative_v) =
                         execution_lock.get_final_and_active_data_entry(&addr, &key);
                     match final_v {
-                        Some(value) => Ok(ExecutionQueryResponseItem::DatastoreValue(value)),
+                        Some(value) => account_large_payload(
+                            &mut response_payload_size,
+                            req.max_response_size,
+                            value.len(),
+                        )
+                        .map(|()| ExecutionQueryResponseItem::DatastoreValue(value)),
                         None => Err(ExecutionQueryError::NotFound(format!(
                             "Account {} datastore entry {:?}",
                             addr, key
@@ -616,6 +643,24 @@ impl ExecutionController for ExecutionControllerImpl {
     fn get_ops_exec_status(&self, batch: &[OperationId]) -> Vec<(Option<bool>, Option<bool>)> {
         self.execution_state.read().get_ops_exec_status(batch)
     }
+}
+
+/// Account a large payload against the cumulative response budget.
+/// Only bytecode and datastore-value lengths are counted; other items are ignored.
+fn account_large_payload(
+    accumulated: &mut usize,
+    max_response_size: usize,
+    payload_len: usize,
+) -> Result<(), ExecutionQueryError> {
+    let new_size = accumulated.saturating_add(payload_len);
+    if new_size > max_response_size {
+        return Err(ExecutionQueryError::TooLargeResponse(format!(
+            "query response size would exceed limit of {} bytes (current {}, item {})",
+            max_response_size, accumulated, payload_len
+        )));
+    }
+    *accumulated = new_size;
+    Ok(())
 }
 
 /// Execution manager

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -3940,6 +3940,7 @@ fn datastore_manipulations() {
                 },
                 ExecutionQueryRequestItem::Events(EventFilter::default()),
             ],
+            max_response_size: usize::MAX,
         });
     // Just checking that is works no asserts for now
     universe

--- a/massa-grpc/src/private.rs
+++ b/massa-grpc/src/private.rs
@@ -282,7 +282,10 @@ pub(crate) fn get_node_status(
             })?
     };
     let next_cycle_time = current_cycle_time.checked_add(cycle_duration)?;
-    let empty_request = ExecutionQueryRequest { requests: vec![] };
+    let empty_request = ExecutionQueryRequest {
+        requests: vec![],
+        max_response_size: grpc.grpc_config.max_encoding_message_size,
+    };
     let state = grpc.execution_controller.query_state(empty_request);
     let node_ip = grpc
         .protocol_config

--- a/massa-grpc/src/public.rs
+++ b/massa-grpc/src/public.rs
@@ -966,7 +966,10 @@ pub(crate) fn get_status(
     };
     let next_cycle_time = current_cycle_time.checked_add(cycle_duration)?;
     //TODO to be enhanced
-    let empty_request = ExecutionQueryRequest { requests: vec![] };
+    let empty_request = ExecutionQueryRequest {
+        requests: vec![],
+        max_response_size: grpc.grpc_config.max_encoding_message_size,
+    };
     let state = grpc.execution_controller.query_state(empty_request);
 
     let current_mip_version = grpc.keypair_factory.mip_store.get_network_version_current();
@@ -1040,7 +1043,10 @@ pub(crate) fn query_state(
 
     let response = grpc
         .execution_controller
-        .query_state(ExecutionQueryRequest { requests: queries });
+        .query_state(ExecutionQueryRequest {
+            requests: queries,
+            max_response_size: grpc.grpc_config.max_encoding_message_size,
+        });
 
     Ok(grpc_api::QueryStateResponse {
         final_cursor: Some(response.final_cursor.into()),


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

This PR volontarily only takes Bytecode and Datastore queries into account for the budget (for performances, if the total size exceeds the budget it will be caught later anyway).
It does not impact API / GRPC users as we just catch earlier big responses that would have error out later.