### PR TITLE
[F62] feat: add metrics to detect underfllled blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "massa_consensus_exports",
  "massa_factory_exports",
  "massa_hash",
+ "massa_metrics",
  "massa_models",
  "massa_pool_exports",
  "massa_pos_exports",

--- a/massa-factory-worker/Cargo.toml
+++ b/massa-factory-worker/Cargo.toml
@@ -22,6 +22,7 @@ massa_wallet = {workspace = true}
 massa_pos_exports = {workspace = true}
 massa_pool_exports = {workspace = true}
 massa_versioning = {workspace = true}
+massa_metrics = {workspace = true}
 
 [dev-dependencies]
 num = {workspace = true}

--- a/massa-factory-worker/src/block_factory.rs
+++ b/massa-factory-worker/src/block_factory.rs
@@ -124,6 +124,7 @@ impl BlockFactoryWorker {
     fn process_slot(&mut self, slot: Slot) {
         let mut timings = Vec::new();
         let channel_timeout = self.cfg.block_opt_channel_timeout;
+        let mut had_pool_timeout = false;
 
         // get block producer address for that slot
         timings.push(("get_producer START", MassaTime::now()));
@@ -204,6 +205,8 @@ impl BlockFactoryWorker {
         ) {
             Ok(result) => result,
             Err(e) => {
+                had_pool_timeout = true;
+                massa_metrics::inc_factory_pool_timeout_endorsements();
                 warn!(
                     "Channel timeout: get_block_endorsements took >{}ms for slot {}: {:?}. Proceeding with empty endorsements.",
                     channel_timeout.as_millis(), slot, e
@@ -243,6 +246,8 @@ impl BlockFactoryWorker {
         {
             Ok(result) => result,
             Err(e) => {
+                had_pool_timeout = true;
+                massa_metrics::inc_factory_pool_timeout_operations();
                 warn!(
                     "Channel timeout: get_block_operations took >{}ms for slot {}: {:?}. Proceeding without operations.",
                     channel_timeout.as_millis(), slot, e
@@ -274,6 +279,8 @@ impl BlockFactoryWorker {
         {
             Ok(result) => result,
             Err(e) => {
+                had_pool_timeout = true;
+                massa_metrics::inc_factory_pool_timeout_denunciations();
                 warn!(
                     "Channel timeout: get_block_denunciations took >{}ms for slot {}: {:?}. Proceeding without denunciations.",
                     channel_timeout.as_millis(), slot, e
@@ -330,6 +337,7 @@ impl BlockFactoryWorker {
         self.channels
             .consensus
             .register_block(block_id, slot, block_storage, true);
+        massa_metrics::inc_factory_blocks_produced(had_pool_timeout);
         timings.push(("register_block END", MassaTime::now()));
 
         // Check block latency

--- a/massa-factory-worker/src/block_factory.rs
+++ b/massa-factory-worker/src/block_factory.rs
@@ -205,6 +205,11 @@ impl BlockFactoryWorker {
         ) {
             Ok(result) => result,
             Err(e) => {
+                // Pool reads are best effort: a block MUST be produced on time. A late or missed block is worse
+                // than an empty one (lost block reward, production stat miss, the network loses the slot),
+                // while an empty block only loses the fees of that block. So pool lock timeouts degrade to an
+                // empty block instead of aborting the slot. This also prevents pool slowness (e.g. op flooding)
+                // from turning into missed blocks. Timeouts are exposed via metrics so the node runner can act.
                 had_pool_timeout = true;
                 massa_metrics::inc_factory_pool_timeout_endorsements();
                 warn!(

--- a/massa-metrics/src/lib.rs
+++ b/massa-metrics/src/lib.rs
@@ -13,7 +13,9 @@ use std::{
 };
 
 use lazy_static::lazy_static;
-use prometheus::{register_int_gauge, Gauge, Histogram, IntCounter, IntGauge};
+use prometheus::{
+    register_int_counter, register_int_gauge, Gauge, Histogram, IntCounter, IntGauge,
+};
 use tokio::sync::oneshot::Sender;
 use tracing::warn;
 
@@ -48,6 +50,31 @@ lazy_static! {
 
         static ref EVENT_CACHE_VEC: IntGauge = register_int_gauge!(
             "event_cache_vec_len", "vector len for events" ).unwrap();
+
+        static ref FACTORY_POOL_TIMEOUT_ENDORSEMENTS: IntCounter = register_int_counter!(
+            "factory_pool_timeout_endorsements",
+            "number of times block factory timed out while fetching endorsements from the pool"
+        ).unwrap();
+
+        static ref FACTORY_POOL_TIMEOUT_OPERATIONS: IntCounter = register_int_counter!(
+            "factory_pool_timeout_operations",
+            "number of times block factory timed out while fetching operations from the pool"
+        ).unwrap();
+
+        static ref FACTORY_POOL_TIMEOUT_DENUNCIATIONS: IntCounter = register_int_counter!(
+            "factory_pool_timeout_denunciations",
+            "number of times block factory timed out while fetching denunciations from the pool"
+        ).unwrap();
+
+        static ref FACTORY_BLOCKS_PRODUCED: IntCounter = register_int_counter!(
+            "factory_blocks_produced",
+            "number of blocks produced by the local block factory"
+        ).unwrap();
+
+        static ref FACTORY_BLOCKS_PRODUCED_WITH_POOL_TIMEOUT: IntCounter = register_int_counter!(
+            "factory_blocks_produced_with_pool_timeout",
+            "number of locally produced blocks where at least one pool read timed out during assembly"
+        ).unwrap();
 
 }
 
@@ -103,6 +130,36 @@ pub fn set_endorsements_counter(val: usize) {
 
 pub fn set_operations_counter(val: usize) {
     OPERATIONS_COUNTER.set(val as i64);
+}
+
+pub fn inc_factory_pool_timeout_endorsements() {
+    FACTORY_POOL_TIMEOUT_ENDORSEMENTS.inc();
+}
+
+pub fn inc_factory_pool_timeout_operations() {
+    FACTORY_POOL_TIMEOUT_OPERATIONS.inc();
+}
+
+pub fn inc_factory_pool_timeout_denunciations() {
+    FACTORY_POOL_TIMEOUT_DENUNCIATIONS.inc();
+}
+
+pub fn inc_factory_blocks_produced(had_pool_timeout: bool) {
+    FACTORY_BLOCKS_PRODUCED.inc();
+    if had_pool_timeout {
+        FACTORY_BLOCKS_PRODUCED_WITH_POOL_TIMEOUT.inc();
+    }
+}
+
+/// Eagerly register lazy_static metrics so they appear on `/metrics` even before
+/// the first increment (e.g. factory pool timeouts that have not occurred yet).
+#[cfg(not(feature = "test-exports"))]
+fn register_lazy_static_metrics() {
+    lazy_static::initialize(&FACTORY_POOL_TIMEOUT_ENDORSEMENTS);
+    lazy_static::initialize(&FACTORY_POOL_TIMEOUT_OPERATIONS);
+    lazy_static::initialize(&FACTORY_POOL_TIMEOUT_DENUNCIATIONS);
+    lazy_static::initialize(&FACTORY_BLOCKS_PRODUCED);
+    lazy_static::initialize(&FACTORY_BLOCKS_PRODUCED_WITH_POOL_TIMEOUT);
 }
 
 #[derive(Default)]
@@ -513,6 +570,7 @@ impl MassaMetrics {
         if enabled {
             #[cfg(not(feature = "test-exports"))]
             {
+                register_lazy_static_metrics();
                 let _ = prometheus::register(Box::new(final_cursor_thread.clone()));
                 let _ = prometheus::register(Box::new(final_cursor_period.clone()));
                 let _ = prometheus::register(Box::new(active_cursor_thread.clone()));


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Adds metrics on:
- the count of specific pool timeouts underfilling a block
- the count of produced blocks
- the count of underfilled produced blocks