### PR TITLE
[F23] feat: sync wishlist after pruning

### DIFF
--- a/massa-consensus-worker/src/state/mod.rs
+++ b/massa-consensus-worker/src/state/mod.rs
@@ -10,6 +10,7 @@ use massa_consensus_exports::{
     ConsensusChannels, ConsensusConfig,
 };
 use massa_execution_exports::ExecutionBlockMetadata;
+use massa_logging::massa_trace;
 use massa_metrics::MassaMetrics;
 use massa_models::{
     active_block::ActiveBlock,
@@ -528,6 +529,52 @@ impl ConsensusState {
         }
 
         Ok(wishlist)
+    }
+
+    /// Recompute the block wishlist from the currently retained waiting blocks
+    /// and publish the delta (new and removed entries) to protocol.
+    ///
+    /// Invariant: the published wishlist is always derived exclusively from
+    /// currently retained, reachable waiting blocks. This must be called after
+    /// any operation that removes or invalidates waiting-for-dependency blocks
+    /// (e.g. `block_db_changed`, `prune_waiting_for_dependencies`) so that
+    /// protocol does not keep requesting blocks that consensus has already
+    /// discarded as unreachable.
+    ///
+    /// # Returns
+    /// Error if the wishlist could not be computed or sent.
+    pub fn sync_wishlist(&mut self) -> Result<(), ConsensusError> {
+        // compute the block wishlist from currently retained waiting blocks
+        let new_wishlist = self.get_block_wishlist()?;
+        let new_blocks: PreHashMap<BlockId, Option<SecuredHeader>> = new_wishlist
+            .iter()
+            .filter_map(|(id, header)| {
+                if !self.wishlist.contains_key(id) {
+                    Some((*id, header.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let remove_blocks: PreHashSet<BlockId> = self
+            .wishlist
+            .iter()
+            .filter_map(|(id, _)| {
+                if !new_wishlist.contains_key(id) {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        if !new_blocks.is_empty() || !remove_blocks.is_empty() {
+            massa_trace!("consensus.consensus_worker.sync_wishlist.send_wishlist_delta", { "new": new_wishlist, "remove": remove_blocks });
+            self.channels
+                .protocol_controller
+                .send_wishlist_delta(new_blocks, remove_blocks)?;
+            self.wishlist = new_wishlist;
+        }
+        Ok(())
     }
 
     /// Gets a block and all its descendants

--- a/massa-consensus-worker/src/state/process.rs
+++ b/massa-consensus-worker/src/state/process.rs
@@ -9,7 +9,6 @@ use massa_logging::massa_trace;
 use massa_models::{
     active_block::ActiveBlock,
     address::Address,
-    block_header::SecuredHeader,
     block_id::BlockId,
     clique::Clique,
     denunciation::DenunciationPrecursor,
@@ -824,36 +823,11 @@ impl ConsensusState {
         self.new_final_blocks.clear();
         self.new_stale_blocks.clear();
 
-        // notify protocol of block wishlist
-        let new_wishlist = self.get_block_wishlist()?;
-        let new_blocks: PreHashMap<BlockId, Option<SecuredHeader>> = new_wishlist
-            .iter()
-            .filter_map(|(id, header)| {
-                if !self.wishlist.contains_key(id) {
-                    Some((*id, header.clone()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        let remove_blocks: PreHashSet<BlockId> = self
-            .wishlist
-            .iter()
-            .filter_map(|(id, _)| {
-                if !new_wishlist.contains_key(id) {
-                    Some(*id)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if !new_blocks.is_empty() || !remove_blocks.is_empty() {
-            massa_trace!("consensus.consensus_worker.block_db_changed.send_wishlist_delta", { "new": new_wishlist, "remove": remove_blocks });
-            self.channels
-                .protocol_controller
-                .send_wishlist_delta(new_blocks, remove_blocks)?;
-            self.wishlist = new_wishlist;
-        }
+        // notify protocol of block wishlist.
+        // This runs after `add_block_to_graph`/`mark_final_blocks` have advanced
+        // `latest_final_blocks_periods`, so blocks that became stale or unreachable
+        // under the new finality floor no longer contribute wishlist entries.
+        self.sync_wishlist()?;
 
         // note new latest final periods
         let latest_final_periods: Vec<u64> = self

--- a/massa-consensus-worker/src/state/prune.rs
+++ b/massa-consensus-worker/src/state/prune.rs
@@ -321,6 +321,12 @@ impl ConsensusState {
             });
         }
 
+        // Pruning removed or invalidated waiting-for-dependency blocks whose unsatisfied
+        // dependencies may have been advertised in the wishlist. Re-derive and publish the
+        // wishlist so protocol gets a removal delta for those now-unreachable ids and does
+        // not keep requesting blocks consensus has already discarded.
+        self.sync_wishlist()?;
+
         Ok(())
     }
 


### PR DESCRIPTION
* [ ] document all added functions
* [ ] try in sandbox /simulation/labnet
  * [ ] if part of node-launch, checked using the `resync_check` flag
* [ ] unit tests on the added/changed features
  * [ ] make tests compile
  * [ ] make tests pass 
* [ ] add logs allowing easy debugging in case the changes caused problems
* [ ] if the API has changed, update the API specification

Note that Instead of reordering, we sync again after pruning (which seems to be the easiest change to make)