### PR TITLE
[F25] fix(consensus-worker): defer denunciation and multistake side e…

### DIFF
--- a/massa-consensus-worker/src/state/mod.rs
+++ b/massa-consensus-worker/src/state/mod.rs
@@ -87,8 +87,10 @@ pub struct ConsensusState {
     pub wishlist: PreHashMap<BlockId, Option<SecuredHeader>>,
     /// previous blockclique notified to Execution
     pub prev_blockclique: PreHashMap<BlockId, Slot>,
-    /// Blocks indexed by slot (used for multi-stake limiting). Blocks
-    /// should be saved in this map when we receive the header or the full block directly.
+    /// Blocks indexed by slot (used for multi-stake limiting). An entry is only
+    /// added once the header/block has passed validation for its slot, not when
+    /// it is first received. This prevents unvalidated future-slot headers from
+    /// polluting the per-slot index while they are still in `WaitingForSlot`.
     pub nonfinal_active_blocks_per_slot: HashMap<Slot, PreHashSet<BlockId>>,
     /// massa metrics
     pub(crate) massa_metrics: MassaMetrics,

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -15,6 +15,7 @@ use massa_models::{
     block_header::SecuredHeader,
     block_id::BlockId,
     clique::Clique,
+    denunciation::DenunciationPrecursor,
     prehash::{PreHashMap, PreHashSet},
     slot::Slot,
     timeslots,
@@ -171,7 +172,16 @@ impl ConsensusState {
                             HeaderCheckOutcome::Discard(reason) => {
                                 self.maybe_note_attack_attempt(reason, &block_id)
                             }
+                            HeaderCheckOutcome::WaitForSlot => {
+                                // The slot is not yet verifiable: defer denunciation and
+                                // multistake side effects until the block is reprocessed.
+                            }
                             _ => {
+                                // Slot is verifiable: forward denunciation precursor and apply
+                                // the multistake limit so only validated blocks compete.
+                                self.channels.pool_controller.add_denunciation_precursor(
+                                    DenunciationPrecursor::from(&stored_block.content.header),
+                                );
                                 // Extra equivocation blocks must leave Incoming so Storage is
                                 // not retained indefinitely (Incoming is not pruned / slot-ticked).
                                 if self.detect_multistake(&stored_block.content.header) {

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -180,14 +180,11 @@ impl ConsensusState {
                                 // multistake side effects until the block is reprocessed.
                             }
                             _ => {
-                                // Slot is verifiable: forward denunciation precursor and apply
-                                // the multistake limit so only validated blocks compete.
-                                self.channels.pool_controller.add_denunciation_precursor(
-                                    DenunciationPrecursor::from(&stored_block.content.header),
-                                );
+                                // Slot is verifiable: forward the denunciation precursor and
+                                // apply the multistake limit so only validated blocks compete.
                                 // Extra equivocation blocks must leave Incoming so Storage is
                                 // not retained indefinitely (Incoming is not pruned / slot-ticked).
-                                if self.detect_multistake(&stored_block.content.header) {
+                                if self.note_verifiable_header(&stored_block.content.header) {
                                     res = HeaderCheckOutcome::Discard(DiscardReason::Invalid(
                                         format!(
                                             "more than 2 blocks for slot {}",

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -176,8 +176,11 @@ impl ConsensusState {
                                 );
                             }
                             HeaderCheckOutcome::WaitForSlot => {
-                                // The slot is not yet verifiable: defer denunciation and
-                                // multistake side effects until the block is reprocessed.
+                                // The slot is not verifiable yet: either the slot is simply
+                                // not reached, or the selector has no draw for it and not even
+                                // the producer was checked. No side effects on this path, they
+                                // are all redone when the slot is reprocessed. See
+                                // `convert_block_header` for the full rationale.
                             }
                             _ => {
                                 // Slot is verifiable: forward the denunciation precursor and

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -170,7 +170,10 @@ impl ConsensusState {
                         );
                         match &res {
                             HeaderCheckOutcome::Discard(reason) => {
-                                self.maybe_note_attack_attempt(reason, &block_id)
+                                self.maybe_note_attack_attempt(reason, &block_id);
+                                self.channels.pool_controller.add_denunciation_precursor(
+                                    DenunciationPrecursor::from(&stored_block.content.header),
+                                );
                             }
                             HeaderCheckOutcome::WaitForSlot => {
                                 // The slot is not yet verifiable: defer denunciation and

--- a/massa-consensus-worker/src/state/process_commands.rs
+++ b/massa-consensus-worker/src/state/process_commands.rs
@@ -5,9 +5,7 @@ use massa_consensus_exports::{
     error::ConsensusError,
 };
 use massa_logging::massa_trace;
-use massa_models::{
-    block_header::SecuredHeader, block_id::BlockId, denunciation::DenunciationPrecursor, slot::Slot,
-};
+use massa_models::{block_header::SecuredHeader, block_id::BlockId, slot::Slot};
 use massa_storage::Storage;
 use massa_time::MassaTime;
 use tracing::debug;
@@ -34,11 +32,6 @@ impl ConsensusState {
         if self.genesis_hashes.contains(&block_id) {
             return Ok(());
         }
-
-        let de_p = DenunciationPrecursor::from(&header);
-        self.channels
-            .pool_controller
-            .add_denunciation_precursor(de_p);
 
         debug!(
             "received header {} for slot {}",
@@ -82,13 +75,6 @@ impl ConsensusState {
         // ignore genesis blocks
         if self.genesis_hashes.contains(&block_id) {
             return Ok(());
-        }
-
-        if let Some(verifiable_block) = storage.read_blocks().get(&block_id) {
-            let de_p = DenunciationPrecursor::from(&verifiable_block.content.header);
-            self.channels
-                .pool_controller
-                .add_denunciation_precursor(de_p);
         }
 
         // Block is coming from protocol mark it for desync calculation

--- a/massa-consensus-worker/src/state/verifications.rs
+++ b/massa-consensus-worker/src/state/verifications.rs
@@ -124,8 +124,13 @@ impl ConsensusState {
                 })
             }
             HeaderCheckOutcome::WaitForSlot => {
-                // The slot is not yet verifiable: defer denunciation and
-                // multistake side effects until the block is reprocessed.
+                // WaitForSlot covers two cases:
+                // 1. producer checked, slot just not reached yet (clock skew)
+                // 2. selector has no draw for this slot yet (> 2 cycles ahead): NOTHING is
+                //    validated, not even the producer. Anyone can forge these for free.
+                // => No side effects of any kind on this path: no precursor, no multistake
+                //    index, no attack note. Only store, capped by prune_slot_waiting.
+                //    Everything is redone when the slot is reprocessed.
                 Some(BlockStatus::WaitingForSlot(HeaderOrBlock::Header(header)))
             }
             HeaderCheckOutcome::Discard(reason) => {

--- a/massa-consensus-worker/src/state/verifications.rs
+++ b/massa-consensus-worker/src/state/verifications.rs
@@ -69,6 +69,22 @@ impl ConsensusState {
         false
     }
 
+    /// Handle the side effects of a header whose slot is verifiable: forward the
+    /// denunciation precursor to the pool, then apply the multi-stake limit.
+    ///
+    /// The precursor is forwarded unconditionally because the pool runs its own
+    /// eligibility checks (PoS draw, expiry, last start period) and keeps at most
+    /// one cache entry per slot: gating it on our local per-slot index could drop
+    /// evidence the pool never received.
+    ///
+    /// Returns `true` if the header is an extra equivocation block for its slot.
+    pub(crate) fn note_verifiable_header(&mut self, header: &SecuredHeader) -> bool {
+        self.channels
+            .pool_controller
+            .add_denunciation_precursor(DenunciationPrecursor::from(header));
+        self.detect_multistake(header)
+    }
+
     /// Check if the header is valid and if it could be processed when we will receive the full block
     pub(crate) fn convert_block_header(
         &mut self,
@@ -79,12 +95,9 @@ impl ConsensusState {
         let header_outcome = self.check_header(&block_id, &header, current_slot);
         match header_outcome {
             HeaderCheckOutcome::Proceed { .. } => {
-                if self.detect_multistake(&header) {
+                if self.note_verifiable_header(&header) {
                     return None;
                 }
-                self.channels
-                    .pool_controller
-                    .add_denunciation_precursor(DenunciationPrecursor::from(&header));
                 // set as waiting dependencies
                 let mut dependencies = PreHashSet::<BlockId>::default();
                 dependencies.insert(block_id); // add self as unsatisfied
@@ -99,12 +112,9 @@ impl ConsensusState {
                 })
             }
             HeaderCheckOutcome::WaitForDependencies(mut dependencies) => {
-                if self.detect_multistake(&header) {
+                if self.note_verifiable_header(&header) {
                     return None;
                 }
-                self.channels
-                    .pool_controller
-                    .add_denunciation_precursor(DenunciationPrecursor::from(&header));
                 // set as waiting dependencies
                 dependencies.insert(block_id); // add self as unsatisfied
                 Some(BlockStatus::WaitingForDependencies {

--- a/massa-consensus-worker/src/state/verifications.rs
+++ b/massa-consensus-worker/src/state/verifications.rs
@@ -119,6 +119,9 @@ impl ConsensusState {
                 Some(BlockStatus::WaitingForSlot(HeaderOrBlock::Header(header)))
             }
             HeaderCheckOutcome::Discard(reason) => {
+                self.channels
+                    .pool_controller
+                    .add_denunciation_precursor(DenunciationPrecursor::from(&header));
                 Some(self.convert_to_discard_block_header(reason, block_id, header))
             }
         }

--- a/massa-consensus-worker/src/state/verifications.rs
+++ b/massa-consensus-worker/src/state/verifications.rs
@@ -2,7 +2,8 @@ use super::{process::BlockInfos, ConsensusState};
 use massa_consensus_exports::block_status::{BlockStatus, DiscardReason, HeaderOrBlock};
 use massa_logging::massa_trace;
 use massa_models::{
-    block_header::SecuredHeader, block_id::BlockId, prehash::PreHashSet, slot::Slot,
+    block_header::SecuredHeader, block_id::BlockId, denunciation::DenunciationPrecursor,
+    prehash::PreHashSet, slot::Slot,
 };
 use tracing::warn;
 
@@ -81,6 +82,9 @@ impl ConsensusState {
                 if self.detect_multistake(&header) {
                     return None;
                 }
+                self.channels
+                    .pool_controller
+                    .add_denunciation_precursor(DenunciationPrecursor::from(&header));
                 // set as waiting dependencies
                 let mut dependencies = PreHashSet::<BlockId>::default();
                 dependencies.insert(block_id); // add self as unsatisfied
@@ -98,6 +102,9 @@ impl ConsensusState {
                 if self.detect_multistake(&header) {
                     return None;
                 }
+                self.channels
+                    .pool_controller
+                    .add_denunciation_precursor(DenunciationPrecursor::from(&header));
                 // set as waiting dependencies
                 dependencies.insert(block_id); // add self as unsatisfied
                 Some(BlockStatus::WaitingForDependencies {
@@ -107,9 +114,8 @@ impl ConsensusState {
                 })
             }
             HeaderCheckOutcome::WaitForSlot => {
-                if self.detect_multistake(&header) {
-                    return None;
-                }
+                // The slot is not yet verifiable: defer denunciation and
+                // multistake side effects until the block is reprocessed.
                 Some(BlockStatus::WaitingForSlot(HeaderOrBlock::Header(header)))
             }
             HeaderCheckOutcome::Discard(reason) => {

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -11,9 +11,10 @@ use super::{
     tools::{consensus_test, register_block},
     universe::{ConsensusForeignControllers, ConsensusTestUniverse},
 };
-use crate::tests::tools::create_block;
+use crate::tests::tools::{create_block, create_block_with_merkle_root};
 use massa_consensus_exports::ConsensusConfig;
 use massa_execution_exports::MockExecutionController;
+use massa_hash::Hash;
 use massa_models::{
     address::Address, block::BlockGraphStatus, block_id::BlockId, config::ENDORSEMENT_COUNT,
     slot::Slot,
@@ -650,5 +651,136 @@ fn test_future_header_side_effects_deferred() {
         precursor_count.load(Ordering::SeqCst),
         1,
         "denunciation precursor was not forwarded exactly once after slot became verifiable"
+    );
+}
+
+/// Extra equivocation blocks are dropped by the multistake limit, but their
+/// denunciation precursor must still reach the pool: the pool runs its own
+/// eligibility checks and may not hold the two precursors our per-slot index
+/// counted.
+#[test]
+fn test_multistake_still_forwards_denunciation_precursor() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let t0 = MassaTime::from_millis(100);
+    let cfg = ConsensusConfig {
+        t0,
+        thread_count: 2,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+    let last_start_period = cfg.last_start_period;
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+
+    let precursor_count = Arc::new(AtomicUsize::new(0));
+    let precursor_count_clone = Arc::clone(&precursor_count);
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(move |_| {
+            precursor_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |_| Ok(staking_address));
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // Three equivocating headers for the same future slot, same creator.
+    let slot = Slot::new(3 + last_start_period, 0);
+    let headers: Vec<_> = (0..3u8)
+        .map(|i| {
+            create_block_with_merkle_root(
+                Hash::compute_from(&[i]),
+                slot,
+                genesis_hashes.clone(),
+                &staking_key,
+            )
+        })
+        .collect();
+    let ids: Vec<BlockId> = headers.iter().map(|b| b.id).collect();
+    for block in &headers {
+        controller.register_block_header(block.id, block.content.header.clone());
+    }
+
+    // Nothing is forwarded while the slot is not verifiable.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(10));
+        waited += 10;
+        let statuses = controller.get_block_statuses(&ids);
+        if statuses
+            .iter()
+            .all(|s| *s == BlockGraphStatus::WaitingForSlot)
+        {
+            break;
+        }
+        assert!(
+            waited < 1000,
+            "headers never all reached WaitingForSlot (statuses: {:?})",
+            statuses
+        );
+    }
+    assert_eq!(
+        precursor_count.load(Ordering::SeqCst),
+        0,
+        "denunciation precursor forwarded before slot was verifiable"
+    );
+
+    // Once the slot is reached, all three headers are processed. The third one is
+    // dropped by the multistake limit but its precursor must still be forwarded.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(25));
+        waited += 25;
+        let statuses = controller.get_block_statuses(&ids);
+        if statuses
+            .iter()
+            .all(|s| *s != BlockGraphStatus::WaitingForSlot)
+        {
+            break;
+        }
+        assert!(
+            waited < 3000,
+            "headers stayed in WaitingForSlot after slot passed (statuses: {:?})",
+            statuses
+        );
+    }
+
+    assert_eq!(
+        precursor_count.load(Ordering::SeqCst),
+        3,
+        "extra equivocation block did not forward its denunciation precursor"
     );
 }

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{HashSet, VecDeque},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -20,7 +20,7 @@ use massa_models::{
     slot::Slot,
 };
 use massa_pool_exports::MockPoolController;
-use massa_pos_exports::{MockSelectorController, Selection};
+use massa_pos_exports::{MockSelectorController, PosError, Selection};
 use massa_signature::KeyPair;
 use massa_storage::Storage;
 use massa_test_framework::TestUniverse;
@@ -783,4 +783,253 @@ fn test_multistake_still_forwards_denunciation_precursor() {
         3,
         "extra equivocation block did not forward its denunciation precursor"
     );
+}
+
+/// A header for a slot the selector cannot draw yet (`get_producer` returns
+/// `Err`) reaches `WaitForSlot` with nothing validated at all - not even the
+/// producer. It must therefore have no side effect: no denunciation precursor
+/// and no entry in the multistake index.
+#[test]
+fn test_undrawable_slot_header_has_no_side_effects() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let attacker_key: KeyPair = KeyPair::generate(0).unwrap();
+    let t0 = MassaTime::from_millis(200);
+    let cfg = ConsensusConfig {
+        t0,
+        thread_count: 2,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+    let last_start_period = cfg.last_start_period;
+    let undrawable_slot = Slot::new(5 + last_start_period, 0);
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+
+    let precursor_count = Arc::new(AtomicUsize::new(0));
+    let precursor_count_clone = Arc::clone(&precursor_count);
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(move |_| {
+            precursor_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+
+    // The selector has no draw for `undrawable_slot`: it is beyond its horizon.
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |slot| {
+            if slot == undrawable_slot {
+                Err(PosError::CycleUnavailable(slot.period))
+            } else {
+                Ok(staking_address)
+            }
+        });
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // Forged by a key that was never drawn: only the signature is checked at this
+    // point, so registering it costs the attacker nothing.
+    let forged = create_block(undrawable_slot, genesis_hashes, &attacker_key);
+    controller.register_block_header(forged.id, forged.content.header.clone());
+
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(10));
+        waited += 10;
+        let status = &controller.get_block_statuses(&[forged.id])[0];
+        if *status == BlockGraphStatus::WaitingForSlot {
+            break;
+        }
+        assert!(
+            waited < 1000,
+            "undrawable-slot header never reached WaitingForSlot (status: {:?})",
+            status
+        );
+    }
+
+    assert_eq!(
+        precursor_count.load(Ordering::SeqCst),
+        0,
+        "denunciation precursor forwarded for a slot the selector cannot draw"
+    );
+}
+
+/// Regression test for the F25 poisoning: two headers forged by an undrawn key
+/// for a slot the selector cannot draw yet must not consume the multistake
+/// budget of that slot. Once the slot becomes drawable, the legit block from the
+/// drawn producer must still be accepted.
+#[test]
+fn test_undrawable_slot_headers_do_not_poison_multistake() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let attacker_key: KeyPair = KeyPair::generate(0).unwrap();
+    let t0 = MassaTime::from_millis(200);
+    let cfg = ConsensusConfig {
+        t0,
+        thread_count: 2,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+    let last_start_period = cfg.last_start_period;
+    let target_slot = Slot::new(5 + last_start_period, 0);
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(|_| {});
+
+    // The selector cannot draw `target_slot` until `draws_ready` is set, which
+    // emulates the cycle becoming available as time passes.
+    let draws_ready = Arc::new(AtomicBool::new(false));
+    let draws_ready_clone = Arc::clone(&draws_ready);
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |slot| {
+            if slot == target_slot && !draws_ready_clone.load(Ordering::SeqCst) {
+                Err(PosError::CycleUnavailable(slot.period))
+            } else {
+                Ok(staking_address)
+            }
+        });
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let storage = foreign_controllers.storage.clone();
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // Two headers forged by an undrawn key, sent while the slot is undrawable.
+    let forged: Vec<_> = (0..2u8)
+        .map(|i| {
+            create_block_with_merkle_root(
+                Hash::compute_from(&[i]),
+                target_slot,
+                genesis_hashes.clone(),
+                &attacker_key,
+            )
+        })
+        .collect();
+    let forged_ids: Vec<BlockId> = forged.iter().map(|b| b.id).collect();
+    for block in &forged {
+        controller.register_block_header(block.id, block.content.header.clone());
+    }
+
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(10));
+        waited += 10;
+        let statuses = controller.get_block_statuses(&forged_ids);
+        if statuses
+            .iter()
+            .all(|s| *s == BlockGraphStatus::WaitingForSlot)
+        {
+            break;
+        }
+        assert!(
+            waited < 1000,
+            "forged headers never all reached WaitingForSlot (statuses: {:?})",
+            statuses
+        );
+    }
+
+    // The cycle becomes available and the legit producer publishes its block.
+    draws_ready.store(true, Ordering::SeqCst);
+    let legit = create_block_with_merkle_root(
+        Hash::compute_from(b"legit"),
+        target_slot,
+        genesis_hashes,
+        &staking_key,
+    );
+    register_block(&controller, legit.clone(), storage.clone());
+
+    // The forged headers are discarded on reprocessing (bad creator turn) and the
+    // legit block is accepted: it never competed with them for the slot.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(25));
+        waited += 25;
+        let legit_status = controller.get_block_statuses(&[legit.id]).remove(0);
+        if legit_status == BlockGraphStatus::ActiveInBlockclique
+            || legit_status == BlockGraphStatus::Final
+        {
+            break;
+        }
+        assert!(
+            waited < 3000,
+            "legit block for the poisoned slot was not accepted (status: {:?}, forged: {:?})",
+            legit_status,
+            controller.get_block_statuses(&forged_ids)
+        );
+    }
+
+    for (id, status) in forged_ids
+        .iter()
+        .zip(controller.get_block_statuses(&forged_ids))
+    {
+        assert_eq!(
+            status,
+            BlockGraphStatus::Discarded,
+            "forged header {} should have been discarded on reprocessing",
+            id
+        );
+    }
 }

--- a/massa-consensus-worker/src/tests/scenarios.rs
+++ b/massa-consensus-worker/src/tests/scenarios.rs
@@ -1,5 +1,9 @@
 use std::{
     collections::{HashSet, VecDeque},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -528,5 +532,123 @@ fn test_slot_maintenance_not_starved_by_command_flood() {
     assert!(
         processed_during_flood,
         "future block stayed in WaitingForSlot during command flood; slot maintenance was starved"
+    );
+}
+
+/// Regression test for F25: a future block header must not trigger denunciation
+/// precursor forwarding or multistake tracking while its slot is unverifiable.
+/// Those side effects should happen exactly once when the slot becomes current
+/// and the header is validated.
+#[test]
+fn test_future_header_side_effects_deferred() {
+    let staking_key: KeyPair = KeyPair::generate(0).unwrap();
+    let t0 = MassaTime::from_millis(100);
+    let cfg = ConsensusConfig {
+        t0,
+        thread_count: 2,
+        genesis_timestamp: MassaTime::now(),
+        force_keep_final_periods: 50,
+        force_keep_final_periods_without_ops: 128,
+        max_future_processing_blocks: 10,
+        genesis_key: staking_key.clone(),
+        ..ConsensusConfig::default()
+    };
+
+    let staking_address = Address::from_public_key(&staking_key.get_public_key());
+    let last_start_period = cfg.last_start_period;
+
+    let mut foreign_controllers = ConsensusForeignControllers::new_with_mocks();
+
+    foreign_controllers
+        .execution_controller
+        .expect_update_blockclique_status()
+        .returning(|_, _, _| {});
+    foreign_controllers
+        .pool_controller
+        .expect_notify_final_cs_periods()
+        .returning(|_| {});
+
+    let precursor_count = Arc::new(AtomicUsize::new(0));
+    let precursor_count_clone = Arc::clone(&precursor_count);
+    foreign_controllers
+        .pool_controller
+        .expect_add_denunciation_precursor()
+        .returning(move |_| {
+            precursor_count_clone.fetch_add(1, Ordering::SeqCst);
+        });
+    foreign_controllers
+        .selector_controller
+        .expect_get_producer()
+        .returning(move |_| Ok(staking_address));
+    foreign_controllers
+        .selector_controller
+        .expect_get_selection()
+        .returning(move |_| {
+            Ok(Selection {
+                producer: staking_address,
+                endorsements: vec![staking_address; ENDORSEMENT_COUNT as usize],
+            })
+        });
+
+    let universe = ConsensusTestUniverse::new(foreign_controllers, cfg);
+    let controller = universe.module_controller.clone();
+
+    let genesis_hashes = controller
+        .get_block_graph_status(None, None)
+        .expect("could not get block graph status")
+        .genesis_blocks;
+
+    // Register a header far enough in the future that it is queued as
+    // WaitingForSlot.
+    let future_slot = Slot::new(3 + last_start_period, 0);
+    let future_block = create_block(future_slot, genesis_hashes, &staking_key);
+    controller.register_block_header(future_block.id, future_block.content.header.clone());
+
+    // Wait until the header is known to be waiting for its slot.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(10));
+        waited += 10;
+        let status = &controller.get_block_statuses(&[future_block.id])[0];
+        if *status == BlockGraphStatus::WaitingForSlot {
+            break;
+        }
+        assert!(
+            waited < 1000,
+            "future block never reached WaitingForSlot (status: {:?})",
+            status
+        );
+    }
+
+    // No side effects should have happened while the slot was unverifiable.
+    assert_eq!(
+        precursor_count.load(Ordering::SeqCst),
+        0,
+        "denunciation precursor forwarded before slot was verifiable"
+    );
+
+    // Wait for the slot to become current; processing should then forward the
+    // precursor and transition the block out of WaitingForSlot.
+    let mut waited = 0u64;
+    loop {
+        std::thread::sleep(Duration::from_millis(25));
+        waited += 25;
+        let status = &controller.get_block_statuses(&[future_block.id])[0];
+        if *status != BlockGraphStatus::WaitingForSlot {
+            break;
+        }
+        assert!(
+            waited < 3000,
+            "future block stayed in WaitingForSlot after slot passed (status: {:?})",
+            status
+        );
+    }
+
+    // The precursor must have been forwarded exactly once when the slot became
+    // verifiable.
+    assert_eq!(
+        precursor_count.load(Ordering::SeqCst),
+        1,
+        "denunciation precursor was not forwarded exactly once after slot became verifiable"
     );
 }


### PR DESCRIPTION
…ffects for unverifiable slots

## What

A block header for a slot the selector cannot draw yet reaches `check_header`'s `WaitForSlot` path via `get_producer() -> Err` (`massa-consensus-worker/src/state/verifications.rs:217`), **before** the creator-turn check. Nothing is validated on that path except the signature — not even the producer. We nevertheless inserted the header into `nonfinal_active_blocks_per_slot` and forwarded a denunciation precursor for it.

## Attack

Anyone, with no stake, signs 2 junk headers for slot S with throwaway keys and sends them ~2 cycles ahead. Both are counted in the multistake index for S. When S arrives, the legitimately drawn producer's block is rejected as `more than 2 blocks for slot S` on every node that received the junk. Repeat per slot: the attacker suppresses blocks for free. The junk precursors also burn the pool's per-slot denunciation cache entry, so real equivocation at S goes undenounced.

## Fix

No side effects of any kind while a slot is unverifiable: no precursor, no multistake index entry, no attack note. `WaitingForSlot` only stores the header, already capped at 400 by `prune_slot_waiting`, which evicts the furthest slots first. Everything is redone when the slot is reprocessed and the producer can actually be checked.

Precursor forwarding and the multistake check are factored into a single `note_verifiable_header` helper so the header path (`convert_block_header`) and the full-block path (`process.rs`) cannot drift apart again. Order is precursor first, then multistake: a 3rd equivocating block is exactly what we want the pool to see, and the pool re-checks the PoS draw, expiry and `last_start_period` itself, so our local per-slot index must not gate what it receives.

## Why no MIP

Node-local only. Block validity rules, header/block serialization and hashing, the final-state hash and execution semantics are untouched. This changes when *this* node updates its own RAM indexes and what it feeds its own denunciation pool; blocks produced and validated are byte-identical, and old/new nodes agree on the same chain. No JSON-RPC or gRPC surface is affected.

## Bonus

Forwarding precursors at validation time rather than at reception closes a slashing-evasion window: the selector horizon is 128..256 periods while the pool's `denunciation_expire_periods` bound is 128, so equivocation submitted far enough ahead could previously be dropped by the pool before it was ever denounceable.

## Tests

| Test | Covers |
| --- | --- |
| `test_future_header_side_effects_deferred` | Precursor forwarded exactly once, when the slot becomes verifiable |
| `test_undrawable_slot_header_has_no_side_effects` | `get_producer -> Err`: header queued, precursor count stays 0 |
| `test_undrawable_slot_headers_do_not_poison_multistake` | 2 forged headers on an undrawable slot must not evict the legit block |
| `test_multistake_still_forwards_denunciation_precursor` | The 3rd equivocating block still reaches the pool before being dropped |

Each new test was verified to fail against the pre-fix behavior. The poisoning regression fails with exactly the reported symptom:

```
legit block for the poisoned slot was not accepted (status: Discarded, forged: [Discarded, Discarded])
```