### PR TITLE
[F46] feat: lock mip_store during finalization

### DIFF
--- a/massa-execution-worker/src/execution.rs
+++ b/massa-execution-worker/src/execution.rs
@@ -34,7 +34,6 @@ use massa_models::execution::EventFilter;
 use massa_models::output_event::SCOutputEvent;
 use massa_models::prehash::PreHashSet;
 use massa_models::stats::ExecutionStats;
-use massa_models::timeslots::get_block_slot_timestamp;
 use massa_models::{
     address::Address,
     block_id::BlockId,
@@ -283,11 +282,6 @@ impl ExecutionState {
             );
         }
 
-        // Update versioning stats
-        // This will update the MIP store and must be called before final state write
-        // as it will also write the MIP store on disk
-        self.update_versioning_stats(&exec_out.block_info, &exec_out.slot);
-
         let exec_out_2 = exec_out.clone();
         #[cfg(feature = "slot-replayer")]
         {
@@ -296,9 +290,13 @@ impl ExecutionState {
             println!("<<<");
         }
         // apply state changes to the final ledger
+        let network_versions = exec_out
+            .block_info
+            .as_ref()
+            .map(|i| (i.current_version, i.announced_version));
         self.final_state
             .write()
-            .finalize(exec_out.slot, exec_out.state_changes);
+            .finalize(exec_out.slot, exec_out.state_changes, network_versions);
 
         // update the final ledger's slot
         self.final_cursor = exec_out.slot;
@@ -2687,24 +2685,6 @@ impl ExecutionState {
                 }
             })
             .collect()
