### PR TITLE
[F29] unbounded command flood can indefinitely delay slot ticks and consensus maintenance

### DIFF
--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -400,3 +400,134 @@ fn test_parent_in_the_future() {
         "wrong status"
     );
 }
+
+/// Regression test for F29: slot-driven maintenance must not be starved by a
+/// sustained flood of consensus commands.
+///
+/// A future block header is registered, then the worker is flooded with
+/// cheap `mark_invalid_block` commands. While the flood is still running, the
+/// block's slot passes. With the starvation bug the block would stay in
+/// `WaitingForSlot` until the flood ends; with the fix `slot_tick` runs
+/// between commands and the block leaves `WaitingForSlot` during the flood.
+#[test]
+fn test_slot_maintenance_not_starved_by_command_flood() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let thread_count = 2;
+    let t0 = MassaTime::from_millis(100);
+    let cfg = ConsensusConfig {
+        t0,
+        thread_count,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let last_start_period = cfg.last_start_period;
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+
+    // `slot_tick` / `block_db_changed` will call the execution controller
+    // multiple times, so use `returning` rather than `return_once`.
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(|_| {});
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |_| Ok(staking_address));
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // Register a block header whose slot is far enough in the future that
+    // the test can flood commands across its slot boundary.
+    let future_block = create_block(
+        Slot::new(3 + last_start_period, 0),
+        genesis_hashes.clone(),
+        &staking_key,
+    );
+    controller.register_block_header(future_block.id, future_block.content.header.clone());
+
+    // Wait until the block is known and waiting for its slot.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(10));
+        waited += 10;
+        let status = &controller.get_block_statuses(&[future_block.id])[0];
+        if *status == BlockGraphStatus::WaitingForSlot {
+            break;
+        }
+        assert!(
+            waited < 1000,
+            "future block never reached WaitingForSlot (status: {:?})",
+            status
+        );
+    }
+
+    // Cheap command used to keep the worker busy. The block must exist in the
+    // graph before we can mark it invalid, so register its header first.
+    let dummy_block = create_block(
+        Slot::new(1 + last_start_period, 0),
+        genesis_hashes,
+        &staking_key,
+    );
+    controller.register_block_header(dummy_block.id, dummy_block.content.header.clone());
+
+    // Flood the command channel from a separate thread.
+    let flood_controller = controller.clone();
+    let flood_handle = std::thread::spawn(move || {
+        let start = std::time::Instant::now();
+        while start.elapsed() < Duration::from_millis(600) {
+            flood_controller.mark_invalid_block(dummy_block.id, dummy_block.content.header.clone());
+        }
+    });
+
+    // Poll the future block status while the flood is still running.
+    // With the fix, slot_tick will run during the flood and process the block.
+    let mut processed_during_flood = false;
+    let poll_start = std::time::Instant::now();
+    while poll_start.elapsed() < Duration::from_millis(600) {
+        std::thread::sleep(Duration::from_millis(25));
+        if &controller.get_block_statuses(&[future_block.id])[0]
+            != &BlockGraphStatus::WaitingForSlot
+        {
+            processed_during_flood = true;
+            break;
+        }
+    }
+
+    flood_handle.join().expect("flood thread panicked");
+
+    assert!(
+        processed_during_flood,
+        "future block stayed in WaitingForSlot during command flood; slot maintenance was starved"
+    );
+}

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -516,8 +516,7 @@ fn test_slot_maintenance_not_starved_by_command_flood() {
     let poll_start = std::time::Instant::now();
     while poll_start.elapsed() < Duration::from_millis(600) {
         std::thread::sleep(Duration::from_millis(25));
-        if &controller.get_block_statuses(&[future_block.id])[0]
-            != &BlockGraphStatus::WaitingForSlot
+        if controller.get_block_statuses(&[future_block.id])[0] != BlockGraphStatus::WaitingForSlot
         {
             processed_during_flood = true;
             break;

--- a/massa-consensus-worker/src/worker/main_loop.rs
+++ b/massa-consensus-worker/src/worker/main_loop.rs
@@ -1,6 +1,6 @@
 use std::time::Instant;
 
-use massa_consensus_exports::{error::ConsensusError, events::ConsensusEvent};
+use massa_consensus_exports::error::ConsensusError;
 use massa_models::{
     slot::Slot,
     timeslots::{get_block_slot_timestamp, get_closest_slot_to_timestamp},
@@ -110,28 +110,12 @@ impl ConsensusWorker {
         (next_slot, next_instant)
     }
 
-    /// Performs all per-slot maintenance: episode-end check, cycle logging,
-    /// `slot_tick`, pruning, and advancing to the next slot.
+    /// Performs all per-slot maintenance: cycle logging, `slot_tick`, pruning,
+    /// and advancing to the next slot.
     ///
     /// # Arguments
     /// * `last_prune`: instant when the block DB was last pruned
-    ///
-    /// # Returns
-    /// `true` if the worker should keep running, `false` if the episode ended.
-    fn process_slot_tick(&mut self, last_prune: &mut Instant) -> bool {
-        if let Some(end) = self.config.end_timestamp {
-            // The testnet has ended. Will be removed for mainnet.
-            if self.next_instant > end.estimate_instant().unwrap() {
-                info!("This episode has come to an end, please get the latest testnet node version to continue");
-                let _ = self
-                    .shared_state
-                    .read()
-                    .channels
-                    .controller_event_tx
-                    .send(ConsensusEvent::Stop);
-                return false;
-            }
-        }
+    fn process_slot_tick(&mut self, last_prune: &mut Instant) {
         let previous_cycle = self
             .previous_slot
             .map(|s| s.get_cycle(self.config.periods_per_cycle));
@@ -161,7 +145,6 @@ impl ConsensusWorker {
         }
         self.previous_slot = Some(self.next_slot);
         (self.next_slot, self.next_instant) = self.get_next_slot(Some(self.next_slot));
-        true
     }
 
     /// Runs in loop forever. This loop must stop every slot to perform operations on stats and graph
@@ -172,9 +155,7 @@ impl ConsensusWorker {
             match self.wait_slot_or_command(self.next_instant) {
                 // When we reached the instant of the next slot
                 WaitingStatus::Ended => {
-                    if !self.process_slot_tick(&mut last_prune) {
-                        break;
-                    }
+                    self.process_slot_tick(&mut last_prune);
                 }
                 WaitingStatus::Disconnected => {
                     break;
@@ -183,10 +164,8 @@ impl ConsensusWorker {
                     // A command was processed. If the slot deadline has already passed,
                     // run the overdue slot maintenance before waiting again so that a
                     // sustained flood of commands cannot starve time-driven work.
-                    if Instant::now() >= self.next_instant
-                        && !self.process_slot_tick(&mut last_prune)
-                    {
-                        break;
+                    if Instant::now() >= self.next_instant {
+                        self.process_slot_tick(&mut last_prune);
                     }
                 }
             };

--- a/massa-consensus-worker/src/worker/main_loop.rs
+++ b/massa-consensus-worker/src/worker/main_loop.rs
@@ -110,6 +110,60 @@ impl ConsensusWorker {
         (next_slot, next_instant)
     }
 
+    /// Performs all per-slot maintenance: episode-end check, cycle logging,
+    /// `slot_tick`, pruning, and advancing to the next slot.
+    ///
+    /// # Arguments
+    /// * `last_prune`: instant when the block DB was last pruned
+    ///
+    /// # Returns
+    /// `true` if the worker should keep running, `false` if the episode ended.
+    fn process_slot_tick(&mut self, last_prune: &mut Instant) -> bool {
+        if let Some(end) = self.config.end_timestamp {
+            // The testnet has ended. Will be removed for mainnet.
+            if self.next_instant > end.estimate_instant().unwrap() {
+                info!("This episode has come to an end, please get the latest testnet node version to continue");
+                let _ = self
+                    .shared_state
+                    .read()
+                    .channels
+                    .controller_event_tx
+                    .send(ConsensusEvent::Stop);
+                return false;
+            }
+        }
+        let previous_cycle = self
+            .previous_slot
+            .map(|s| s.get_cycle(self.config.periods_per_cycle));
+        let observed_cycle = self.next_slot.get_cycle(self.config.periods_per_cycle);
+        if previous_cycle.is_none() {
+            // first cycle observed
+            info!("Massa network has started ! 🎉")
+        }
+        if previous_cycle < Some(observed_cycle) {
+            info!("Started cycle {}", observed_cycle);
+        }
+        // Execute all operations and checks that should be performed at each slot
+        {
+            let mut write_shared_state = self.shared_state.write();
+            if let Err(err) = write_shared_state.slot_tick(self.next_slot) {
+                warn!("Error while processing block tick: {}", err);
+            }
+        };
+        if last_prune.elapsed().as_millis()
+            > self.config.block_db_prune_interval.as_millis() as u128
+        {
+            self.shared_state
+                .write()
+                .prune()
+                .expect("Error while pruning");
+            *last_prune = Instant::now();
+        }
+        self.previous_slot = Some(self.next_slot);
+        (self.next_slot, self.next_instant) = self.get_next_slot(Some(self.next_slot));
+        true
+    }
+
     /// Runs in loop forever. This loop must stop every slot to perform operations on stats and graph
     /// but can be stopped anytime by a command received.
     pub fn run(&mut self) {
@@ -118,54 +172,22 @@ impl ConsensusWorker {
             match self.wait_slot_or_command(self.next_instant) {
                 // When we reached the instant of the next slot
                 WaitingStatus::Ended => {
-                    if let Some(end) = self.config.end_timestamp {
-                        // The testnet has ended. Will be removed for mainnet.
-                        if self.next_instant > end.estimate_instant().unwrap() {
-                            info!("This episode has come to an end, please get the latest testnet node version to continue");
-                            let _ = self
-                                .shared_state
-                                .read()
-                                .channels
-                                .controller_event_tx
-                                .send(ConsensusEvent::Stop);
-                            break;
-                        }
+                    if !self.process_slot_tick(&mut last_prune) {
+                        break;
                     }
-                    let previous_cycle = self
-                        .previous_slot
-                        .map(|s| s.get_cycle(self.config.periods_per_cycle));
-                    let observed_cycle = self.next_slot.get_cycle(self.config.periods_per_cycle);
-                    if previous_cycle.is_none() {
-                        // first cycle observed
-                        info!("Massa network has started ! 🎉")
-                    }
-                    if previous_cycle < Some(observed_cycle) {
-                        info!("Started cycle {}", observed_cycle);
-                    }
-                    // Execute all operations and checks that should be performed at each slot
-                    {
-                        let mut write_shared_state = self.shared_state.write();
-                        if let Err(err) = write_shared_state.slot_tick(self.next_slot) {
-                            warn!("Error while processing block tick: {}", err);
-                        }
-                    };
-                    if last_prune.elapsed().as_millis()
-                        > self.config.block_db_prune_interval.as_millis() as u128
-                    {
-                        self.shared_state
-                            .write()
-                            .prune()
-                            .expect("Error while pruning");
-                        last_prune = Instant::now();
-                    }
-                    self.previous_slot = Some(self.next_slot);
-                    (self.next_slot, self.next_instant) = self.get_next_slot(Some(self.next_slot));
                 }
                 WaitingStatus::Disconnected => {
                     break;
                 }
                 WaitingStatus::Interrupted => {
-                    continue;
+                    // A command was processed. If the slot deadline has already passed,
+                    // run the overdue slot maintenance before waiting again so that a
+                    // sustained flood of commands cannot starve time-driven work.
+                    if Instant::now() >= self.next_instant
+                        && !self.process_slot_tick(&mut last_prune)
+                    {
+                        break;
+                    }
                 }
             };
         }

--- a/massa-protocol-worker/src/handlers/block_handler/propagation.rs
+++ b/massa-protocol-worker/src/handlers/block_handler/propagation.rs
@@ -68,6 +68,15 @@ pub struct PropagationThread {
 }
 
 impl PropagationThread {
+    /// Run one propagation tick: announce stored blocks to peers that need them
+    /// and advance the next tick deadline.
+    fn propagation_tick(&mut self, deadline: &mut Instant) {
+        self.perform_propagations();
+        *deadline = Instant::now()
+            .checked_add(self.config.block_propagation_tick.to_duration())
+            .expect("could not get time of next propagation tick");
+    }
+
     fn run(&mut self) {
         let tick_interval = self.config.block_propagation_tick.to_duration();
         let mut deadline = Instant::now()
@@ -93,6 +102,11 @@ impl PropagationThread {
                                         "claimed block {} absent from storage on propagation",
                                         block_id
                                     );
+                                    // Even on this error path, don't let a command flood
+                                    // starve the periodic propagation tick.
+                                    if Instant::now() >= deadline {
+                                        self.propagation_tick(&mut deadline);
+                                    }
                                     continue;
                                 }
                             };
@@ -142,12 +156,7 @@ impl PropagationThread {
                             );
 
                             // propagate everything that needs to be propagated
-                            self.perform_propagations();
-
-                            // renew tick because propagation propagations were updated
-                            deadline = Instant::now()
-                                .checked_add(tick_interval)
-                                .expect("could not get time of next propagation tick");
+                            self.propagation_tick(&mut deadline);
                         }
                         BlockHandlerPropagationCommand::AttackBlockDetected(block_id) => {
                             debug!("received AttackBlockDetected({})", block_id);
@@ -165,6 +174,15 @@ impl PropagationThread {
                             } else {
                                 self.ban_peers(&peers_to_ban);
                             }
+
+                            // `recv_deadline` returns immediately whenever a message is ready,
+                            // so a continuously non-empty channel would never let the timeout
+                            // branch below fire. Enforce the deadline here as well to make sure
+                            // periodic re-propagation to newly connected nodes keeps happening
+                            // under a constant flow of commands.
+                            if Instant::now() >= deadline {
+                                self.propagation_tick(&mut deadline);
+                            }
                         }
                         BlockHandlerPropagationCommand::Stop => {
                             info!("Stop block propagation thread");
@@ -174,11 +192,7 @@ impl PropagationThread {
                 }
                 Err(RecvTimeoutError::Timeout) => {
                     // Propagation tick. This is useful to quickly propagate headers to newly connected nodes.
-                    self.perform_propagations();
-                    // renew deadline of next tick
-                    deadline = Instant::now()
-                        .checked_add(tick_interval)
-                        .expect("could not get time of next propagation tick");
+                    self.propagation_tick(&mut deadline);
                 }
                 Err(RecvTimeoutError::Disconnected) => {
                     info!("Stop block propagation thread");


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification