### PR TITLE
[F35] feat: document allowed malleability for deferred calls serialization

### DIFF
--- a/massa-deferred-calls/src/registry_changes.rs
+++ b/massa-deferred-calls/src/registry_changes.rs
@@ -233,6 +233,11 @@ impl Deserializer<DeferredCallRegistryChanges> for DeferredRegistryChangesDeseri
                 )),
             )),
         )
+        // Note: Unsorted or duplicate (Slot, DeferredRegistrySlotChanges) pairs on the wire still
+        // deserialize to the same BTreeMap. This serializer/deserializer pair is effectively test-only;
+        // production deferred-call processing does not rely on these serialized map blobs for hashing,
+        // networking, or deduplication. This is intentional malleability that Massa tolerates by
+        // construction and is not exploitable.
         .map(
             |(changes, total_gas, exec_stats)| DeferredCallRegistryChanges {
                 slots_change: changes.into_iter().collect::<BTreeMap<_, _>>(),

--- a/massa-deferred-calls/src/registry_changes.rs
+++ b/massa-deferred-calls/src/registry_changes.rs
@@ -233,11 +233,10 @@ impl Deserializer<DeferredCallRegistryChanges> for DeferredRegistryChangesDeseri
                 )),
             )),
         )
-        // Note: Unsorted or duplicate (Slot, DeferredRegistrySlotChanges) pairs on the wire still
-        // deserialize to the same BTreeMap. This serializer/deserializer pair is effectively test-only;
-        // production deferred-call processing does not rely on these serialized map blobs for hashing,
-        // networking, or deduplication. This is intentional malleability that Massa tolerates by
-        // construction and is not exploitable.
+        // Note: unsorted pairs, and duplicate keys (last occurrence wins), on the wire still deserialize
+        // to a normalized BTreeMap. This serializer/deserializer pair is only used in tests: production
+        // deferred-call processing reads per-key values from the DB and never parses these map blobs.
+        // Massa is malleability-resistant by construction, this is not exploitable.
         .map(
             |(changes, total_gas, exec_stats)| DeferredCallRegistryChanges {
                 slots_change: changes.into_iter().collect::<BTreeMap<_, _>>(),

--- a/massa-deferred-calls/src/slot_changes.rs
+++ b/massa-deferred-calls/src/slot_changes.rs
@@ -203,6 +203,11 @@ impl Deserializer<DeferredRegistrySlotChanges> for DeferredRegistrySlotChangesDe
                 }),
             )),
         )
+        // Note: Unsorted or duplicate (DeferredCallId, change) pairs on the wire still deserialize
+        // to the same BTreeMap. This serializer/deserializer pair is effectively test-only; production
+        // deferred-call processing does not rely on these serialized map blobs for hashing, networking,
+        // or deduplication. This is intentional malleability that Massa tolerates by construction
+        // and is not exploitable.
         .map(|(vec, gas, base_fee)| {
             let calls = vec.into_iter().collect::<BTreeMap<_, _>>();
 

--- a/massa-deferred-calls/src/slot_changes.rs
+++ b/massa-deferred-calls/src/slot_changes.rs
@@ -203,11 +203,10 @@ impl Deserializer<DeferredRegistrySlotChanges> for DeferredRegistrySlotChangesDe
                 }),
             )),
         )
-        // Note: Unsorted or duplicate (DeferredCallId, change) pairs on the wire still deserialize
-        // to the same BTreeMap. This serializer/deserializer pair is effectively test-only; production
-        // deferred-call processing does not rely on these serialized map blobs for hashing, networking,
-        // or deduplication. This is intentional malleability that Massa tolerates by construction
-        // and is not exploitable.
+        // Note: unsorted pairs, and duplicate keys (last occurrence wins), on the wire still deserialize
+        // to a normalized BTreeMap. This serializer/deserializer pair is only used in tests: production
+        // deferred-call processing reads per-key values from the DB and never parses these map blobs.
+        // Massa is malleability-resistant by construction, this is not exploitable.
         .map(|(vec, gas, base_fee)| {
             let calls = vec.into_iter().collect::<BTreeMap<_, _>>();
 


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Note: only documented the behaviour, no fix, as outlined in https://github.com/massalabs/massa/pull/5220