### PR TITLE
[F26] fix(consensus-worker): preserve pruned future/dep-waiting block…

### DIFF
--- a/massa-consensus-worker/src/state/process_commands.rs
+++ b/massa-consensus-worker/src/state/process_commands.rs
@@ -148,14 +148,19 @@ impl ConsensusState {
         self.maybe_note_attack_attempt(&reason, block_id);
         massa_trace!("consensus.block_graph.process.invalid_block", {"block_id": block_id, "reason": reason});
         let sequence_number = self.blocks_state.sequence_counter();
-        self.blocks_state.transition_map(block_id, |_, _| {
-            Some(BlockStatus::Discarded {
-                slot: header.content.slot,
-                creator: header.content_creator_address,
-                parents: header.content.parents,
-                reason,
-                sequence_number,
-            })
-        });
+        self.blocks_state
+            .transition_map(block_id, |block_status, _| {
+                // If the block has already been pruned from consensus, there is nothing
+                // left to mark invalid. Avoid a None -> Discarded panic by treating it as
+                // a no-op; the attack attempt was already recorded above.
+                block_status.as_ref()?;
+                Some(BlockStatus::Discarded {
+                    slot: header.content.slot,
+                    creator: header.content_creator_address,
+                    parents: header.content.parents,
+                    reason,
+                    sequence_number,
+                })
+            });
     }
 }

