### PR TITLE
[F30] fix(consensus-worker): preserve side-effect queues on downstrea…

### DIFF
--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -20,7 +20,7 @@ use massa_models::{
 use massa_signature::PublicKey;
 use massa_storage::Storage;
 use massa_time::MassaTime;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::state::{
     clique_computation::compute_max_cliques,
@@ -709,6 +709,27 @@ impl ConsensusState {
     /// 9. notify protocol of block wish list
     /// 10. note new latest final periods (prune graph if changed)
     /// 11. add stale blocks to stats
+    ///
+    /// Delivery to protocol (`integrated_block`, `notify_block_attack`) is best effort: both go
+    /// through `try_send` on the bounded block propagation channel and fail when it is full. On
+    /// failure we neither block nor add a retry queue, and this is deliberate:
+    ///
+    /// - blocking would stall the consensus worker on a saturated protocol, and the first casualty
+    ///   would be the propagation of the block we just produced ourselves, precisely when the node
+    ///   is already struggling;
+    /// - a dedicated retry queue would duplicate state that already exists: on failure the items
+    ///   simply stay in the pending sets they were drained from (`to_propagate`,
+    ///   `attack_attempts`) and are retried at the next `block_db_changed`, i.e. the next consensus
+    ///   command or slot tick.
+    ///
+    /// No per-item expiry is needed either, because the failure is channel-level rather than
+    /// per-item: it says nothing about the block being sent, so everything flushes as soon as
+    /// protocol drains. A closed channel means the block handler is gone and the node is shutting
+    /// down anyway. Growth while protocol stays saturated is bounded by the block integration
+    /// rate: `to_propagate` is keyed by block id, so re-inserting the same block is idempotent,
+    /// and `Storage` is a refcounted handle rather than a copy of the block. Channel saturation is
+    /// visible through the `blocks_propagation_ext_channel_actual_size` metric, and the size of
+    /// the pending sets is logged on each failure.
     pub fn block_db_changed(&mut self) -> Result<(), ConsensusError> {
         massa_trace!("consensus.consensus_worker.block_db_changed", {});
 
@@ -727,6 +748,7 @@ impl ConsensusState {
                 .protocol_controller
                 .integrated_block(block_id, storage.clone())
             {
+                // keeping the undelivered items pending is intended, see the note on this method
                 self.to_propagate.insert(block_id, storage);
                 propagate_error = Some(e);
                 break;
@@ -736,6 +758,11 @@ impl ConsensusState {
             self.to_propagate.insert(block_id, storage);
         }
         if let Some(e) = propagate_error {
+            warn!(
+                "error propagating blocks to protocol: {}. {} block(s) kept pending for retry.",
+                e,
+                self.to_propagate.len()
+            );
             return Err(e.into());
         }
 
@@ -745,6 +772,7 @@ impl ConsensusState {
         let mut attack_error = None;
         while let Some(hash) = attack_attempts.pop() {
             if let Err(e) = self.channels.protocol_controller.notify_block_attack(hash) {
+                // keeping the undelivered items pending is intended, see the note on this method
                 attack_attempts.push(hash);
                 attack_error = Some(e);
                 break;
@@ -755,6 +783,11 @@ impl ConsensusState {
         }
         self.attack_attempts.extend(attack_attempts);
         if let Some(e) = attack_error {
+            warn!(
+                "error notifying protocol of attack attempts: {}. {} attempt(s) kept pending for retry.",
+                e,
+                self.attack_attempts.len()
+            );
             return Err(e.into());
         }
 
@@ -779,12 +812,7 @@ impl ConsensusState {
                 ));
             }
         }
-        // add stale blocks to stats
-        let timestamp = MassaTime::now();
-        let mut stale_block_stats = VecDeque::with_capacity(self.new_stale_blocks.len());
-        for _ in 0..self.new_stale_blocks.len() {
-            stale_block_stats.push_back(timestamp);
-        }
+        let stale_block_count = self.new_stale_blocks.len();
 
         // notify execution
         self.notify_execution(final_block_slots);
@@ -793,7 +821,9 @@ impl ConsensusState {
         self.new_final_blocks.clear();
         self.new_stale_blocks.clear();
         self.final_block_stats.extend(final_block_stats);
-        self.stale_block_stats.extend(stale_block_stats);
+        // add stale blocks to stats
+        self.stale_block_stats
+            .extend((0..stale_block_count).map(|_| timestamp));
 
         // notify protocol of block wishlist
         let new_wishlist = self.get_block_wishlist()?;

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
-    mem,
-};
+use std::collections::{BTreeSet, HashMap, VecDeque};
 
 use massa_consensus_exports::{
     block_status::{BlockStatus, DiscardReason, HeaderOrBlock, StorageOrBlock},
@@ -713,64 +710,90 @@ impl ConsensusState {
     /// 10. note new latest final periods (prune graph if changed)
     /// 11. add stale blocks to stats
     pub fn block_db_changed(&mut self) -> Result<(), ConsensusError> {
-        let final_block_slots = {
-            massa_trace!("consensus.consensus_worker.block_db_changed", {});
+        massa_trace!("consensus.consensus_worker.block_db_changed", {});
 
-            // Propagate new blocks
-            for (block_id, storage) in mem::take(&mut self.to_propagate).into_iter() {
-                massa_trace!("consensus.consensus_worker.block_db_changed.integrated", {
-                    "block_id": block_id
-                });
-                self.channels
-                    .protocol_controller
-                    .integrated_block(block_id, storage)?;
+        // Propagate new blocks incrementally. If a downstream call fails, restore
+        // the unprocessed items so they can be retried on the next call instead
+        // of being silently lost.
+        let mut to_propagate: Vec<(BlockId, Storage)> =
+            std::mem::take(&mut self.to_propagate).into_iter().collect();
+        let mut propagate_error = None;
+        while let Some((block_id, storage)) = to_propagate.pop() {
+            massa_trace!("consensus.consensus_worker.block_db_changed.integrated", {
+                "block_id": block_id
+            });
+            if let Err(e) = self
+                .channels
+                .protocol_controller
+                .integrated_block(block_id, storage.clone())
+            {
+                self.to_propagate.insert(block_id, storage);
+                propagate_error = Some(e);
+                break;
             }
+        }
+        for (block_id, storage) in to_propagate {
+            self.to_propagate.insert(block_id, storage);
+        }
+        if let Some(e) = propagate_error {
+            return Err(e.into());
+        }
 
-            // Notify protocol of attack attempts.
-            for hash in mem::take(&mut self.attack_attempts).into_iter() {
-                self.channels
-                    .protocol_controller
-                    .notify_block_attack(hash)?;
-                massa_trace!("consensus.consensus_worker.block_db_changed.attack", {
-                    "hash": hash
-                });
+        // Notify protocol of attack attempts incrementally, preserving unprocessed
+        // items on failure so they are retried later.
+        let mut attack_attempts = std::mem::take(&mut self.attack_attempts);
+        let mut attack_error = None;
+        while let Some(hash) = attack_attempts.pop() {
+            if let Err(e) = self.channels.protocol_controller.notify_block_attack(hash) {
+                attack_attempts.push(hash);
+                attack_error = Some(e);
+                break;
             }
+            massa_trace!("consensus.consensus_worker.block_db_changed.attack", {
+                "hash": hash
+            });
+        }
+        self.attack_attempts.extend(attack_attempts);
+        if let Some(e) = attack_error {
+            return Err(e.into());
+        }
 
-            // manage finalized blocks
-            let timestamp = MassaTime::now();
-            let finalized_blocks = mem::take(&mut self.new_final_blocks);
-            let mut final_block_slots = HashMap::with_capacity(finalized_blocks.len());
-            let mut final_block_stats = VecDeque::with_capacity(finalized_blocks.len());
-            for b_id in finalized_blocks {
-                if let Some(BlockStatus::Active { a_block, .. }) = self.blocks_state.get(&b_id) {
-                    // add to final blocks to notify execution
-                    final_block_slots.insert(a_block.slot, b_id);
+        // manage finalized blocks
+        let timestamp = MassaTime::now();
+        let mut final_block_slots = HashMap::with_capacity(self.new_final_blocks.len());
+        let mut final_block_stats = VecDeque::with_capacity(self.new_final_blocks.len());
+        for b_id in &self.new_final_blocks {
+            if let Some(BlockStatus::Active { a_block, .. }) = self.blocks_state.get(b_id) {
+                // add to final blocks to notify execution
+                final_block_slots.insert(a_block.slot, *b_id);
 
-                    // add to stats
-                    let block_is_from_protocol = self
-                        .protocol_blocks
-                        .iter()
-                        .any(|(_, block_id)| block_id == &b_id);
-                    final_block_stats.push_back((
-                        timestamp,
-                        a_block.creator_address,
-                        block_is_from_protocol,
-                    ));
-                }
+                // add to stats
+                let block_is_from_protocol = self
+                    .protocol_blocks
+                    .iter()
+                    .any(|(_, block_id)| block_id == b_id);
+                final_block_stats.push_back((
+                    timestamp,
+                    a_block.creator_address,
+                    block_is_from_protocol,
+                ));
             }
-            self.final_block_stats.extend(final_block_stats);
-
-            // add stale blocks to stats
-            let new_stale_block_ids_creators_slots = mem::take(&mut self.new_stale_blocks);
-            let timestamp = MassaTime::now();
-            for (_b_id, (_b_creator, _b_slot)) in new_stale_block_ids_creators_slots.into_iter() {
-                self.stale_block_stats.push_back(timestamp);
-            }
-            final_block_slots
-        };
+        }
+        // add stale blocks to stats
+        let timestamp = MassaTime::now();
+        let mut stale_block_stats = VecDeque::with_capacity(self.new_stale_blocks.len());
+        for _ in 0..self.new_stale_blocks.len() {
+            stale_block_stats.push_back(timestamp);
+        }
 
         // notify execution
         self.notify_execution(final_block_slots);
+
+        // Downstream delivery confirmed: drain notification queues and commit stats.
+        self.new_final_blocks.clear();
+        self.new_stale_blocks.clear();
+        self.final_block_stats.extend(final_block_stats);
+        self.stale_block_stats.extend(stale_block_stats);
 
         // notify protocol of block wishlist
         let new_wishlist = self.get_block_wishlist()?;

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -812,18 +812,17 @@ impl ConsensusState {
                 ));
             }
         }
-        let stale_block_count = self.new_stale_blocks.len();
 
         // notify execution
         self.notify_execution(final_block_slots);
 
-        // Downstream delivery confirmed: drain notification queues and commit stats.
-        self.new_final_blocks.clear();
-        self.new_stale_blocks.clear();
+        // Downstream delivery confirmed: commit stats and drain notification queues.
         self.final_block_stats.extend(final_block_stats);
         // add stale blocks to stats
         self.stale_block_stats
-            .extend((0..stale_block_count).map(|_| timestamp));
+            .extend((0..self.new_stale_blocks.len()).map(|_| timestamp));
+        self.new_final_blocks.clear();
+        self.new_stale_blocks.clear();
 
         // notify protocol of block wishlist
         let new_wishlist = self.get_block_wishlist()?;

--- a/massa-consensus-worker/src/worker/main_loop.rs
+++ b/massa-consensus-worker/src/worker/main_loop.rs
@@ -132,6 +132,9 @@ impl ConsensusWorker {
             let mut write_shared_state = self.shared_state.write();
             if let Err(err) = write_shared_state.slot_tick(self.next_slot) {
                 warn!("Error while processing block tick: {}", err);
+                // Do not advance to the next slot while the tick failed, so that
+                // consensus cannot move forward with undelivered side effects.
+                return;
             }
         };
         if last_prune.elapsed().as_millis()

--- a/massa-consensus-worker/src/worker/main_loop.rs
+++ b/massa-consensus-worker/src/worker/main_loop.rs
@@ -132,9 +132,10 @@ impl ConsensusWorker {
             let mut write_shared_state = self.shared_state.write();
             if let Err(err) = write_shared_state.slot_tick(self.next_slot) {
                 warn!("Error while processing block tick: {}", err);
-                // Do not advance to the next slot while the tick failed, so that
-                // consensus cannot move forward with undelivered side effects.
-                return;
+                // Side effects are preserved in `to_propagate`, `attack_attempts`,
+                // `new_final_blocks` and `new_stale_blocks`, so they will be
+                // retried on the next tick. Keep advancing slots to avoid
+                // halting consensus while downstream is under transient pressure.
             }
         };
         if last_prune.elapsed().as_millis()


### PR DESCRIPTION
…m failure and stop slot advancement on tick errors

### Problem

`ConsensusState::block_db_changed` drained its pending side-effect queues with `mem::take` and then propagated them with `?`:

```rust
for (block_id, storage) in mem::take(&mut self.to_propagate).into_iter() {
    self.channels.protocol_controller.integrated_block(block_id, storage)?;
}
```

The queues were emptied *before* the sends. `integrated_block` and `notify_block_attack` are `try_send` on a bounded channel, so they fail as soon as protocol is saturated — and the `?` then returned with **the entire remaining batch already gone**. One full channel dropped every pending item, including, potentially, the propagation of our own freshly produced block. The same shape applied to `new_final_blocks` / `new_stale_blocks`, which were taken before `notify_execution`.

Because the failure is channel-level rather than per-item, the dropped blocks were not retried anywhere: they were simply never propagated.

### Fix

**Drain incrementally, keep what wasn't delivered.** Each queue is processed item by item; on the first send failure the failed item and everything still unprocessed are put back into the pending set, and the error is returned:

```rust
let mut to_propagate: Vec<(BlockId, Storage)> =
    std::mem::take(&mut self.to_propagate).into_iter().collect();
let mut propagate_error = None;
while let Some((block_id, storage)) = to_propagate.pop() {
    if let Err(e) = self
        .channels
        .protocol_controller
        .integrated_block(block_id, storage.clone())
    {
        self.to_propagate.insert(block_id, storage);
        propagate_error = Some(e);
        break;
    }
}
for (block_id, storage) in to_propagate {
    self.to_propagate.insert(block_id, storage);
}
```

Same treatment for `attack_attempts`. `new_final_blocks` / `new_stale_blocks` are now only cleared *after* `notify_execution` has actually run.

**Keep advancing slots on tick errors.** The first iteration of this fix also stopped slot advancement when `slot_tick` returned an error. That was wrong — halting consensus is far worse than a delayed propagation, and it is unnecessary once the side effects survive the failure. The main loop logs and moves on:

```rust
if let Err(err) = write_shared_state.slot_tick(self.next_slot) {
    warn!("Error while processing block tick: {}", err);
    // Side effects are preserved in `to_propagate`, `attack_attempts`,
    // `new_final_blocks` and `new_stale_blocks`, so they will be
    // retried on the next tick. Keep advancing slots to avoid
    // halting consensus while downstream is under transient pressure.
}
```

### Design: no blocking, no retry queue

The delivery policy is deliberately **best effort**, and is now stated in the `block_db_changed` doc comment:

- the calls stay `try_send`, we never block the consensus worker on a saturated protocol channel;
- **no new retry queue** is introduced — the items stay in the pending sets they already lived in (`to_propagate`, `attack_attempts`) and are retried at the next `block_db_changed`, i.e. the next consensus command or slot tick;
- the failure is channel-level, not per-item, so nothing needs per-item expiry: everything flushes as soon as protocol drains. A closed channel means the block handler is gone and the node is shutting down anyway;
- growth is bounded by the block integration rate for as long as protocol stays saturated. `to_propagate` is a `PreHashMap<BlockId, Storage>`, so re-inserting the same block is idempotent, and `Storage` is a refcounted handle rather than a copy of the block.

### Observability

Both failure paths now `warn!` with the size of the pending set, so a lasting protocol saturation shows up in the logs instead of being a bare `ConsensusError` with no size information:

```
error propagating blocks to protocol: {e}. {n} block(s) kept pending for retry.
error notifying protocol of attack attempts: {e}. {n} attempt(s) kept pending for retry.
```

An F62-style `MassaMetrics` gauge was considered and left out as out of scope for this fix.

### Drive-by cleanup

The intermediate `VecDeque<MassaTime>` built for the stale-block stats (pre-existing, not introduced here) is gone, along with a redundant second `MassaTime::now()`. The count is captured before the queue is cleared:

```rust
let stale_block_count = self.new_stale_blocks.len();
// ...
self.stale_block_stats
    .extend((0..stale_block_count).map(|_| timestamp));
```

### Known trade-off

`integrated_block` takes `storage: Storage` **by value** and the implementation discards it on failure (`try_send(...).map_err(|_| ProtocolError::ChannelError(...))` throws away the `TrySendError` that still owns the command). To be able to re-insert into `to_propagate` on error we must still own a handle at call time, hence the `storage.clone()` before the call — a happy-path cost that `Storage::clone` does not make entirely free, since it takes write locks on the op/block/endorsement owner maps (`massa-storage/src/lib.rs:65`).

Removing it means changing the trait to take `&Storage`, or having `integrated_block` hand the storage back on error. Both ripple through every implementation and the mocks, so they are left for a follow-up rather than widening this PR.

### Scope

Not consensus-observable: no change to block validity rules, serialization, hashing, final-state or ledger hash, VM semantics, or PoS draws. This only changes *when* already-valid blocks are handed to protocol locally, and the retry is invisible to peers. **No MIP gating required.** No public API surface changes — JSON-RPC and gRPC are untouched.