### PR TITLE
[F47] feat: use min_gas_cost as fallback for deferred calls uninitialized slots

### DIFF
--- a/massa-deferred-calls/src/lib.rs
+++ b/massa-deferred-calls/src/lib.rs
@@ -48,6 +48,7 @@ pub struct DeferredCallRegistry {
     call_id_deserializer: DeferredCallIdDeserializer,
     registry_changes_deserializer: DeferredRegistryChangesDeserializer,
     registry_changes_serializer: DeferredRegistryChangesSerializer,
+    min_gas_cost: u64,
 }
 
 impl DeferredCallRegistry {
@@ -68,6 +69,7 @@ impl DeferredCallRegistry {
             call_id_deserializer: DeferredCallIdDeserializer::new(),
             registry_changes_deserializer: DeferredRegistryChangesDeserializer::new(config),
             registry_changes_serializer: DeferredRegistryChangesSerializer::new(config),
+            min_gas_cost: config.min_gas_cost,
         }
     }
 
@@ -151,10 +153,12 @@ impl DeferredCallRegistry {
         }
     }
 
-    /// Returns the base fee for a slot
+    /// Returns the base fee for a slot.
+    /// Uninitialized slots (missing from storage or set to zero) fall back to
+    /// `min_gas_cost` so bookable slots are never priced at zero.
     pub fn get_slot_base_fee(&self, slot: &Slot) -> Amount {
         let key = deferred_call_slot_base_fee_key!(slot.to_bytes_key());
-        match self.db.read().get_cf(STATE_CF, key) {
+        let base_fee = match self.db.read().get_cf(STATE_CF, key) {
             Ok(Some(v)) => {
                 self.call_deserializer
                     .amount_deserializer
@@ -163,6 +167,12 @@ impl DeferredCallRegistry {
                     .1
             }
             _ => Amount::zero(),
+        };
+
+        if base_fee.is_zero() {
+            Amount::from_raw(self.min_gas_cost)
+        } else {
+            base_fee
         }
     }
 

--- a/massa-deferred-calls/src/lib.rs
+++ b/massa-deferred-calls/src/lib.rs
@@ -154,8 +154,11 @@ impl DeferredCallRegistry {
     }
 
     /// Returns the base fee for a slot.
-    /// Uninitialized slots (missing from storage or set to zero) fall back to
-    /// `min_gas_cost` so bookable slots are never priced at zero.
+    /// Uninitialized slots (no entry, or zero) fall back to `min_gas_cost`: this is exactly
+    /// what `advance_slot` would have written for them from an empty registry (0 booked gas
+    /// puts the controller in its "decrease" branch, which floors at `min_gas_cost`), so the
+    /// fallback is the missing initialization, not a different pricing rule. On a registry
+    /// that has been advancing for more than `max_future_slots` this never fires.
     pub fn get_slot_base_fee(&self, slot: &Slot) -> Amount {
         let key = deferred_call_slot_base_fee_key!(slot.to_bytes_key());
         let base_fee = match self.db.read().get_cf(STATE_CF, key) {

--- a/massa-deferred-calls/src/tests/mod.rs
+++ b/massa-deferred-calls/src/tests/mod.rs
@@ -139,3 +139,33 @@ fn call_registry_get_slot_calls() {
     assert_eq!(result.slot_base_fee, Amount::from_raw(10000000));
     assert_eq!(result.effective_slot_gas, 100_000);
 }
+
+#[test]
+fn uninitialized_slot_base_fee_uses_min_gas_cost() {
+    let temp_dir = tempdir().expect("Unable to create a temp folder");
+    let db_config = MassaDBConfig {
+        path: temp_dir.path().to_path_buf(),
+        max_history_length: 100,
+        max_final_state_elements_size: 100,
+        max_versioning_elements_size: 100,
+        thread_count: THREAD_COUNT,
+        max_ledger_backups: 100,
+        enable_metrics: false,
+    };
+    let db: ShareableMassaDBController = Arc::new(RwLock::new(
+        Box::new(MassaDB::new(db_config)) as Box<(dyn MassaDBController + 'static)>
+    ));
+
+    let config = DeferredCallsConfig::default();
+    let registry = DeferredCallRegistry::new(db, config);
+
+    let slot = Slot {
+        thread: 0,
+        period: 42,
+    };
+
+    assert_eq!(
+        registry.get_slot_base_fee(&slot),
+        Amount::from_raw(config.min_gas_cost)
+    );
+}

--- a/massa-deferred-calls/src/tests/mod.rs
+++ b/massa-deferred-calls/src/tests/mod.rs
@@ -148,6 +148,8 @@ fn uninitialized_slot_base_fee_uses_min_gas_cost() {
         max_history_length: 100,
         max_final_state_elements_size: 100,
         max_versioning_elements_size: 100,
+        max_final_state_elements_count: MAX_BOOTSTRAP_FINAL_STATE_ELEMENTS_COUNT as usize,
+        max_versioning_elements_count: MAX_BOOTSTRAP_VERSIONING_ELEMENTS_COUNT as usize,
         thread_count: THREAD_COUNT,
         max_ledger_backups: 100,
         enable_metrics: false,

--- a/massa-execution-worker/src/speculative_deferred_calls.rs
+++ b/massa-execution-worker/src/speculative_deferred_calls.rs
@@ -165,14 +165,8 @@ impl SpeculativeDeferredCallRegistry {
             .get_prev_slot(self.config.thread_count)
             .expect("cannot get prev slot");
 
-        let prev_slot_base_fee = {
-            let temp_slot_fee = self.get_slot_base_fee(&prev_slot);
-            if temp_slot_fee.eq(&Amount::zero()) {
-                Amount::from_raw(self.config.min_gas_cost)
-            } else {
-                temp_slot_fee
-            }
-        };
+        // uninitialized slots fall back to `min_gas_cost`, so we can use the `get_slot_base_fee` method directly
+        let prev_slot_base_fee = self.get_slot_base_fee(&prev_slot);
 
         let new_slot_base_fee = match avg_booked_gas.cmp(&TARGET_BOOKING) {
             // the previous booking rate was exactly the expected one: do not adjust the base fee

--- a/massa-execution-worker/src/speculative_deferred_calls.rs
+++ b/massa-execution-worker/src/speculative_deferred_calls.rs
@@ -673,6 +673,8 @@ mod tests {
             max_history_length: 10,
             max_final_state_elements_size: 100_000,
             max_versioning_elements_size: 100_000,
+            max_final_state_elements_count: MAX_BOOTSTRAP_FINAL_STATE_ELEMENTS_COUNT as usize,
+            max_versioning_elements_count: MAX_BOOTSTRAP_VERSIONING_ELEMENTS_COUNT as usize,
             thread_count: THREAD_COUNT,
             max_ledger_backups: 10,
             enable_metrics: false,

--- a/massa-execution-worker/src/speculative_deferred_calls.rs
+++ b/massa-execution-worker/src/speculative_deferred_calls.rs
@@ -118,7 +118,9 @@ impl SpeculativeDeferredCallRegistry {
     pub fn get_slot_base_fee(&self, slot: &Slot) -> Amount {
         // get slot base fee from current changes
         if let Some(v) = self.deferred_calls_changes.get_slot_base_fee(slot) {
-            return v;
+            if !v.is_zero() {
+                return v;
+            }
         }
 
         // check in history backwards
@@ -130,17 +132,18 @@ impl SpeculativeDeferredCallRegistry {
                     .deferred_call_changes
                     .get_slot_base_fee(slot)
                 {
-                    return v;
+                    if !v.is_zero() {
+                        return v;
+                    }
                 }
             }
         }
 
-        // check in final state
-        return self
-            .final_state
+        // check in final state (applies the min_gas_cost fallback for uninitialized slots)
+        self.final_state
             .read()
             .get_deferred_call_registry()
-            .get_slot_base_fee(slot);
+            .get_slot_base_fee(slot)
     }
 
     /// Consumes and deletes the current slot, prepares a new slot in the future
@@ -635,7 +638,7 @@ mod tests {
             )
             .is_err());
 
-        // no params
+        // no params: uninitialized slots must still charge the integral fee
         assert_eq!(
             speculative
                 .compute_call_fee(
@@ -648,7 +651,7 @@ mod tests {
                     0,
                 )
                 .unwrap(),
-            Amount::from_str("0.036600079").unwrap()
+            Amount::from_str("0.038600079").unwrap()
         );
 
         // 10Ko params size
@@ -664,7 +667,51 @@ mod tests {
                     10_000,
                 )
                 .unwrap(),
-            Amount::from_str("1.036600079").unwrap()
+            Amount::from_str("1.038600079").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_uninitialized_slot_base_fee_fallback() {
+        let disk_ledger = TempDir::new().expect("cannot create temp directory");
+        let db_config = MassaDBConfig {
+            path: disk_ledger.path().to_path_buf(),
+            max_history_length: 10,
+            max_final_state_elements_size: 100_000,
+            max_versioning_elements_size: 100_000,
+            thread_count: THREAD_COUNT,
+            max_ledger_backups: 10,
+            enable_metrics: false,
+        };
+
+        let db = Arc::new(RwLock::new(
+            Box::new(MassaDB::new(db_config)) as Box<(dyn MassaDBController + 'static)>
+        ));
+        let mock_final_state = Arc::new(RwLock::new(MockFinalStateController::new()));
+        let config = DeferredCallsConfig::default();
+
+        let deferred_call_registry =
+            DeferredCallRegistry::new(db.clone(), DeferredCallsConfig::default());
+
+        mock_final_state
+            .write()
+            .expect_get_deferred_call_registry()
+            .return_const(deferred_call_registry);
+
+        let speculative = SpeculativeDeferredCallRegistry::new(
+            mock_final_state,
+            Arc::new(Default::default()),
+            config,
+        );
+
+        let slot = Slot {
+            period: 10,
+            thread: 1,
+        };
+
+        assert_eq!(
+            speculative.get_slot_base_fee(&slot),
+            Amount::from_raw(config.min_gas_cost)
         );
     }
 }

--- a/massa-execution-worker/src/tests/scenarios_mandatories.rs
+++ b/massa-execution-worker/src/tests/scenarios_mandatories.rs
@@ -2559,7 +2559,7 @@ fn deferred_call_quote() {
         .module_controller
         .get_filtered_sc_output_event(EventFilter::default());
 
-    assert_eq!(events[0].data, "136600000");
+    assert_eq!(events[0].data, "147100000");
 }
 
 /// Context


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Note: I don't remember exactly the expected formula for the deferred call quotes, and if this first uninitialized window was expected / left on purpose or not. If you have something to add don't hesitate @damip @Soulthym @modship 