--- a/massa-consensus-worker/src/state/process_commands.rs
+++ b/massa-consensus-worker/src/state/process_commands.rs
@@ -150,9 +150,11 @@ impl ConsensusState {
         let sequence_number = self.blocks_state.sequence_counter();
         self.blocks_state
             .transition_map(block_id, |block_status, _| {
-                // If the block has already been pruned from consensus, there is nothing
-                // left to mark invalid. Avoid a None -> Discarded panic by treating it as
-                // a no-op; the attack attempt was already recorded above.
+                // The block may be unknown to consensus: a wishlisted parent is never inserted in
+                // `blocks_state` until its full block arrives, but protocol can decide it is invalid
+                // before that (committed ops exceed the max block size). `None -> Discarded` is a
+                // forbidden transition (panic), so do nothing: the attack attempt is already noted
+                // above, and the waiters depending on it will be pruned as stale.
                 block_status.as_ref()?;
                 Some(BlockStatus::Discarded {
                     slot: header.content.slot,

--- a/massa-consensus-worker/src/state/prune.rs
+++ b/massa-consensus-worker/src/state/prune.rs
@@ -104,7 +104,8 @@ impl ConsensusState {
     }
 
     // Keep only a certain (`config.max_future_processing_blocks`) number of blocks that have slots in the future
-    // to avoid high memory consumption
+    // to avoid high memory consumption. Over-limit entries are preserved as `Discarded` rather than
+    // silently removed, so protocol-side `checked_headers` stays aligned with consensus state.
     fn prune_slot_waiting(&mut self) {
         if self.blocks_state.waiting_for_slot_blocks().len()
             <= self.config.max_future_processing_blocks
@@ -128,7 +129,32 @@ impl ConsensusState {
         let len_slot_waiting = slot_waiting.len();
         (self.config.max_future_processing_blocks..len_slot_waiting).for_each(|idx| {
             let (_slot, block_id) = &slot_waiting[idx];
-            self.blocks_state.transition_map(block_id, |_, _| None);
+            let sequence_number = self.blocks_state.sequence_counter();
+            self.blocks_state
+                .transition_map(block_id, |block_status, _| {
+                    if let Some(BlockStatus::WaitingForSlot(header_or_block)) = block_status {
+                        let header = match header_or_block {
+                            HeaderOrBlock::Header(h) => h,
+                            HeaderOrBlock::Block { id, .. } => self
+                                .storage
+                                .read_blocks()
+                                .get(&id)
+                                .unwrap_or_else(|| panic!("block {} should be in storage", id))
+                                .content
+                                .header
+                                .clone(),
+                        };
+                        Some(BlockStatus::Discarded {
+                            slot: header.content.slot,
+                            creator: header.content_creator_address,
+                            parents: header.content.parents,
+                            reason: DiscardReason::Stale,
+                            sequence_number,
+                        })
+                    } else {
+                        panic!("block {} should be in WaitingForSlot state", block_id);
+                    }
+                });
         });
     }
 
@@ -267,7 +293,8 @@ impl ConsensusState {
                     .min();
                 if let Some((_seq_num, _slot, hash)) = remove_elt {
                     to_keep.remove(&hash);
-                    to_discard.insert(hash, None);
+                    // Preserve the over-limit entry as discarded instead of silently deleting it.
+                    to_discard.insert(hash, Some(DiscardReason::Stale));
                     continue;
                 }
             }

--- a/massa-consensus-worker/src/state/prune.rs
+++ b/massa-consensus-worker/src/state/prune.rs
@@ -189,7 +189,7 @@ impl ConsensusState {
     }
 
     fn prune_waiting_for_dependencies(&mut self) -> Result<(), ConsensusError> {
-        let mut to_discard: PreHashMap<BlockId, Option<DiscardReason>> = PreHashMap::default();
+        let mut to_discard: PreHashMap<BlockId, DiscardReason> = PreHashMap::default();
         let mut to_keep: PreHashMap<BlockId, (u64, Slot)> = PreHashMap::default();
 
         // list items that are older than the latest final blocks in their threads or have deps that are discarded
@@ -220,14 +220,17 @@ impl ConsensusState {
                         }
                     }
                     if discarded_dep_found {
-                        to_discard.insert(*block_id, discard_reason);
+                        // A discarded dependency always yields a reason (Invalid or Stale).
+                        let reason = discard_reason
+                            .expect("discarded dependency should produce a discard reason");
+                        to_discard.insert(*block_id, reason);
                         continue;
                     }
 
                     // is at least as old as the latest final block in its thread => discard as stale
                     let slot = header_or_block.get_slot();
                     if slot.period <= self.latest_final_blocks_periods[slot.thread as usize].1 {
-                        to_discard.insert(*block_id, Some(DiscardReason::Stale));
+                        to_discard.insert(*block_id, DiscardReason::Stale);
                         continue;
                     }
 
@@ -253,23 +256,21 @@ impl ConsensusState {
                         if let Some(reason) = to_discard.get(dep) {
                             dep_to_discard_found = true;
                             match reason {
-                                Some(DiscardReason::Invalid(reason)) => {
+                                DiscardReason::Invalid(reason) => {
                                     discard_reason = Some(DiscardReason::Invalid(format!("discarded because depend on block:{} that has discard reason:{}", hash, reason)));
                                     break;
                                 }
-                                Some(DiscardReason::Stale) => {
-                                    discard_reason = Some(DiscardReason::Stale)
-                                }
-                                Some(DiscardReason::Final) => {
-                                    discard_reason = Some(DiscardReason::Stale)
-                                }
-                                None => {} // leave as None
+                                DiscardReason::Stale => discard_reason = Some(DiscardReason::Stale),
+                                DiscardReason::Final => discard_reason = Some(DiscardReason::Stale),
                             }
                         }
                     }
                     if dep_to_discard_found {
+                        // A dependency queued for discard always has a reason.
+                        let reason = discard_reason
+                            .expect("dependency queued for discard should have a reason");
                         to_keep.remove(&hash);
-                        to_discard.insert(hash, discard_reason);
+                        to_discard.insert(hash, reason);
                         continue;
                     }
                 }
@@ -294,7 +295,7 @@ impl ConsensusState {
                 if let Some((_seq_num, _slot, hash)) = remove_elt {
                     to_keep.remove(&hash);
                     // Preserve the over-limit entry as discarded instead of silently deleting it.
-                    to_discard.insert(hash, Some(DiscardReason::Stale));
+                    to_discard.insert(hash, DiscardReason::Stale);
                     continue;
                 }
             }
@@ -303,8 +304,8 @@ impl ConsensusState {
             break;
         }
 
-        // transition states to Discarded if there is a reason, otherwise just drop
-        for (block_id, reason_opt) in to_discard.drain() {
+        // transition states to Discarded (every entry in to_discard now has a reason)
+        for (block_id, reason) in to_discard.drain() {
             let sequence_number = self.blocks_state.sequence_counter();
             self.blocks_state.transition_map(&block_id, |block_status, _| {
                 if let Some(BlockStatus::WaitingForDependencies {
@@ -321,27 +322,21 @@ impl ConsensusState {
                             .header
                             .clone()
                     };
-                    massa_trace!("consensus.block_graph.prune_waiting_for_dependencies", {"hash": block_id, "reason": reason_opt});
-                    if let Some(reason) = reason_opt {
-                        // add to stats if reason is Stale
-                        if reason == DiscardReason::Stale {
-                            self.new_stale_blocks.insert(
-                                block_id,
-                                (header.content_creator_address, header.content.slot),
-                            );
-                        }
-                        // transition to Discarded only if there is a reason
-                        Some(BlockStatus::Discarded {
-                                slot: header.content.slot,
-                                creator: header.content_creator_address,
-                                parents: header.content.parents,
-                                reason,
-                                sequence_number,
-                            },
-                        )
-                    } else {
-                        None
+                    massa_trace!("consensus.block_graph.prune_waiting_for_dependencies", {"hash": block_id, "reason": reason});
+                    // add to stats if reason is Stale
+                    if reason == DiscardReason::Stale {
+                        self.new_stale_blocks.insert(
+                            block_id,
+                            (header.content_creator_address, header.content.slot),
+                        );
                     }
+                    Some(BlockStatus::Discarded {
+                        slot: header.content.slot,
+                        creator: header.content_creator_address,
+                        parents: header.content.parents,
+                        reason,
+                        sequence_number,
+                    })
                 } else {
                     panic!("block {} should be in WaitingForDependencies state", block_id);
                 }

--- a/massa-consensus-worker/src/state/prune.rs
+++ b/massa-consensus-worker/src/state/prune.rs
@@ -104,8 +104,7 @@ impl ConsensusState {
     }
 
     // Keep only a certain (`config.max_future_processing_blocks`) number of blocks that have slots in the future
-    // to avoid high memory consumption. Over-limit entries are preserved as `Discarded` rather than
-    // silently removed, so protocol-side `checked_headers` stays aligned with consensus state.
+    // to avoid high memory consumption
     fn prune_slot_waiting(&mut self) {
         if self.blocks_state.waiting_for_slot_blocks().len()
             <= self.config.max_future_processing_blocks
@@ -129,32 +128,11 @@ impl ConsensusState {
         let len_slot_waiting = slot_waiting.len();
         (self.config.max_future_processing_blocks..len_slot_waiting).for_each(|idx| {
             let (_slot, block_id) = &slot_waiting[idx];
-            let sequence_number = self.blocks_state.sequence_counter();
-            self.blocks_state
-                .transition_map(block_id, |block_status, _| {
-                    if let Some(BlockStatus::WaitingForSlot(header_or_block)) = block_status {
-                        let header = match header_or_block {
-                            HeaderOrBlock::Header(h) => h,
-                            HeaderOrBlock::Block { id, .. } => self
-                                .storage
-                                .read_blocks()
-                                .get(&id)
-                                .unwrap_or_else(|| panic!("block {} should be in storage", id))
-                                .content
-                                .header
-                                .clone(),
-                        };
-                        Some(BlockStatus::Discarded {
-                            slot: header.content.slot,
-                            creator: header.content_creator_address,
-                            parents: header.content.parents,
-                            reason: DiscardReason::Stale,
-                            sequence_number,
-                        })
-                    } else {
-                        panic!("block {} should be in WaitingForSlot state", block_id);
-                    }
-                });
+            // Eviction for size is NOT a verdict on the block: forget it (None), do not mark it
+            // Discarded. Discarded is terminal (never reprocessed) and inherited by every child
+            // in check_header. A forgotten block is refetched through the wishlist as soon as a
+            // child references it, which is the recovery path we want.
+            self.blocks_state.transition_map(block_id, |_, _| None);
         });
     }
 
@@ -189,7 +167,7 @@ impl ConsensusState {
     }
 
     fn prune_waiting_for_dependencies(&mut self) -> Result<(), ConsensusError> {
-        let mut to_discard: PreHashMap<BlockId, DiscardReason> = PreHashMap::default();
+        let mut to_discard: PreHashMap<BlockId, Option<DiscardReason>> = PreHashMap::default();
         let mut to_keep: PreHashMap<BlockId, (u64, Slot)> = PreHashMap::default();
 
         // list items that are older than the latest final blocks in their threads or have deps that are discarded
@@ -220,17 +198,14 @@ impl ConsensusState {
                         }
                     }
                     if discarded_dep_found {
-                        // A discarded dependency always yields a reason (Invalid or Stale).
-                        let reason = discard_reason
-                            .expect("discarded dependency should produce a discard reason");
-                        to_discard.insert(*block_id, reason);
+                        to_discard.insert(*block_id, discard_reason);
                         continue;
                     }
 
                     // is at least as old as the latest final block in its thread => discard as stale
                     let slot = header_or_block.get_slot();
                     if slot.period <= self.latest_final_blocks_periods[slot.thread as usize].1 {
-                        to_discard.insert(*block_id, DiscardReason::Stale);
+                        to_discard.insert(*block_id, Some(DiscardReason::Stale));
                         continue;
                     }
 
@@ -256,21 +231,23 @@ impl ConsensusState {
                         if let Some(reason) = to_discard.get(dep) {
                             dep_to_discard_found = true;
                             match reason {
-                                DiscardReason::Invalid(reason) => {
+                                Some(DiscardReason::Invalid(reason)) => {
                                     discard_reason = Some(DiscardReason::Invalid(format!("discarded because depend on block:{} that has discard reason:{}", hash, reason)));
                                     break;
                                 }
-                                DiscardReason::Stale => discard_reason = Some(DiscardReason::Stale),
-                                DiscardReason::Final => discard_reason = Some(DiscardReason::Stale),
+                                Some(DiscardReason::Stale) => {
+                                    discard_reason = Some(DiscardReason::Stale)
+                                }
+                                Some(DiscardReason::Final) => {
+                                    discard_reason = Some(DiscardReason::Stale)
+                                }
+                                None => {} // leave as None
                             }
                         }
                     }
                     if dep_to_discard_found {
-                        // A dependency queued for discard always has a reason.
-                        let reason = discard_reason
-                            .expect("dependency queued for discard should have a reason");
                         to_keep.remove(&hash);
-                        to_discard.insert(hash, reason);
+                        to_discard.insert(hash, discard_reason);
                         continue;
                     }
                 }
@@ -294,8 +271,13 @@ impl ConsensusState {
                     .min();
                 if let Some((_seq_num, _slot, hash)) = remove_elt {
                     to_keep.remove(&hash);
-                    // Preserve the over-limit entry as discarded instead of silently deleting it.
-                    to_discard.insert(hash, DiscardReason::Stale);
+                    // Eviction for size is NOT a verdict on the block: forget it (None), do not mark
+                    // it Discarded. Discarded is terminal (never reprocessed) and inherited by every
+                    // child in check_header, and here it would also be propagated by the
+                    // discarded-dependency cascade above to every waiter built on this block. A
+                    // forgotten block is refetched through the wishlist as soon as a child
+                    // references it, which is the recovery path we want.
+                    to_discard.insert(hash, None);
                     continue;
                 }
             }
@@ -304,8 +286,8 @@ impl ConsensusState {
             break;
         }
 
-        // transition states to Discarded (every entry in to_discard now has a reason)
-        for (block_id, reason) in to_discard.drain() {
+        // transition states to Discarded if there is a reason, otherwise just drop
+        for (block_id, reason_opt) in to_discard.drain() {
             let sequence_number = self.blocks_state.sequence_counter();
             self.blocks_state.transition_map(&block_id, |block_status, _| {
                 if let Some(BlockStatus::WaitingForDependencies {
@@ -322,21 +304,27 @@ impl ConsensusState {
                             .header
                             .clone()
                     };
-                    massa_trace!("consensus.block_graph.prune_waiting_for_dependencies", {"hash": block_id, "reason": reason});
-                    // add to stats if reason is Stale
-                    if reason == DiscardReason::Stale {
-                        self.new_stale_blocks.insert(
-                            block_id,
-                            (header.content_creator_address, header.content.slot),
-                        );
+                    massa_trace!("consensus.block_graph.prune_waiting_for_dependencies", {"hash": block_id, "reason": reason_opt});
+                    if let Some(reason) = reason_opt {
+                        // add to stats if reason is Stale
+                        if reason == DiscardReason::Stale {
+                            self.new_stale_blocks.insert(
+                                block_id,
+                                (header.content_creator_address, header.content.slot),
+                            );
+                        }
+                        // transition to Discarded only if there is a reason
+                        Some(BlockStatus::Discarded {
+                                slot: header.content.slot,
+                                creator: header.content_creator_address,
+                                parents: header.content.parents,
+                                reason,
+                                sequence_number,
+                            },
+                        )
+                    } else {
+                        None
                     }
-                    Some(BlockStatus::Discarded {
-                        slot: header.content.slot,
-                        creator: header.content_creator_address,
-                        parents: header.content.parents,
-                        reason,
-                        sequence_number,
-                    })
                 } else {
                     panic!("block {} should be in WaitingForDependencies state", block_id);
                 }

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -391,7 +391,10 @@ fn test_parent_in_the_future() {
 
     // Wait for blocks_db to be pruned
     std::thread::sleep(Duration::from_millis(1500));
-    // We only keep t0s2 and t1s1 because of max_future_processing_blocks set to 2
+    // We only keep t0s1 and t1s1 in WaitingForSlot because of
+    // max_future_processing_blocks set to 2. The evicted block (t0s2) is
+    // preserved as Discarded rather than silently removed, so valid reannounced
+    // headers are still recognized by protocol's checked_headers cache.
     let status = universe
         .module_controller
         .get_block_statuses(&[t0s1.id, t1s1.id, t0s2.id]);
@@ -400,7 +403,7 @@ fn test_parent_in_the_future() {
         vec![
             BlockGraphStatus::WaitingForSlot,
             BlockGraphStatus::WaitingForSlot,
-            BlockGraphStatus::NotFound
+            BlockGraphStatus::Discarded
         ],
         "wrong status"
     );

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -391,10 +391,7 @@ fn test_parent_in_the_future() {
 
     // Wait for blocks_db to be pruned
     std::thread::sleep(Duration::from_millis(1500));
-    // We only keep t0s1 and t1s1 in WaitingForSlot because of
-    // max_future_processing_blocks set to 2. The evicted block (t0s2) is
-    // preserved as Discarded rather than silently removed, so valid reannounced
-    // headers are still recognized by protocol's checked_headers cache.
+    // We only keep t0s2 and t1s1 because of max_future_processing_blocks set to 2
     let status = universe
         .module_controller
         .get_block_statuses(&[t0s1.id, t1s1.id, t0s2.id]);
@@ -403,7 +400,7 @@ fn test_parent_in_the_future() {
         vec![
             BlockGraphStatus::WaitingForSlot,
             BlockGraphStatus::WaitingForSlot,
-            BlockGraphStatus::Discarded
+            BlockGraphStatus::NotFound
         ],
         "wrong status"
     );
@@ -1035,4 +1032,116 @@ fn test_undrawable_slot_headers_do_not_poison_multistake() {
             id
         );
     }
+}
+
+/// Regression test for F26: marking invalid a block that consensus has never
+/// seen must be a no-op, not a panic.
+///
+/// This is the normal missing-parent flow, not a pruning race: a block
+/// wishlisted as a missing parent is never inserted in `blocks_state` (protocol
+/// keeps wishlisted headers to itself), yet protocol can decide it is invalid
+/// before its full block arrives (e.g. its committed operations exceed the max
+/// block size) and send `mark_invalid_block` for it. `None -> Discarded` is a
+/// forbidden transition, so the worker used to panic while holding the shared
+/// state write lock, taking the whole consensus down.
+#[test]
+fn test_mark_invalid_unknown_block_is_noop() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let cfg = ConsensusConfig {
+        t0: MassaTime::from_millis(100),
+        thread_count: 2,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+    let last_start_period = cfg.last_start_period;
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(|_| {});
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |_| Ok(staking_address));
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // A block consensus has never been told about: no header registered, no block registered.
+    let unknown_block = create_block(
+        Slot::new(1 + last_start_period, 0),
+        genesis_hashes.clone(),
+        &staking_key,
+    );
+    assert_eq!(
+        controller.get_block_statuses(&[unknown_block.id])[0],
+        BlockGraphStatus::NotFound,
+        "the block must be unknown to consensus for this test to be meaningful"
+    );
+
+    controller.mark_invalid_block(unknown_block.id, unknown_block.content.header.clone());
+
+    // The worker holds the shared state write lock while handling the command, so a panic
+    // there leaves the lock held forever: check liveness from a separate thread with a
+    // deadline instead of blocking the test process.
+    let (tx, rx) = std::sync::mpsc::channel();
+    let liveness_controller = controller.clone();
+    let liveness_block = create_block(
+        Slot::new(1 + last_start_period, 1),
+        genesis_hashes,
+        &staking_key,
+    );
+    let liveness_block_id = liveness_block.id;
+    std::thread::spawn(move || {
+        liveness_controller
+            .register_block_header(liveness_block_id, liveness_block.content.header.clone());
+        loop {
+            let statuses =
+                liveness_controller.get_block_statuses(&[unknown_block.id, liveness_block_id]);
+            if statuses[1] != BlockGraphStatus::NotFound {
+                let _ = tx.send(statuses);
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    });
+
+    let statuses = rx.recv_timeout(Duration::from_secs(5)).expect(
+        "consensus worker stopped handling commands after mark_invalid_block on an unknown block",
+    );
+
+    assert_eq!(
+        statuses[0],
+        BlockGraphStatus::NotFound,
+        "marking an unknown block invalid must not create an entry for it"
+    );
 }


### PR DESCRIPTION
…s as Discarded and harden mark_invalid_block

* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification