### PR TITLE
[F20] feat: cap consensus bootstrap client cursor on reconnect

### DIFF
--- a/massa-bootstrap/src/client.rs
+++ b/massa-bootstrap/src/client.rs
@@ -1,11 +1,12 @@
 use humantime::format_duration;
+use massa_consensus_exports::bootstrapable_graph::BootstrapableGraph;
 use massa_db_exports::DBBatch;
 use massa_final_state::{FinalStateController, FinalStateError};
 use massa_logging::massa_trace;
 use massa_metrics::MassaMetrics;
 use massa_models::{
-    node::NodeId, slot::Slot, streaming_step::StreamingStep, timeslots::get_block_slot_timestamp,
-    version::Version,
+    block_id::BlockId, node::NodeId, prehash::PreHashSet, slot::Slot,
+    streaming_step::StreamingStep, timeslots::get_block_slot_timestamp, version::Version,
 };
 use massa_signature::PublicKey;
 use massa_time::MassaTime;
@@ -68,12 +69,18 @@ impl BSConnector for DefaultConnector {
 /// This function will send the starting point to receive a stream of the ledger and will receive and process each part until receive a `BootstrapServerMessage::FinalStateFinished` message from the server.
 /// `next_bootstrap_message` passed as parameter must be `BootstrapClientMessage::AskFinalStatePart` enum variant.
 /// `next_bootstrap_message` will be updated after receiving each part so that in case of connection lost we can restart from the last message we processed.
+///
+/// The consensus reconnect cursor is capped to `max_consensus_block_ids` (newest finals by slot).
+/// The full graph is kept while streaming; on the next attempt it is pruned to the ids we claim
+/// so dropped finals can be re-downloaded.
 pub(crate) fn stream_final_state_and_consensus(
     cfg: &BootstrapConfig,
     client: &mut BootstrapClientBinder,
     next_bootstrap_message: &mut BootstrapClientMessage,
     global_bootstrap_state: &mut GlobalBootstrapState,
 ) -> Result<(), BootstrapError> {
+    align_consensus_resume_state_before_ask(next_bootstrap_message, global_bootstrap_state);
+
     if let BootstrapClientMessage::AskBootstrapPart {
         send_last_start_period: false,
         ..
@@ -151,16 +158,11 @@ pub(crate) fn stream_final_state_and_consensus(
                     } else {
                         global_bootstrap_state.graph = Some(consensus_part);
                     }
-                    let last_consensus_step = StreamingStep::Ongoing(
-                        // Note that this unwrap call is safe because of the above conditional statement
-                        global_bootstrap_state
-                            .graph
-                            .as_ref()
-                            .unwrap()
-                            .final_blocks
-                            .iter()
-                            .map(|b_export| b_export.block.id)
-                            .collect(),
+
+                    // Cap the reconnect ask only; keep the full in-session graph.
+                    let last_consensus_step = capped_consensus_resume_step(
+                        global_bootstrap_state.graph.as_ref(),
+                        cfg.max_consensus_block_ids as usize,
                     );
 
                     // Set new message in case of disconnection
@@ -835,10 +837,95 @@ fn warn_user_about_versioning_updates(updated: Vec<MipInfo>, added: BTreeMap<Mip
     debug!("MIP store got {} MIP updated from bootstrap", updated.len());
 }
 
+fn align_consensus_resume_state_before_ask(
+    next_bootstrap_message: &mut BootstrapClientMessage,
+    global_bootstrap_state: &mut GlobalBootstrapState,
+) {
+    let mut must_restart_consensus = false;
+    if let BootstrapClientMessage::AskBootstrapPart {
+        last_consensus_step: StreamingStep::Ongoing(ids),
+        ..
+    } = next_bootstrap_message
+    {
+        if let Some(graph) = global_bootstrap_state.graph.as_mut() {
+            graph
+                .final_blocks
+                .retain(|block_export| ids.contains(&block_export.block.id));
+            ids.clear();
+            ids.extend(
+                graph
+                    .final_blocks
+                    .iter()
+                    .map(|block_export| block_export.block.id),
+            );
+            if graph.final_blocks.is_empty() {
+                global_bootstrap_state.graph = None;
+            }
+        } else {
+            ids.clear();
+        }
+        must_restart_consensus = ids.is_empty();
+    }
+    if must_restart_consensus {
+        if let BootstrapClientMessage::AskBootstrapPart {
+            last_consensus_step,
+            ..
+        } = next_bootstrap_message
+        {
+            *last_consensus_step = StreamingStep::Started;
+        }
+    }
+}
+
+fn capped_consensus_resume_step(
+    graph: Option<&BootstrapableGraph>,
+    max_ids: usize,
+) -> StreamingStep<PreHashSet<BlockId>> {
+    let Some(graph) = graph else {
+        return StreamingStep::Started;
+    };
+    let ids = capped_consensus_cursor_ids(graph, max_ids);
+    if ids.is_empty() {
+        StreamingStep::Started
+    } else {
+        StreamingStep::Ongoing(ids)
+    }
+}
+
+/// Ids for the reconnect ask: all finals if under the cap, otherwise the newest `max_ids` by slot.
+fn capped_consensus_cursor_ids(graph: &BootstrapableGraph, max_ids: usize) -> PreHashSet<BlockId> {
+    if max_ids == 0 || graph.final_blocks.is_empty() {
+        return PreHashSet::default();
+    }
+    if graph.final_blocks.len() <= max_ids {
+        return graph
+            .final_blocks
+            .iter()
+            .map(|block_export| block_export.block.id)
+            .collect();
+    }
+    let mut ordered: Vec<_> = graph
+        .final_blocks
+        .iter()
+        .map(|block_export| {
+            (
+                block_export.block.content.header.content.slot,
+                block_export.block.id,
+            )
+        })
+        .collect();
+    ordered.sort_unstable_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    ordered[ordered.len() - max_ids..]
+        .iter()
+        .map(|(_, id)| *id)
+        .collect()
+}
+
 #[cfg(test)]
 mod restart_metadata_tests {
     use super::*;
-    use crate::tests::tools::get_bootstrap_config;
+    use crate::tests::tools::{gen_export_active_blocks, get_bootstrap_config};
+    use massa_consensus_exports::bootstrapable_graph::BootstrapableGraph;
     use massa_signature::KeyPair;
 
     fn config() -> BootstrapConfig {
@@ -882,6 +969,78 @@ mod restart_metadata_tests {
                     "accepted {:?} / {:?}",
                     last_start_period, last_slot_before_downtime
                 ));
+        }
+    }
+
+    #[test]
+    fn capped_consensus_cursor_returns_started_when_empty() {
+        assert_eq!(
+            capped_consensus_resume_step(None, 10),
+            StreamingStep::Started
+        );
+        let graph = BootstrapableGraph {
+            final_blocks: vec![],
+        };
+        assert_eq!(
+            capped_consensus_resume_step(Some(&graph), 10),
+            StreamingStep::Started
+        );
+    }
+
+    #[test]
+    fn capped_consensus_cursor_is_bounded() {
+        let mut rng = rand::thread_rng();
+        let graph = BootstrapableGraph {
+            final_blocks: (0..10)
+                .map(|_| gen_export_active_blocks(&mut rng))
+                .collect(),
+        };
+        match capped_consensus_resume_step(Some(&graph), 3) {
+            StreamingStep::Ongoing(ids) => assert_eq!(ids.len(), 3),
+            other => panic!("expected Ongoing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn align_reconnect_cursor_prunes_graph_to_claimed_ids() {
+        let mut rng = rand::thread_rng();
+        let blocks: Vec<_> = (0..8).map(|_| gen_export_active_blocks(&mut rng)).collect();
+        let claimed: PreHashSet<_> = blocks
+            .iter()
+            .take(3)
+            .map(|block_export| block_export.block.id)
+            .collect();
+
+        let mut state = GlobalBootstrapState {
+            final_state: Arc::new(RwLock::new(
+                massa_final_state::MockFinalStateController::new(),
+            )),
+            graph: Some(BootstrapableGraph {
+                final_blocks: blocks,
+            }),
+            peers: None,
+        };
+        let mut msg = BootstrapClientMessage::AskBootstrapPart {
+            last_slot: Some(Slot::new(1, 0)),
+            last_state_step: StreamingStep::Ongoing(vec![0]),
+            last_versioning_step: StreamingStep::Ongoing(vec![0]),
+            last_consensus_step: StreamingStep::Ongoing(claimed.clone()),
+            send_last_start_period: false,
+        };
+
+        align_consensus_resume_state_before_ask(&mut msg, &mut state);
+
+        let graph = state.graph.expect("graph should remain");
+        assert_eq!(graph.final_blocks.len(), claimed.len());
+        for b in &graph.final_blocks {
+            assert!(claimed.contains(&b.block.id));
+        }
+        match msg {
+            BootstrapClientMessage::AskBootstrapPart {
+                last_consensus_step: StreamingStep::Ongoing(ids),
+                ..
+            } => assert_eq!(ids, claimed),
+            other => panic!("unexpected message {other:?}"),
         }
     }
 }

--- a/massa-models/src/config/constants.rs
+++ b/massa-models/src/config/constants.rs
@@ -209,7 +209,8 @@ pub const POS_SAVED_CYCLES: usize = 7;
 pub const SELECTOR_DRAW_CACHE_SIZE: usize = 6;
 /// Maximum number of consensus blocks in a bootstrap batch
 pub const CONSENSUS_BOOTSTRAP_PART_SIZE: u64 = 50;
-/// Maximum number of consensus block ids when sending a bootstrap cursor from the client
+/// Max block ids in the client consensus reconnect ask. Larger local graphs are fine in-session;
+/// only the ask is capped (newest finals), and the graph is pruned to match on reconnect.
 pub const MAX_CONSENSUS_BLOCKS_IDS: u64 = 300;
 /// Maximum size of proof-of-stake rolls
 pub const MAX_ROLLS_COUNT_LENGTH: u64 = 10_000;


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

In order to avoid a breaking bootstrap behaviour and simplify the design, I chose to cap and truncate reconnect asks.
This means everything stays the same (client sends `StreamingStep::Ongoing(PreHashSet<BlockId>)` on reconnect), but:
- the cursor size is capped at `MAX_CONSENSUS_BLOCKS_IDS`.
- If it exceeds that value, the graph is pruned (dropping oldest slots).