-    }
-
-    /// Update MipStore with block header stats
-    pub fn update_versioning_stats(&mut self, block_info: &Option<ExecutedBlockInfo>, slot: &Slot) {
-        let slot_ts = get_block_slot_timestamp(
-            self.config.thread_count,
-            self.config.t0,
-            self.config.genesis_timestamp,
-            *slot,
-        )
-        .expect("Cannot get timestamp from slot");
-
-        self.mip_store.update_network_version_stats(
-            slot_ts,
-            block_info
-                .as_ref()
-                .map(|i| (i.current_version, i.announced_version)),
-        );
     }
 
     pub fn deferred_call_quote(

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -189,8 +189,12 @@ fn expect_finalize_deploy_and_call_blocks(
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(deploy_sc_slot), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(deploy_sc_slot),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             let mut saved_bytecode = saved_bytecode_edit.write();
             if !changes.ledger_changes.get_bytecode_updates().is_empty() {
                 *saved_bytecode = Some(changes.ledger_changes.get_bytecode_updates()[0].clone());
@@ -202,8 +206,12 @@ fn expect_finalize_deploy_and_call_blocks(
             .write()
             .expect_finalize()
             .times(1)
-            .with(predicate::eq(call_sc_slot), predicate::always())
-            .returning(move |_, _| {
+            .with(
+                predicate::eq(call_sc_slot),
+                predicate::always(),
+                predicate::always(),
+            )
+            .returning(move |_, _, _| {
                 finalized_waitpoint_trigger_handle_2.trigger();
             });
     }
@@ -1090,8 +1098,12 @@ fn send_and_receive_async_message() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             {
                 let mut saved_bytecode = saved_bytecode_edit.write();
                 *saved_bytecode = Some(changes.ledger_changes.get_bytecode_updates()[0].clone());
@@ -1115,8 +1127,12 @@ fn send_and_receive_async_message() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             match changes.ledger_changes.0.get(&destination).unwrap() {
                 // sc has received the coins (0.0000001)
                 SetUpdateOrDelete::Update(change_sc_update) => {
@@ -1240,8 +1256,12 @@ fn send_and_receive_async_message_expired() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             //println!("changes S (1 0): {:?}", changes);
             assert_eq!(
                 changes.async_pool_changes,
@@ -1330,8 +1350,12 @@ fn send_and_receive_async_message_expired_2() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert_eq!(
                 changes.async_pool_changes,
                 AsyncPoolChanges(BTreeMap::new())
@@ -1421,8 +1445,12 @@ fn send_and_receive_async_message_without_init_gas() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert_eq!(
                 changes.async_pool_changes,
                 AsyncPoolChanges(BTreeMap::new())
@@ -1520,8 +1548,12 @@ fn cancel_async_message() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             {
                 let mut saved_bytecode = saved_bytecode_edit.write();
                 *saved_bytecode = Some(changes.ledger_changes.get_bytecode_updates()[0].clone());
@@ -1544,8 +1576,12 @@ fn cancel_async_message() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             match changes.ledger_changes.0.get(&sender_addr).unwrap() {
                 // at slot (1,1) msg was canceled so sender has received the coins (0.0000001)
                 // sender has received the coins (0.0000001)
@@ -1720,8 +1756,12 @@ fn deferred_calls() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             {
                 let mut saved_bytecode = saved_bytecode_edit.write();
                 *saved_bytecode = Some(changes.ledger_changes.get_bytecode_updates()[0].clone());
@@ -1738,8 +1778,12 @@ fn deferred_calls() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             match changes.ledger_changes.0.get(&destination).unwrap() {
                 // sc has received the coins (0.0000001)
                 SetUpdateOrDelete::Update(change_sc_update) => {
@@ -1912,8 +1956,12 @@ fn deferred_call_register() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             // assert sender was debited ( -10 coins) and -5.2866 for fees
             match changes.ledger_changes.0.get(&sender_addr_clone).unwrap() {
                 SetUpdateOrDelete::Update(change_sc_update) => {
@@ -1962,8 +2010,12 @@ fn deferred_call_register() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             match changes
                 .ledger_changes
                 .0
@@ -2116,8 +2168,12 @@ fn deferred_call_register_fail() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert!(changes.deferred_call_changes.effective_total_gas == SetOrKeep::Keep);
             finalized_waitpoint_trigger_handle.trigger();
         });
@@ -2128,8 +2184,12 @@ fn deferred_call_register_fail() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert_eq!(changes.deferred_call_changes.slots_change.len(), 1);
             // deferred call was not register
             assert!(changes.deferred_call_changes.effective_total_gas == SetOrKeep::Keep);
@@ -2314,8 +2374,12 @@ fn deferred_call_exists() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert!(changes.deferred_call_changes.effective_total_gas == SetOrKeep::Keep);
             finalized_waitpoint_trigger_handle.trigger();
         });
@@ -2452,8 +2516,12 @@ fn deferred_call_quote() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert!(changes.deferred_call_changes.effective_total_gas == SetOrKeep::Keep);
             finalized_waitpoint_trigger_handle.trigger();
         });
@@ -2852,8 +2920,12 @@ fn send_and_receive_transaction() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             // 110 because 100 in the get_balance in the `final_state_boilerplate` and 10 from the transfer.
             assert_eq!(
                 changes
@@ -2986,8 +3058,12 @@ fn roll_buy() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert_eq!(changes.pos_changes.roll_changes.len(), 1);
             // 100 base + 1 bought
             assert_eq!(changes.pos_changes.roll_changes.get(&address), Some(&101));
@@ -3097,8 +3173,12 @@ fn roll_sell() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(3, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(3, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             let amount = changes
                 .ledger_changes
                 .get_balance_or_else(&address, || None)
@@ -3269,15 +3349,23 @@ fn auto_sell_on_missed_blocks() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, _changes| {});
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, _changes, _| {});
 
     foreign_controllers
         .final_state
         .write()
         .expect_finalize()
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             println!("changes: {:?}", changes);
             let deferred_credits = changes
                 .pos_changes
@@ -3343,7 +3431,7 @@ fn roll_slash() {
         .final_state
         .write()
         .expect_finalize()
-        .returning(move |_, changes| {
+        .returning(move |_, changes, _| {
             let rolls = changes.pos_changes.roll_changes.get(&address).unwrap();
             // 97 sold and 3 slashed
             assert_eq!(rolls, &0);
@@ -3474,7 +3562,7 @@ fn roll_slash_2() {
         .final_state
         .write()
         .expect_finalize()
-        .returning(move |_, changes| {
+        .returning(move |_, changes, _| {
             let rolls = changes.pos_changes.roll_changes.get(&address).unwrap();
             // 100 sold
             assert_eq!(rolls, &0);
@@ -3791,8 +3879,12 @@ fn datastore_manipulations() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             let key_len = (key_a.len() + key_b.len()) as u64;
             let value_len = ([21, 0, 49].len() + [5, 12, 241].len()) as u64;
             let amount = changes
@@ -4202,8 +4294,12 @@ fn test_rewards() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             let block_credits = exec_cfg.block_reward;
             let block_credit_part = block_credits
                 .checked_div_u64(BLOCK_CREDIT_PART_COUNT)
@@ -4248,8 +4344,12 @@ fn test_rewards() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             let block_credits = exec_cfg.block_reward;
             let block_credit_part = block_credits
                 .checked_div_u64(BLOCK_CREDIT_PART_COUNT)
@@ -4455,8 +4555,12 @@ fn send_and_receive_async_message_with_reset() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             assert_eq!(changes.async_pool_changes.0.len(), 1);
             assert_eq!(
                 changes.async_pool_changes.0.first_key_value().unwrap().1,
@@ -4476,8 +4580,12 @@ fn send_and_receive_async_message_with_reset() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 1)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 1)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             match changes.async_pool_changes.0.first_key_value().unwrap().1 {
                 SetUpdateOrDelete::Delete => {
                     // msg was deleted
@@ -4580,8 +4688,12 @@ fn execution_trace_transfers_are_bound_to_event() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, _| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, _, _| {
             finalized_waitpoint_trigger_handle.trigger();
         });
 
@@ -4932,8 +5044,12 @@ fn test_dump_block() {
         .write()
         .expect_finalize()
         .times(1)
-        .with(predicate::eq(Slot::new(1, 0)), predicate::always())
-        .returning(move |_, changes| {
+        .with(
+            predicate::eq(Slot::new(1, 0)),
+            predicate::always(),
+            predicate::always(),
+        )
+        .returning(move |_, changes, _| {
             // 190 because 100 in the get_balance in the `final_state_boilerplate` and 90 from the transfer.
             assert_eq!(
                 changes

--- a/massa-final-state/src/controller_trait.rs
+++ b/massa-final-state/src/controller_trait.rs
@@ -35,7 +35,12 @@ pub trait FinalStateController: Send + Sync {
     /// Once this is called, the state is attached at the output of the provided slot.
     ///
     /// Panics if the new slot is not the one coming just after the current one.
-    fn finalize(&mut self, slot: Slot, changes: StateChanges);
+    fn finalize(
+        &mut self,
+        slot: Slot,
+        changes: StateChanges,
+        network_versions: Option<(u32, Option<u32>)>,
+    );
 
     /// After bootstrap or load from disk, recompute all the caches.
     fn recompute_caches(&mut self);

--- a/massa-final-state/src/final_state.rs
+++ b/massa-final-state/src/final_state.rs
@@ -418,7 +418,12 @@ impl FinalState {
         Ok(())
     }
 
-    fn _finalize(&mut self, slot: Slot, changes: StateChanges) -> AnyResult<()> {
+    fn _finalize(
+        &mut self,
+        slot: Slot,
+        changes: StateChanges,
+        network_versions: Option<(u32, Option<u32>)>,
+    ) -> AnyResult<()> {
         let cur_slot = self.db.read().get_change_id()?;
         // check slot consistency
         let next_slot = cur_slot.get_next_slot(self.config.thread_count)?;
@@ -470,7 +475,12 @@ impl FinalState {
             slot.get_prev_slot(self.config.thread_count)?,
         )?;
 
-        self.mip_store.update_batches(
+        // Hold the MIP store write lock while updating versioning stats, serializing
+        // them to the DB batch, and committing the batch atomically. This prevents
+        // other threads from observing in-memory versioning state ahead of disk.
+        let mut mip_guard = self.mip_store.0.write();
+        mip_guard.update_network_version_stats(slot_ts, network_versions);
+        mip_guard.update_batches(
             &mut db_batch,
             &mut db_versioning_batch,
             Some((&slot_prev_ts, &slot_ts)),
@@ -487,6 +497,7 @@ impl FinalState {
         self.db
             .write()
             .write_batch(db_batch, db_versioning_batch, Some(slot));
+        drop(mip_guard);
 
         let final_state_hash = self.db.read().get_xof_db_hash();
 
@@ -804,8 +815,13 @@ impl FinalStateController for FinalState {
             .map_err(|err| FinalStateError::PosError(err.to_string()))
     }
 
-    fn finalize(&mut self, slot: Slot, changes: StateChanges) {
-        self._finalize(slot, changes).unwrap()
+    fn finalize(
+        &mut self,
+        slot: Slot,
+        changes: StateChanges,
+        network_versions: Option<(u32, Option<u32>)>,
+    ) {
+        self._finalize(slot, changes, network_versions).unwrap()
     }
 
     fn get_execution_trail_hash(&self) -> Hash {
@@ -1140,7 +1156,7 @@ mod test {
         let ok_next_slot = Slot::new(0, 1);
         let changes = get_state_changes();
 
-        let res = fstate._finalize(wrong_next_slot, changes.clone());
+        let res = fstate._finalize(wrong_next_slot, changes.clone(), None);
         assert!(res
             .err()
             .unwrap()
@@ -1150,7 +1166,7 @@ mod test {
         assert_eq!(fstate.get_slot(), initial_slot);
 
         // This should also fail because there is no initial cycle (required by POS state)
-        let res = fstate._finalize(ok_next_slot, changes.clone());
+        let res = fstate._finalize(ok_next_slot, changes.clone(), None);
 
         assert!(res.is_err());
         match res {
@@ -1168,7 +1184,7 @@ mod test {
 
         let mut batch = DBBatch::new();
         fstate.pos_state.create_initial_cycle(&mut batch);
-        let res = fstate._finalize(ok_next_slot, changes);
+        let res = fstate._finalize(ok_next_slot, changes, None);
         assert!(res.is_ok());
         assert_eq!(fstate.get_slot(), ok_next_slot);
     }
@@ -1184,7 +1200,7 @@ mod test {
         let changes = get_state_changes();
         let mut batch = DBBatch::new();
         fstate.pos_state.create_initial_cycle(&mut batch);
-        let res = fstate._finalize(ok_next_slot, changes);
+        let res = fstate._finalize(ok_next_slot, changes, None);
         assert!(res.is_ok());
         assert_eq!(fstate.get_slot(), ok_next_slot);
 
@@ -1244,7 +1260,7 @@ mod test {
         let changes = get_state_changes();
         let mut batch = DBBatch::new();
         fstate.pos_state.create_initial_cycle(&mut batch);
-        let res = fstate._finalize(ok_next_slot, changes);
+        let res = fstate._finalize(ok_next_slot, changes, None);
         assert!(res.is_ok());
         assert_eq!(fstate.get_slot(), ok_next_slot);
 

--- a/massa-final-state/src/tests/scenarios.rs
+++ b/massa-final-state/src/tests/scenarios.rs
@@ -217,7 +217,7 @@ fn test_final_state() {
         );
         state_changes.ledger_changes = ledger_changes;
 
-        fs.write().finalize(slot, state_changes);
+        fs.write().finalize(slot, state_changes, None);
 
         hash = fs.read().db.read().get_xof_db_hash();
 

--- a/massa-versioning/src/versioning.rs
+++ b/massa-versioning/src/versioning.rs
@@ -1002,7 +1002,7 @@ impl MipStoreRaw {
         }
     }
 
-    fn update_network_version_stats(
+    pub fn update_network_version_stats(
         &mut self,
         slot_timestamp: MassaTime,
         network_versions: Option<(u32, Option<u32>)>,
@@ -1370,7 +1370,7 @@ impl MipStoreRaw {
     // DB methods
 
     /// Get MIP store changes between 2 timestamps - used by the db to update the disk
-    fn update_batches(
+    pub fn update_batches(
         &self,
         batch: &mut DBBatch,
         versioning_batch: &mut DBBatch,


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Note: The reorder recommended in the finding's issue has correctness issue.
We have a choice:
- Option 1: add a write lock for in-memory MIP (lock the in-memory MIP, update it, finalize, and release the lock)
- Option 2: have a two-step stagin process and a lock (first, stage the wanted MIP changes without updating the in-memory view, then lock the in-memory MIP, finalize, update the in-memory MIP once finalized, and release the lock).

Both options have similar impact (readers don't see a desync view, disk changes have no impact (same as without this PR)). I went with option 1 as it fixes the issue completely, it both is simpler and a smaller refactor.